### PR TITLE
Feat/create transaction drawer

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -163,6 +163,7 @@ func main() {
 	transactions.GET("", transactionHandler.Search)
 	transactions.POST("", transactionHandler.Create)
 	transactions.GET("/balance", transactionHandler.GetBalance)
+	transactions.GET("/suggestions", transactionHandler.Suggestions)
 	transactions.DELETE("/:id", transactionHandler.Delete)
 	transactions.GET("/:id", transactionHandler.GetByID)
 	transactions.PUT("/:id", transactionHandler.Update)

--- a/backend/internal/entity/transaction.go
+++ b/backend/internal/entity/transaction.go
@@ -57,7 +57,9 @@ func (t *Transaction) ToDomain() *domain.Transaction {
 		deletedAt = &t.DeletedAt.Time
 	}
 
-	allLinked := append(t.LinkedTransactions, t.SourceTransactions...)
+	allLinked := make([]Transaction, len(t.LinkedTransactions), len(t.LinkedTransactions)+len(t.SourceTransactions))
+	copy(allLinked, t.LinkedTransactions)
+	allLinked = append(allLinked, t.SourceTransactions...)
 	var linkedTransactions []domain.Transaction
 	if len(allLinked) > 0 {
 		linkedTransactions = lo.Map(allLinked, func(lt Transaction, _ int) domain.Transaction {

--- a/backend/internal/entity/transaction.go
+++ b/backend/internal/entity/transaction.go
@@ -30,6 +30,7 @@ type Transaction struct {
 	TransactionRecurrence   *TransactionRecurrence `gorm:"<-:false"`
 	Tags                    []Tag                  `gorm:"many2many:transaction_tags;joinForeignKey:transaction_id;joinReferences:tag_id"`
 	LinkedTransactions      []Transaction          `gorm:"many2many:linked_transactions;joinForeignKey:transaction_id;joinReferences:linked_transaction_id"`
+	SourceTransactions      []Transaction          `gorm:"many2many:linked_transactions;joinForeignKey:linked_transaction_id;joinReferences:transaction_id"`
 	SettlementsFromSource   []Settlement           `gorm:"foreignKey:SourceTransactionID;<-:false"`
 }
 
@@ -56,9 +57,10 @@ func (t *Transaction) ToDomain() *domain.Transaction {
 		deletedAt = &t.DeletedAt.Time
 	}
 
+	allLinked := append(t.LinkedTransactions, t.SourceTransactions...)
 	var linkedTransactions []domain.Transaction
-	if len(t.LinkedTransactions) > 0 {
-		linkedTransactions = lo.Map(t.LinkedTransactions, func(lt Transaction, _ int) domain.Transaction {
+	if len(allLinked) > 0 {
+		linkedTransactions = lo.Map(allLinked, func(lt Transaction, _ int) domain.Transaction {
 			return *lt.ToDomain()
 		})
 	}

--- a/backend/internal/handler/transaction_handler.go
+++ b/backend/internal/handler/transaction_handler.go
@@ -43,7 +43,7 @@ func (h *TransactionHandler) Create(c echo.Context) error {
 
 	err := h.transactionService.Create(c.Request().Context(), userID, &transaction)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return pkgErrors.ToHTTPError(err)
 	}
 
 	return c.NoContent(http.StatusCreated)
@@ -237,6 +237,52 @@ func (h *TransactionHandler) GetBalance(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, result)
+}
+
+// Suggestions godoc
+// @Summary      Suggest transactions by description
+// @Description  Returns up to `limit` transactions whose description matches the query string (PostgreSQL text search). Used for autocomplete when creating a new transaction.
+// @Tags         transactions
+// @Produce      json
+// @Security     CookieAuth
+// @Security     BearerAuth
+// @Param        q      query  string  true   "Description search query"
+// @Param        limit  query  int     false  "Maximum results (default 10, max 50)"
+// @Success      200  {array}   domain.Transaction
+// @Failure      400  {object}  middleware.ErrorResponse
+// @Failure      401  {object}  middleware.ErrorResponse
+// @Router       /api/transactions/suggestions [get]
+func (h *TransactionHandler) Suggestions(c echo.Context) error {
+	userID := appcontext.GetUserIDFromContext(c.Request().Context())
+
+	q := c.QueryParam("q")
+	if q == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "q is required")
+	}
+
+	limit := 10
+	if l := c.QueryParam("limit"); l != "" {
+		parsed, err := strconv.Atoi(l)
+		if err != nil || parsed < 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid limit")
+		}
+		if parsed > 50 {
+			parsed = 50
+		}
+		limit = parsed
+	}
+
+	filter := domain.TransactionFilter{
+		Description: &domain.TextSearch{Query: q},
+		Limit:       &limit,
+	}
+
+	results, err := h.transactionService.Suggestions(c.Request().Context(), userID, filter)
+	if err != nil {
+		return pkgErrors.ToHTTPError(err)
+	}
+
+	return c.JSON(http.StatusOK, results)
 }
 
 // Delete godoc

--- a/backend/internal/middleware/error_handler.go
+++ b/backend/internal/middleware/error_handler.go
@@ -3,19 +3,26 @@ package middleware
 import (
 	"net/http"
 
+	apperrors "github.com/finance_app/backend/pkg/errors"
 	"github.com/labstack/echo/v4"
 )
 
 type ErrorResponse struct {
-	Error   string `json:"error"`
-	Message string `json:"message,omitempty"`
+	Error   string   `json:"error"`
+	Message string   `json:"message,omitempty"`
+	Tags    []string `json:"tags,omitempty"`
 }
 
 func ErrorHandler(err error, c echo.Context) {
 	code := http.StatusInternalServerError
 	message := "Internal server error"
+	var tags []string
 
-	if he, ok := err.(*echo.HTTPError); ok {
+	if tagged, ok := err.(*apperrors.TaggedHTTPError); ok {
+		code = tagged.Code
+		message = tagged.Message
+		tags = tagged.Tags
+	} else if he, ok := err.(*echo.HTTPError); ok {
 		code = he.Code
 		message = he.Message.(string)
 	}
@@ -28,6 +35,7 @@ func ErrorHandler(err error, c echo.Context) {
 	response := ErrorResponse{
 		Error:   http.StatusText(code),
 		Message: message,
+		Tags:    tags,
 	}
 
 	if !c.Response().Committed {
@@ -36,4 +44,3 @@ func ErrorHandler(err error, c echo.Context) {
 		}
 	}
 }
-

--- a/backend/internal/repository/transaction_repository.go
+++ b/backend/internal/repository/transaction_repository.go
@@ -88,7 +88,7 @@ func (r *transactionRepository) Search(ctx context.Context, filter domain.Transa
 	var ents []entity.Transaction
 	query := GetTxFromContext(ctx, r.db)
 
-	query = query.Preload("TransactionRecurrence").Preload("LinkedTransactions").Preload("Tags").Preload("LinkedTransactions.Tags")
+	query = query.Preload("TransactionRecurrence").Preload("LinkedTransactions").Preload("SourceTransactions").Preload("Tags").Preload("LinkedTransactions.Tags").Preload("SourceTransactions.Tags")
 
 	if filter.WithSettlements {
 		query = query.Preload("SettlementsFromSource")
@@ -96,16 +96,6 @@ func (r *transactionRepository) Search(ctx context.Context, filter domain.Transa
 
 	if filter.UserID != nil {
 		query = query.Where("user_id = ?", *filter.UserID)
-
-		query = query.Where(`
-		NOT EXISTS (
-			SELECT 1
-			  FROM linked_transactions
-			 WHERE linked_transaction_id = transactions.id
-			   AND transactions.original_user_id = transactions.user_id
-		)
-		`)
-
 	}
 
 	if len(filter.IDs) > 0 {

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -19,6 +19,7 @@ type TransactionService interface {
 	Create(ctx context.Context, userID int, transaction *domain.TransactionCreateRequest) error
 	Update(ctx context.Context, userID, id int, transaction *domain.TransactionUpdateRequest) error
 	Search(ctx context.Context, userID int, period domain.Period, filter domain.TransactionFilter) ([]*domain.Transaction, error)
+	Suggestions(ctx context.Context, userID int, filter domain.TransactionFilter) ([]*domain.Transaction, error)
 	Delete(ctx context.Context, userID int, id int, propagationSettings domain.TransactionPropagationSettings) error
 	GetBalance(ctx context.Context, userID int, period domain.Period, filter domain.BalanceFilter) (*domain.BalanceResult, error)
 }

--- a/backend/internal/service/transaction_balance_test.go
+++ b/backend/internal/service/transaction_balance_test.go
@@ -832,7 +832,7 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Transfer_SameUser
 
 	txs, err := suite.Services.Transaction.Search(ctx, user.ID, period, domain.TransactionFilter{UserID: &user.ID})
 	suite.Require().NoError(err)
-	suite.Require().Len(txs, 1)
+	suite.Require().Len(txs, 2)
 
 	err = suite.Services.Transaction.Update(ctx, txs[0].ID, user.ID, &domain.TransactionUpdateRequest{
 		TransactionType:      lo.ToPtr(domain.TransactionTypeTransfer),
@@ -938,7 +938,7 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Transfer_SameUser
 
 	txs, err := suite.Services.Transaction.Search(ctx, user.ID, period, domain.TransactionFilter{UserID: &user.ID})
 	suite.Require().NoError(err)
-	suite.Require().Len(txs, 1)
+	suite.Require().Len(txs, 2)
 
 	err = suite.Services.Transaction.Update(ctx, txs[0].ID, user.ID, &domain.TransactionUpdateRequest{
 		TransactionType:      lo.ToPtr(domain.TransactionTypeTransfer),
@@ -1007,7 +1007,7 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Transfer_SameUser
 
 	txs, err := suite.Services.Transaction.Search(ctx, user1.ID, period, domain.TransactionFilter{UserID: &user1.ID})
 	suite.Require().NoError(err)
-	suite.Require().Len(txs, 1)
+	suite.Require().Len(txs, 2)
 
 	// redirect destination to user2's connection account
 	err = suite.Services.Transaction.Update(ctx, txs[0].ID, user1.ID, &domain.TransactionUpdateRequest{

--- a/backend/internal/service/transaction_create.go
+++ b/backend/internal/service/transaction_create.go
@@ -491,11 +491,24 @@ func (s *transactionService) incrementInstallmentDate(baseDate time.Time, recurr
 	case domain.RecurrenceTypeWeekly:
 		return baseDate.AddDate(0, 0, increment*7)
 	case domain.RecurrenceTypeMonthly:
-		return baseDate.AddDate(0, increment, 0)
+		return clampToEndOfMonth(baseDate, baseDate.Year(), baseDate.Month()+time.Month(increment))
 	case domain.RecurrenceTypeYearly:
-		return baseDate.AddDate(increment, 0, 0)
+		return clampToEndOfMonth(baseDate, baseDate.Year()+increment, baseDate.Month())
 	}
 	return baseDate
+}
+
+// clampToEndOfMonth builds a date in the target year/month using the original day from
+// baseDate, clamping it to the last day of the target month when needed.
+// This prevents Go's AddDate overflow behaviour (e.g. Jan 31 + 1 month → Mar 3 instead of Feb 28).
+func clampToEndOfMonth(baseDate time.Time, targetYear int, targetMonth time.Month) time.Time {
+	// Normalise month (handles values outside 1–12 produced by arithmetic)
+	normalised := time.Date(targetYear, targetMonth, 1, 0, 0, 0, 0, baseDate.Location())
+	// Last day of the normalised month: day 0 of the following month
+	lastDay := time.Date(normalised.Year(), normalised.Month()+1, 0, 0, 0, 0, 0, baseDate.Location()).Day()
+	day := min(baseDate.Day(), lastDay)
+	return time.Date(normalised.Year(), normalised.Month(), day,
+		baseDate.Hour(), baseDate.Minute(), baseDate.Second(), baseDate.Nanosecond(), baseDate.Location())
 }
 
 func (s *transactionService) createTags(ctx context.Context, userID int, tags []domain.Tag) pkgErrors.ServiceErrors {

--- a/backend/internal/service/transaction_create.go
+++ b/backend/internal/service/transaction_create.go
@@ -114,7 +114,7 @@ func (s *transactionService) validateCreateTransactionRequest(transaction *domai
 				errs = append(errs, pkgErrors.ErrSplitSettingPercentageAndAmountCannotBeUsedTogether(i))
 			}
 
-			if splitSetting.Percentage != nil && *splitSetting.Percentage < 1 || *splitSetting.Percentage > 100 {
+			if splitSetting.Percentage != nil && (*splitSetting.Percentage < 1 || *splitSetting.Percentage > 100) {
 				errs = append(errs, pkgErrors.ErrSplitSettingPercentageMustBeBetween1And100(i))
 			}
 

--- a/backend/internal/service/transaction_create_test.go
+++ b/backend/internal/service/transaction_create_test.go
@@ -205,11 +205,11 @@ func (suite *TransactionCreateWithDBTestSuite) TestCreateTransfer() {
 		suite.T().Fatalf("Failed to get transaction: %v", err)
 	}
 
-	suite.Assert().Len(transactions, 1)
+	suite.Assert().Len(transactions, 2)
 
 	suite.Assert().NoError(err)
 
-	// Primeira transação é o débito (conta origem), segunda é o crédito (conta destino)
+	// transactions[0] é o débito (conta origem), transactions[1] é o crédito (conta destino)
 	suite.Assert().Greater(transactions[0].ID, 0, "transactions[0].ID should be greater than 0")
 	suite.Assert().Equal(transaction.AccountID, transactions[0].AccountID, "transactions[0].AccountID should be equal to transaction.AccountID")
 	suite.Assert().Equal(transaction.Amount, transactions[0].Amount, "transactions[0].Amount should be equal to transaction.Amount")
@@ -298,37 +298,40 @@ func (suite *TransactionCreateWithDBTestSuite) TestRecurringCreateTransfer() {
 		suite.T().Fatalf("Failed to get transaction: %v", err)
 	}
 
-	suite.Assert().Len(transactions, 3)
+	suite.Assert().Len(transactions, 6)
 
 	suite.Assert().NoError(err)
 
+	debitTransactions := lo.Filter(transactions, func(t *domain.Transaction, _ int) bool {
+		return t.OperationType == domain.OperationTypeDebit
+	})
+	suite.Assert().Len(debitTransactions, 3)
+
 	expectedInstallmentNumber := 1
 
-	for i := range transactions {
-		suite.Assert().NotNil(transactions[i].TransactionRecurrenceID, fmt.Sprintf("transactions[%d].TransactionRecurrenceID should not be nil", i))
-		suite.Assert().NotNil(transactions[i].InstallmentNumber, fmt.Sprintf("transactions[%d].InstallmentNumber should not be nil", i))
-		suite.Assert().Nil(transactions[i].CategoryID, fmt.Sprintf("transactions[%d].CategoryID should be nil", i))
-		suite.Assert().Equal(user.ID, transactions[i].UserID, fmt.Sprintf("transactions[%d].UserID should be %d", i, user.ID))
-		suite.Assert().Equal(user.ID, lo.FromPtr(transactions[i].OriginalUserID), fmt.Sprintf("transactions[%d].OriginalUserID should be %d", i, user.ID))
-		suite.Assert().Equal(int64(100), int64(transactions[i].Amount), fmt.Sprintf("transactions[%d].Amount should be %d", i, 100))
-		suite.Assert().Equal(transaction.Date.AddDate(0, i, 0), transactions[i].Date, fmt.Sprintf("transactions[%d].Date should be %s", i, transaction.Date.AddDate(0, i, 0)))
-		suite.Assert().Equal(domain.TransactionTypeTransfer, transactions[i].Type, fmt.Sprintf("transactions[%d].Type should be %s", i, domain.TransactionTypeTransfer))
-		suite.Assert().Equal(expectedInstallmentNumber, lo.FromPtr(transactions[i].InstallmentNumber), fmt.Sprintf("transactions[%d].InstallmentNumber should be %d", i, expectedInstallmentNumber))
-		suite.Assert().Equal(account1.ID, transactions[i].AccountID, fmt.Sprintf("transactions[%d].AccountID should be %d", i, account1.ID))
-		suite.Assert().Len(transactions[i].LinkedTransactions, 1, fmt.Sprintf("transactions[%d].LinkedTransactions should have 1", i))
-		suite.Assert().Equal(domain.OperationTypeDebit, transactions[i].OperationType, fmt.Sprintf("transactions[%d].OperationType should be %s", i, domain.OperationTypeDebit))
+	for i := range debitTransactions {
+		suite.Assert().NotNil(debitTransactions[i].TransactionRecurrenceID, fmt.Sprintf("debitTransactions[%d].TransactionRecurrenceID should not be nil", i))
+		suite.Assert().NotNil(debitTransactions[i].InstallmentNumber, fmt.Sprintf("debitTransactions[%d].InstallmentNumber should not be nil", i))
+		suite.Assert().Nil(debitTransactions[i].CategoryID, fmt.Sprintf("debitTransactions[%d].CategoryID should be nil", i))
+		suite.Assert().Equal(user.ID, debitTransactions[i].UserID, fmt.Sprintf("debitTransactions[%d].UserID should be %d", i, user.ID))
+		suite.Assert().Equal(user.ID, lo.FromPtr(debitTransactions[i].OriginalUserID), fmt.Sprintf("debitTransactions[%d].OriginalUserID should be %d", i, user.ID))
+		suite.Assert().Equal(int64(100), int64(debitTransactions[i].Amount), fmt.Sprintf("debitTransactions[%d].Amount should be %d", i, 100))
+		suite.Assert().Equal(transaction.Date.AddDate(0, i, 0), debitTransactions[i].Date, fmt.Sprintf("debitTransactions[%d].Date should be %s", i, transaction.Date.AddDate(0, i, 0)))
+		suite.Assert().Equal(domain.TransactionTypeTransfer, debitTransactions[i].Type, fmt.Sprintf("debitTransactions[%d].Type should be %s", i, domain.TransactionTypeTransfer))
+		suite.Assert().Equal(expectedInstallmentNumber, lo.FromPtr(debitTransactions[i].InstallmentNumber), fmt.Sprintf("debitTransactions[%d].InstallmentNumber should be %d", i, expectedInstallmentNumber))
+		suite.Assert().Equal(account1.ID, debitTransactions[i].AccountID, fmt.Sprintf("debitTransactions[%d].AccountID should be %d", i, account1.ID))
+		suite.Assert().Len(debitTransactions[i].LinkedTransactions, 1, fmt.Sprintf("debitTransactions[%d].LinkedTransactions should have 1", i))
+		suite.Assert().Equal(domain.OperationTypeDebit, debitTransactions[i].OperationType, fmt.Sprintf("debitTransactions[%d].OperationType should be %s", i, domain.OperationTypeDebit))
 
-		suite.Assert().Len(transactions[i].LinkedTransactions, 1, fmt.Sprintf("transactions[%d].LinkedTransactions should have 1", i))
-
-		suite.Assert().Equal(account2.ID, transactions[i].LinkedTransactions[0].AccountID, fmt.Sprintf("transactions[%d].LinkedTransactions[0].AccountID should be %d", i, account2.ID))
-		suite.Assert().Equal(int64(100), int64(transactions[i].LinkedTransactions[0].Amount), fmt.Sprintf("transactions[%d].LinkedTransactions[0].Amount should be %d", i, 100))
-		suite.Assert().Equal(transaction.Date.AddDate(0, i, 0), transactions[i].LinkedTransactions[0].Date, fmt.Sprintf("transactions[%d].LinkedTransactions[0].Date should be %s", i, transaction.Date.AddDate(0, i, 0)))
-		suite.Assert().Equal(transaction.Description, transactions[i].LinkedTransactions[0].Description, fmt.Sprintf("transactions[%d].LinkedTransactions[0].Description should be %s", i, transaction.Description))
-		suite.Assert().Equal(domain.TransactionTypeTransfer, transactions[i].LinkedTransactions[0].Type, fmt.Sprintf("transactions[%d].LinkedTransactions[0].Type should be %s", i, domain.TransactionTypeTransfer))
-		suite.Assert().Equal(user.ID, transactions[i].LinkedTransactions[0].UserID, fmt.Sprintf("transactions[%d].LinkedTransactions[0].UserID should be %d", i, user.ID))
-		suite.Assert().Equal(user.ID, lo.FromPtr(transactions[i].LinkedTransactions[0].OriginalUserID), fmt.Sprintf("transactions[%d].LinkedTransactions[0].OriginalUserID should be %d", i, user.ID))
-		suite.Assert().Len(transactions[i].LinkedTransactions[0].Tags, 1, fmt.Sprintf("transactions[%d].LinkedTransactions[0].Tags should have 1 tag", i))
-		suite.Assert().Equal(tag.ID, transactions[i].LinkedTransactions[0].Tags[0].ID, fmt.Sprintf("transactions[%d].LinkedTransactions[0].Tags[0].ID should be %d", i, tag.ID))
+		suite.Assert().Equal(account2.ID, debitTransactions[i].LinkedTransactions[0].AccountID, fmt.Sprintf("debitTransactions[%d].LinkedTransactions[0].AccountID should be %d", i, account2.ID))
+		suite.Assert().Equal(int64(100), int64(debitTransactions[i].LinkedTransactions[0].Amount), fmt.Sprintf("debitTransactions[%d].LinkedTransactions[0].Amount should be %d", i, 100))
+		suite.Assert().Equal(transaction.Date.AddDate(0, i, 0), debitTransactions[i].LinkedTransactions[0].Date, fmt.Sprintf("debitTransactions[%d].LinkedTransactions[0].Date should be %s", i, transaction.Date.AddDate(0, i, 0)))
+		suite.Assert().Equal(transaction.Description, debitTransactions[i].LinkedTransactions[0].Description, fmt.Sprintf("debitTransactions[%d].LinkedTransactions[0].Description should be %s", i, transaction.Description))
+		suite.Assert().Equal(domain.TransactionTypeTransfer, debitTransactions[i].LinkedTransactions[0].Type, fmt.Sprintf("debitTransactions[%d].LinkedTransactions[0].Type should be %s", i, domain.TransactionTypeTransfer))
+		suite.Assert().Equal(user.ID, debitTransactions[i].LinkedTransactions[0].UserID, fmt.Sprintf("debitTransactions[%d].LinkedTransactions[0].UserID should be %d", i, user.ID))
+		suite.Assert().Equal(user.ID, lo.FromPtr(debitTransactions[i].LinkedTransactions[0].OriginalUserID), fmt.Sprintf("debitTransactions[%d].LinkedTransactions[0].OriginalUserID should be %d", i, user.ID))
+		suite.Assert().Len(debitTransactions[i].LinkedTransactions[0].Tags, 1, fmt.Sprintf("debitTransactions[%d].LinkedTransactions[0].Tags should have 1 tag", i))
+		suite.Assert().Equal(tag.ID, debitTransactions[i].LinkedTransactions[0].Tags[0].ID, fmt.Sprintf("debitTransactions[%d].LinkedTransactions[0].Tags[0].ID should be %d", i, tag.ID))
 
 		expectedInstallmentNumber++
 	}
@@ -423,7 +426,7 @@ func (suite *TransactionCreateWithDBTestSuite) TestTransferBetweenDifferentUsers
 			suite.Assert().Equal(user2.ID, lo.FromPtr(transactionsUser1[i].OriginalUserID), fmt.Sprintf("transactionsUser1[%d].OriginalUserID should be %d", i, user2.ID))
 			suite.Assert().Equal(int64(500), int64(transactionsUser1[i].Amount), fmt.Sprintf("transactionsUser1[%d].Amount should be %d", i, 500))
 			suite.Assert().Equal(connection.FromAccountID, transactionsUser1[i].AccountID, fmt.Sprintf("transactionsUser1[%d].AccountID should be %d", i, connection.FromAccountID))
-			suite.Assert().Len(transactionsUser1[i].LinkedTransactions, 0, fmt.Sprintf("transactionsUser1[%d].LinkedTransactions should have 0", i))
+			suite.Assert().Len(transactionsUser1[i].LinkedTransactions, 1, fmt.Sprintf("transactionsUser1[%d].LinkedTransactions should have 1 (source tx)", i))
 			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser1[i].OperationType, fmt.Sprintf("transactionsUser1[%d].OperationType should be %s", i, domain.OperationTypeCredit))
 		}
 	}
@@ -460,7 +463,7 @@ func (suite *TransactionCreateWithDBTestSuite) TestTransferBetweenDifferentUsers
 			suite.Assert().Equal(user1.ID, lo.FromPtr(transactionsUser2[i].OriginalUserID), fmt.Sprintf("transactionsUser2[%d].OriginalUserID should be %d", i, user1.ID))
 			suite.Assert().Equal(int64(100), int64(transactionsUser2[i].Amount), fmt.Sprintf("transactionsUser2[%d].Amount should be %d", i, 500))
 			suite.Assert().Equal(connection.ToAccountID, transactionsUser2[i].AccountID, fmt.Sprintf("transactionsUser2[%d].AccountID should be %d", i, connection.ToAccountID))
-			suite.Assert().Len(transactionsUser2[i].LinkedTransactions, 0, fmt.Sprintf("transactionsUser2[%d].LinkedTransactions should have 0", i))
+			suite.Assert().Len(transactionsUser2[i].LinkedTransactions, 1, fmt.Sprintf("transactionsUser2[%d].LinkedTransactions should have 1 (source tx)", i))
 			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser2[i].OperationType, fmt.Sprintf("transactionsUser2[%d].OperationType should be %s", i, domain.OperationTypeCredit))
 		}
 	}
@@ -577,7 +580,7 @@ func (suite *TransactionCreateWithDBTestSuite) TestRecurringTransferBetweenDiffe
 			suite.Assert().Equal(user2.ID, lo.FromPtr(transactionsUser1[i].OriginalUserID), fmt.Sprintf("transactionsUser1[%d].OriginalUserID should be %d", i, user2.ID))
 			suite.Assert().Equal(int64(500), int64(transactionsUser1[i].Amount), fmt.Sprintf("transactionsUser1[%d].Amount should be %d", i, 500))
 			suite.Assert().Equal(connection.FromAccountID, transactionsUser1[i].AccountID, fmt.Sprintf("transactionsUser1[%d].AccountID should be %d", i, connection.FromAccountID))
-			suite.Assert().Len(transactionsUser1[i].LinkedTransactions, 0, fmt.Sprintf("transactionsUser1[%d].LinkedTransactions should have 0", i))
+			suite.Assert().Len(transactionsUser1[i].LinkedTransactions, 1, fmt.Sprintf("transactionsUser1[%d].LinkedTransactions should have 1 (source tx)", i))
 			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser1[i].OperationType, fmt.Sprintf("transactionsUser1[%d].OperationType should be %s", i, domain.OperationTypeCredit))
 		}
 	}
@@ -614,7 +617,7 @@ func (suite *TransactionCreateWithDBTestSuite) TestRecurringTransferBetweenDiffe
 			suite.Assert().Equal(user1.ID, lo.FromPtr(transactionsUser2[i].OriginalUserID), fmt.Sprintf("transactionsUser2[%d].OriginalUserID should be %d", i, user1.ID))
 			suite.Assert().Equal(int64(100), int64(transactionsUser2[i].Amount), fmt.Sprintf("transactionsUser2[%d].Amount should be %d", i, 500))
 			suite.Assert().Equal(connection.ToAccountID, transactionsUser2[i].AccountID, fmt.Sprintf("transactionsUser2[%d].AccountID should be %d", i, connection.ToAccountID))
-			suite.Assert().Len(transactionsUser2[i].LinkedTransactions, 0, fmt.Sprintf("transactionsUser2[%d].LinkedTransactions should have 0", i))
+			suite.Assert().Len(transactionsUser2[i].LinkedTransactions, 1, fmt.Sprintf("transactionsUser2[%d].LinkedTransactions should have 1 (source tx)", i))
 			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser2[i].OperationType, fmt.Sprintf("transactionsUser2[%d].OperationType should be %s", i, domain.OperationTypeCredit))
 		}
 	}

--- a/backend/internal/service/transaction_service.go
+++ b/backend/internal/service/transaction_service.go
@@ -43,3 +43,9 @@ func (s *transactionService) Search(ctx context.Context, userID int, period doma
 
 	return s.transactionRepo.Search(ctx, filter)
 }
+
+// Suggestions searches transactions across all time periods for autocomplete purposes.
+func (s *transactionService) Suggestions(ctx context.Context, userID int, filter domain.TransactionFilter) ([]*domain.Transaction, error) {
+	filter.UserID = &userID
+	return s.transactionRepo.Search(ctx, filter)
+}

--- a/backend/internal/service/transaction_update_test.go
+++ b/backend/internal/service/transaction_update_test.go
@@ -1277,7 +1277,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestScenario7_OwnTransfer() {
 		suite.T().Fatalf("Failed to get transaction: %v", err)
 	}
 
-	if len(transactions) != 1 {
+	if len(transactions) != 2 {
 		suite.T().Fatalf("Expected 1 transactions, got %d", len(transactions))
 	}
 
@@ -1416,7 +1416,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestScenario8_OwnTransferToOwnExp
 		suite.T().Fatalf("Failed to get transaction: %v", err)
 	}
 
-	if len(transactions) != 1 {
+	if len(transactions) != 2 {
 		suite.T().Fatalf("Expected 1 transactions, got %d", len(transactions))
 	}
 
@@ -1533,7 +1533,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestScenario8_OwnTransferToOwnInc
 		suite.T().Fatalf("Failed to get transaction: %v", err)
 	}
 
-	if len(transactions) != 1 {
+	if len(transactions) != 2 {
 		suite.T().Fatalf("Expected 1 transactions, got %d", len(transactions))
 	}
 
@@ -1650,7 +1650,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestScenario9_OwnTransferToSplitE
 		suite.T().Fatalf("Failed to get transaction: %v", err)
 	}
 
-	if len(transactions) != 1 {
+	if len(transactions) != 2 {
 		suite.T().Fatalf("Expected 1 transactions, got %d", len(transactions))
 	}
 

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -173,8 +173,20 @@ func (e *ServiceError) Unwrap() error {
 	return e.Err
 }
 
-func (e *ServiceError) ToHTTPError() *echo.HTTPError {
+func (e *ServiceError) ToHTTPError() error {
 	return ToHTTPError(e)
+}
+
+// TaggedHTTPError is an HTTP error that also carries structured error tags
+// so the error handler can serialize them in the response.
+type TaggedHTTPError struct {
+	Code    int
+	Message string
+	Tags    []string
+}
+
+func (e *TaggedHTTPError) Error() string {
+	return fmt.Sprintf("code=%d, message=%s", e.Code, e.Message)
 }
 
 func (e *ServiceError) AddTag(tag string) *ServiceError {
@@ -224,32 +236,60 @@ func AsServiceError(err error) (*ServiceError, bool) {
 	return serviceErr, ok
 }
 
-// ToHTTPError converts a service error to an HTTP error
-// Returns the HTTP status code and error message
-func ToHTTPError(err error) *echo.HTTPError {
+// ToHTTPError converts a service error to an HTTP error.
+// Handles both *ServiceError and ServiceErrors (slice).
+// For ServiceErrors, tags from all errors are merged into a TaggedHTTPError.
+func ToHTTPError(err error) error {
+	// Handle ServiceErrors (slice of *ServiceError) first
+	if serviceErrs, ok := err.(ServiceErrors); ok && len(serviceErrs) > 0 {
+		first := serviceErrs[0]
+		code := serviceErrHTTPCode(first.Code)
+		// Collect all tags, deduplicated
+		seen := make(map[string]struct{})
+		var tags []string
+		for _, se := range serviceErrs {
+			for _, t := range se.Tags {
+				if _, exists := seen[t]; !exists {
+					seen[t] = struct{}{}
+					tags = append(tags, t)
+				}
+			}
+		}
+		return &TaggedHTTPError{Code: code, Message: first.Message, Tags: tags}
+	}
+
 	serviceErr, ok := AsServiceError(err)
 	if !ok {
-		// If it's not a ServiceError, treat it as internal error
 		return echo.NewHTTPError(http.StatusInternalServerError, "Internal server error")
 	}
 
-	switch serviceErr.Code {
+	if len(serviceErr.Tags) > 0 {
+		return &TaggedHTTPError{
+			Code:    serviceErrHTTPCode(serviceErr.Code),
+			Message: serviceErr.Message,
+			Tags:    serviceErr.Tags,
+		}
+	}
+
+	return echo.NewHTTPError(serviceErrHTTPCode(serviceErr.Code), serviceErr.Message)
+}
+
+func serviceErrHTTPCode(code ErrorCode) int {
+	switch code {
 	case ErrCodeNotFound:
-		return echo.NewHTTPError(http.StatusNotFound, serviceErr.Message)
+		return http.StatusNotFound
 	case ErrCodeAlreadyExists:
-		return echo.NewHTTPError(http.StatusConflict, serviceErr.Message)
+		return http.StatusConflict
 	case ErrCodeUnauthorized:
-		return echo.NewHTTPError(http.StatusUnauthorized, serviceErr.Message)
+		return http.StatusUnauthorized
 	case ErrCodeForbidden:
-		return echo.NewHTTPError(http.StatusForbidden, serviceErr.Message)
-	case ErrCodeValidation:
-		return echo.NewHTTPError(http.StatusBadRequest, serviceErr.Message)
-	case ErrCodeBadRequest:
-		return echo.NewHTTPError(http.StatusBadRequest, serviceErr.Message)
+		return http.StatusForbidden
+	case ErrCodeValidation, ErrCodeBadRequest:
+		return http.StatusBadRequest
 	case ErrCodeInternal:
-		return echo.NewHTTPError(http.StatusInternalServerError, serviceErr.Message)
+		return http.StatusInternalServerError
 	default:
-		return echo.NewHTTPError(http.StatusInternalServerError, "Internal server error")
+		return http.StatusInternalServerError
 	}
 }
 

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -241,7 +241,8 @@ func AsServiceError(err error) (*ServiceError, bool) {
 // For ServiceErrors, tags from all errors are merged into a TaggedHTTPError.
 func ToHTTPError(err error) error {
 	// Handle ServiceErrors (slice of *ServiceError) first
-	if serviceErrs, ok := err.(ServiceErrors); ok && len(serviceErrs) > 0 {
+	serviceErrs, ok := err.(ServiceErrors)
+	if ok && len(serviceErrs) > 0 {
 		first := serviceErrs[0]
 		code := serviceErrHTTPCode(first.Code)
 		// Collect all tags, deduplicated

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "finance-app-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@mantine/core": "^7.17.0",
         "@mantine/dates": "^8.3.18",
         "@mantine/hooks": "^7.17.0",
@@ -971,6 +972,18 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1473,6 +1486,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tabler/icons": {
       "version": "3.40.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@mantine/core": "^7.17.0",
     "@mantine/dates": "^8.3.18",
     "@mantine/hooks": "^7.17.0",

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -2,6 +2,18 @@ import { Transactions } from '@/types/transactions'
 
 const apiUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:8080'
 
+/** Converts a YYYY-MM-DD string to an RFC3339 string at local midnight, preserving the calendar date. */
+function localMidnightISO(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  const d = new Date(year, month - 1, day, 0, 0, 0)
+  const offsetMin = -d.getTimezoneOffset()
+  const sign = offsetMin >= 0 ? '+' : '-'
+  const absMin = Math.abs(offsetMin)
+  const hh = String(Math.floor(absMin / 60)).padStart(2, '0')
+  const mm = String(absMin % 60).padStart(2, '0')
+  return `${dateStr}T00:00:00${sign}${hh}:${mm}`
+}
+
 export async function fetchBalance(
   params: Transactions.FetchBalanceParams,
 ): Promise<Transactions.BalanceResult> {
@@ -54,4 +66,36 @@ export async function fetchTransactions(
   const res = await fetch(url.toString(), { credentials: 'include' })
   if (!res.ok) throw new Error('Failed to fetch transactions')
   return res.json()
+}
+
+export async function fetchTransactionSuggestions(
+  q: string,
+  limit = 10,
+): Promise<Transactions.TransactionSuggestion[]> {
+  const url = new URL(`${apiUrl}/api/transactions/suggestions`)
+  url.searchParams.set('q', q)
+  url.searchParams.set('limit', String(limit))
+
+  const res = await fetch(url.toString(), { credentials: 'include' })
+  if (!res.ok) throw new Error('Failed to fetch suggestions')
+  return res.json()
+}
+
+export async function createTransaction(
+  payload: Transactions.CreateTransactionPayload,
+): Promise<Response> {
+  const body = {
+    ...payload,
+    // Backend expects time.Time (RFC3339); DatePickerInput gives YYYY-MM-DD.
+    // Send local midnight with timezone offset so the backend stores the correct day.
+    date: payload.date.length === 10 ? localMidnightISO(payload.date) : payload.date,
+  }
+  const res = await fetch(`${apiUrl}/api/transactions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw res
+  return res
 }

--- a/frontend/src/components/transactions/CreateTransactionDrawer.tsx
+++ b/frontend/src/components/transactions/CreateTransactionDrawer.tsx
@@ -1,0 +1,73 @@
+import { useState, useRef, useEffect } from 'react'
+import { Drawer } from '@mantine/core'
+import { useAccounts } from '@/hooks/useAccounts'
+import { useCategories } from '@/hooks/useCategories'
+import { useTransactionPrefill } from '@/hooks/useTransactionPrefill'
+import { Transactions } from '@/types/transactions'
+import { TransactionForm, TransactionFormHandle } from './form/TransactionForm'
+
+interface Props {
+  opened: boolean
+  onClose: () => void
+  currentUserId: number
+}
+
+const TYPE_LABELS: Record<Transactions.TransactionType, string> = {
+  expense: 'Nova Despesa',
+  income: 'Nova Receita',
+  transfer: 'Nova Transferência',
+}
+
+export function CreateTransactionDrawer({ opened, onClose, currentUserId }: Props) {
+  const [transactionType, setTransactionType] = useState<Transactions.TransactionType>('expense')
+  const formRef = useRef<TransactionFormHandle>(null)
+  const hasFocused = useRef(false)
+
+  useEffect(() => {
+    if (opened) hasFocused.current = false
+  }, [opened])
+
+  const { query: accountsQuery } = useAccounts()
+  const { query: categoriesQuery } = useCategories()
+
+  const accounts = accountsQuery.data ?? []
+  const categories = categoriesQuery.data ?? []
+
+  const { prefill, savePrefill } = useTransactionPrefill({
+    userId: currentUserId,
+    accounts,
+    categories,
+  })
+
+  const initialValues: Record<string, unknown> = {}
+  if (prefill.date) initialValues.date = prefill.date
+  if (prefill.accountId) initialValues.account_id = prefill.accountId
+  if (prefill.categoryId) initialValues.category_id = prefill.categoryId
+
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      title={TYPE_LABELS[transactionType]}
+      position="right"
+      size="md"
+      onTransitionEnd={() => {
+        if (opened && !hasFocused.current) {
+          hasFocused.current = true
+          formRef.current?.focusAmount()
+        }
+      }}
+    >
+      {opened && (
+        <TransactionForm
+          ref={formRef}
+          currentUserId={currentUserId}
+          initialValues={initialValues}
+          onSuccess={onClose}
+          onSavePrefill={savePrefill}
+          onTypeChange={setTransactionType}
+        />
+      )}
+    </Drawer>
+  )
+}

--- a/frontend/src/components/transactions/CreateTransactionDrawer.tsx
+++ b/frontend/src/components/transactions/CreateTransactionDrawer.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { Drawer } from '@mantine/core'
 import { useAccounts } from '@/hooks/useAccounts'
 import { useCategories } from '@/hooks/useCategories'
+import { useMe } from '@/hooks/useMe'
 import { useTransactionPrefill } from '@/hooks/useTransactionPrefill'
 import { Transactions } from '@/types/transactions'
 import { TransactionForm, TransactionFormHandle } from './form/TransactionForm'
@@ -9,7 +10,6 @@ import { TransactionForm, TransactionFormHandle } from './form/TransactionForm'
 interface Props {
   opened: boolean
   onClose: () => void
-  currentUserId: number
 }
 
 const TYPE_LABELS: Record<Transactions.TransactionType, string> = {
@@ -18,10 +18,13 @@ const TYPE_LABELS: Record<Transactions.TransactionType, string> = {
   transfer: 'Nova Transferência',
 }
 
-export function CreateTransactionDrawer({ opened, onClose, currentUserId }: Props) {
+export function CreateTransactionDrawer({ opened, onClose }: Props) {
   const [transactionType, setTransactionType] = useState<Transactions.TransactionType>('expense')
   const formRef = useRef<TransactionFormHandle>(null)
   const hasFocused = useRef(false)
+
+  const { query: meQuery } = useMe((me) => me.id)
+  const currentUserId = meQuery.data ?? 0
 
   useEffect(() => {
     if (opened) hasFocused.current = false

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -16,7 +16,12 @@ interface TransactionListProps {
 
 function groupNetTotal(group: Transactions.TransactionGroup): number {
   return group.transactions.reduce((sum, tx) => {
-    return sum + (tx.operation_type === 'credit' ? tx.amount : -tx.amount)
+    const txAmount = tx.operation_type === 'credit' ? tx.amount : -tx.amount
+    const settlementsAmount = (tx.settlements_from_source ?? []).reduce(
+      (s, settlement) => s + (settlement.type === 'credit' ? settlement.amount : -settlement.amount),
+      0,
+    )
+    return sum + txAmount + settlementsAmount
   }, 0)
 }
 

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -2,6 +2,7 @@ import { Badge, Group, Stack, Text, Tooltip } from '@mantine/core'
 import { IconArrowDown, IconUsers } from '@tabler/icons-react'
 import { Transactions } from '@/types/transactions'
 import { formatCents } from '@/utils/formatCents'
+import { parseDate } from '@/utils/parseDate'
 import { RecurrenceBadge } from './RecurrenceBadge'
 import classes from './TransactionRow.module.css'
 
@@ -64,7 +65,7 @@ export function TransactionRow({
 
   const hasLinkedUser = (tx.linked_transactions ?? []).some((l) => l.user_id !== currentUserId)
 
-  const date = new Date(tx.date)
+  const date = parseDate(tx.date)
   const dateLabel = date.toLocaleDateString('pt-BR', {
     day: '2-digit',
     month: '2-digit',

--- a/frontend/src/components/transactions/form/CurrencyInput.tsx
+++ b/frontend/src/components/transactions/form/CurrencyInput.tsx
@@ -1,0 +1,73 @@
+import { useRef, forwardRef, useImperativeHandle } from 'react'
+import { TextInput } from '@mantine/core'
+
+interface Props {
+  value: number // in cents
+  onChange: (cents: number) => void
+  error?: string
+  label?: string
+  required?: boolean
+}
+
+export interface CurrencyInputHandle {
+  focus: () => void
+}
+
+const MAX_CENTS = 9_999_999_999 // R$ 99.999.999,99
+
+function formatCents(cents: number): string {
+  return new Intl.NumberFormat('pt-BR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(cents / 100)
+}
+
+export const CurrencyInput = forwardRef<CurrencyInputHandle, Props>(function CurrencyInput(
+  { value, onChange, error, label, required }: Props,
+  ref,
+) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useImperativeHandle(ref, () => ({
+    focus: () => inputRef.current?.focus(),
+  }))
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    // Let browser handle shortcuts and navigation
+    if (e.ctrlKey || e.metaKey) return
+    if (['Tab', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].includes(e.key)) return
+
+    e.preventDefault()
+
+    const el = e.currentTarget
+    const allSelected = el.selectionStart === 0 && el.selectionEnd === el.value.length
+
+    if (e.key === 'Backspace' || e.key === 'Delete') {
+      if (allSelected) {
+        onChange(0)
+      } else if (e.key === 'Backspace') {
+        onChange(Math.floor(value / 10))
+      }
+      return
+    }
+
+    if (/^\d$/.test(e.key)) {
+      const next = allSelected ? parseInt(e.key, 10) : value * 10 + parseInt(e.key, 10)
+      if (next <= MAX_CENTS) onChange(next)
+    }
+  }
+
+  return (
+    <TextInput
+      ref={inputRef}
+      label={label}
+      required={required}
+      value={formatCents(value)}
+      onChange={() => {}}
+      onKeyDown={handleKeyDown}
+      onFocus={(e) => e.currentTarget.select()}
+      error={error}
+      inputMode="numeric"
+    />
+  )
+})

--- a/frontend/src/components/transactions/form/DescriptionAutocomplete.tsx
+++ b/frontend/src/components/transactions/form/DescriptionAutocomplete.tsx
@@ -10,18 +10,19 @@ interface Props {
   required?: boolean
 }
 
-export function DescriptionAutocomplete({ value, onChange, onSuggestionSelect, error, required }: Props) {
-  const { data: suggestions = [] } = useTransactionSuggestions(value)
-
-  // Deduplicate by description and build autocomplete options
+function selectUniqueDescriptions(suggestions: Transactions.TransactionSuggestion[]) {
   const seen = new Set<string>()
-  const options = suggestions
-    .filter((s) => {
-      if (seen.has(s.description)) return false
-      seen.add(s.description)
-      return true
-    })
-    .map((s) => s.description)
+  return suggestions.filter((s) => {
+    if (seen.has(s.description)) return false
+    seen.add(s.description)
+    return true
+  })
+}
+
+export function DescriptionAutocomplete({ value, onChange, onSuggestionSelect, error, required }: Props) {
+  const { data: suggestions = [] } = useTransactionSuggestions(value, selectUniqueDescriptions)
+
+  const options = suggestions.map((s) => s.description)
 
   function handleOptionSubmit(val: string) {
     const match = suggestions.find((s) => s.description === val)

--- a/frontend/src/components/transactions/form/DescriptionAutocomplete.tsx
+++ b/frontend/src/components/transactions/form/DescriptionAutocomplete.tsx
@@ -1,0 +1,44 @@
+import { Autocomplete } from '@mantine/core'
+import { useTransactionSuggestions } from '@/hooks/useTransactionSuggestions'
+import { Transactions } from '@/types/transactions'
+
+interface Props {
+  value: string
+  onChange: (value: string) => void
+  onSuggestionSelect: (suggestion: Transactions.TransactionSuggestion) => void
+  error?: string
+  required?: boolean
+}
+
+export function DescriptionAutocomplete({ value, onChange, onSuggestionSelect, error, required }: Props) {
+  const { data: suggestions = [] } = useTransactionSuggestions(value)
+
+  // Deduplicate by description and build autocomplete options
+  const seen = new Set<string>()
+  const options = suggestions
+    .filter((s) => {
+      if (seen.has(s.description)) return false
+      seen.add(s.description)
+      return true
+    })
+    .map((s) => s.description)
+
+  function handleOptionSubmit(val: string) {
+    const match = suggestions.find((s) => s.description === val)
+    if (match) onSuggestionSelect(match)
+    onChange(val)
+  }
+
+  return (
+    <Autocomplete
+      label="Descrição"
+      placeholder="Ex: Supermercado"
+      required={required}
+      value={value}
+      onChange={onChange}
+      onOptionSubmit={handleOptionSubmit}
+      data={options}
+      error={error}
+    />
+  )
+}

--- a/frontend/src/components/transactions/form/RecurrenceFields.tsx
+++ b/frontend/src/components/transactions/form/RecurrenceFields.tsx
@@ -1,0 +1,117 @@
+import { Switch, Select, NumberInput, Stack, Group, Text, Alert } from '@mantine/core'
+import { DatePickerInput } from '@mantine/dates'
+import { Controller, Control, useWatch } from 'react-hook-form'
+import type { TransactionFormValues } from './TransactionForm'
+
+interface RecurrenceErrors {
+  type?: string
+  repetitions?: string
+  end_date?: string
+  _general?: string
+}
+
+interface Props {
+  control: Control<TransactionFormValues>
+  errors?: RecurrenceErrors
+}
+
+export function RecurrenceFields({ control, errors }: Props) {
+  const enabled = useWatch({ control, name: 'recurrenceEnabled' })
+  const endDateMode = useWatch({ control, name: 'recurrenceEndDateMode' })
+
+  return (
+    <Stack gap="xs">
+      <Controller
+        control={control}
+        name="recurrenceEnabled"
+        render={({ field }) => (
+          <Switch
+            label="Recorrência"
+            checked={field.value}
+            onChange={(e) => field.onChange(e.currentTarget.checked)}
+          />
+        )}
+      />
+
+      {enabled && (
+        <Stack gap="sm" pl="md">
+          {errors?._general && (
+            <Alert color="red" variant="light" p="xs">
+              {errors._general}
+            </Alert>
+          )}
+
+          <Controller
+            control={control}
+            name="recurrenceType"
+            render={({ field }) => (
+              <Select
+                label="Frequência"
+                data={[
+                  { value: 'daily', label: 'Diário' },
+                  { value: 'weekly', label: 'Semanal' },
+                  { value: 'monthly', label: 'Mensal' },
+                  { value: 'yearly', label: 'Anual' },
+                ]}
+                value={field.value}
+                onChange={field.onChange}
+                error={errors?.type}
+              />
+            )}
+          />
+
+          <Group gap="sm">
+            <Controller
+              control={control}
+              name="recurrenceEndDateMode"
+              render={({ field }) => (
+                <Switch
+                  label="Usar data de término"
+                  checked={field.value}
+                  onChange={(e) => field.onChange(e.currentTarget.checked)}
+                />
+              )}
+            />
+          </Group>
+
+          {endDateMode ? (
+            <Controller
+              control={control}
+              name="recurrenceEndDate"
+              render={({ field }) => (
+                <DatePickerInput
+                  label="Data de término"
+                  value={field.value || null}
+                  onChange={(date) => field.onChange(date ?? null)}
+                  error={errors?.end_date}
+                  valueFormat="DD/MM/YYYY"
+                />
+              )}
+            />
+          ) : (
+            <Controller
+              control={control}
+              name="recurrenceRepetitions"
+              render={({ field }) => (
+                <NumberInput
+                  label="Repetições"
+                  description="Número de parcelas"
+                  min={1}
+                  value={field.value ?? ''}
+                  onChange={(val) => field.onChange(val === '' ? null : Number(val))}
+                  error={errors?.repetitions}
+                />
+              )}
+            />
+          )}
+
+          <Text size="xs" c="dimmed">
+            {endDateMode
+              ? 'A recorrência terminará na data selecionada'
+              : 'Deixe em branco para repetir indefinidamente'}
+          </Text>
+        </Stack>
+      )}
+    </Stack>
+  )
+}

--- a/frontend/src/components/transactions/form/SplitSettingsFields.tsx
+++ b/frontend/src/components/transactions/form/SplitSettingsFields.tsx
@@ -1,0 +1,208 @@
+import { useState, useRef, useEffect } from 'react'
+import { Group, Avatar, ActionIcon, Text, Alert, Stack, Divider, Box, NumberInput, Tooltip, Switch } from '@mantine/core'
+import { CurrencyInput } from './CurrencyInput'
+import { Controller, Control, useWatch } from 'react-hook-form'
+import { Transactions } from '@/types/transactions'
+import type { TransactionFormValues } from './TransactionForm'
+
+interface Props {
+  control: Control<TransactionFormValues>
+  accounts: Transactions.Account[]
+  currentUserId: number
+  errors?: Record<string, string>
+}
+
+function formatCurrency(cents: number): string {
+  return (cents / 100).toLocaleString('pt-BR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+function getInitials(text: string): string {
+  return text
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('')
+}
+
+interface SplitRowProps {
+  account: Transactions.Account
+  currentUserId: number
+  totalAmount: number
+  enabled: boolean
+  onToggle: (enabled: boolean) => void
+  amount: number
+  onChange: (cents: number) => void
+  error?: string
+}
+
+function SplitRow({ account, currentUserId, totalAmount, enabled, onToggle, amount, onChange, error }: SplitRowProps) {
+  const conn = account.user_connection!
+  const isFrom = conn.from_user_id === currentUserId
+  const defaultPercentage = isFrom
+    ? conn.from_default_split_percentage
+    : conn.to_default_split_percentage
+
+  const [mode, setMode] = useState<'percentage' | 'amount'>('percentage')
+  const [percentage, setPercentage] = useState(defaultPercentage)
+
+  const calculatedAmount = Math.round((totalAmount * percentage) / 100)
+
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
+
+  useEffect(() => {
+    if (enabled && mode === 'percentage') {
+      onChangeRef.current(calculatedAmount)
+    }
+  }, [calculatedAmount, mode, enabled])
+
+  function toggleMode() {
+    const next = mode === 'percentage' ? 'amount' : 'percentage'
+    if (next === 'amount') onChange(calculatedAmount)
+    setMode(next)
+  }
+
+  const label = account.description || account.name
+  const initials = getInitials(label)
+  const tooltipLabel = account.description ?? account.name
+
+  return (
+    <Stack gap={4}>
+      <Group gap="sm" align="center" wrap="nowrap">
+        <Tooltip label={tooltipLabel} withArrow>
+          <Avatar size="sm" radius="xl" color="blue" style={{ cursor: 'default' }}>
+            {initials}
+          </Avatar>
+        </Tooltip>
+
+        <Switch checked={enabled} onChange={(e) => onToggle(e.currentTarget.checked)} />
+
+        {enabled && (
+          <>
+            <ActionIcon
+              size="md"
+              radius="xl"
+              variant="light"
+              onClick={toggleMode}
+              title={mode === 'percentage' ? 'Mudar para valor fixo' : 'Mudar para percentual'}
+              style={{ flexShrink: 0, fontWeight: 700, fontSize: '0.7rem' }}
+            >
+              {mode === 'percentage' ? '%' : 'R$'}
+            </ActionIcon>
+
+            {mode === 'percentage' ? (
+              <Group gap="xs" align="center" style={{ flex: 1 }}>
+                <NumberInput
+                  min={1}
+                  max={100}
+                  suffix="%"
+                  value={percentage}
+                  onChange={(val) => setPercentage(Number(val))}
+                  style={{ width: 90 }}
+                  size="sm"
+                />
+                {totalAmount > 0 && (
+                  <Text size="sm" c="dimmed">
+                    = R$ {formatCurrency(calculatedAmount)}
+                  </Text>
+                )}
+              </Group>
+            ) : (
+              <Box style={{ flex: 1 }}>
+                <CurrencyInput value={amount} onChange={onChange} error={error} />
+              </Box>
+            )}
+          </>
+        )}
+      </Group>
+
+      {error && enabled && mode === 'percentage' && (
+        <Text size="xs" c="red">{error}</Text>
+      )}
+    </Stack>
+  )
+}
+
+export function SplitSettingsFields({ control, accounts, currentUserId, errors }: Props) {
+  const totalAmount = useWatch({ control, name: 'amount' }) ?? 0
+
+  const connectedAccounts = accounts.filter(
+    (a) => a.user_connection && a.user_connection.connection_status === 'accepted',
+  )
+
+  const [enabledMap, setEnabledMap] = useState<Record<number, boolean>>({})
+
+  if (connectedAccounts.length === 0) return null
+
+  const generalError = errors?.['split_settings']
+
+  return (
+    <Stack gap="xs">
+      <Text fw={500} size="sm">Divisão</Text>
+
+      {generalError && (
+        <Alert color="red" variant="light" p="xs">
+          {generalError}
+        </Alert>
+      )}
+
+      <Divider />
+
+      <Controller
+        control={control}
+        name="split_settings"
+        render={({ field }) => (
+          <Stack gap="sm">
+            {connectedAccounts.map((account) => {
+              const conn = account.user_connection!
+              const connectionId = conn.id
+              const enabled = enabledMap[connectionId] ?? false
+
+              const entry = (field.value ?? []).find((s) => s.connection_id === connectionId)
+              const currentAmount = entry?.amount ?? 0
+
+              const entryIndex = (field.value ?? []).findIndex((s) => s.connection_id === connectionId)
+              const indexErrors = entryIndex >= 0
+                ? Object.fromEntries(
+                    Object.entries(errors ?? {})
+                      .filter(([k]) => k.startsWith(`split_settings.${entryIndex}.`))
+                      .map(([k, v]) => [k.replace(`split_settings.${entryIndex}.`, ''), v]),
+                  )
+                : {}
+
+              function handleToggle(on: boolean) {
+                setEnabledMap((prev) => ({ ...prev, [connectionId]: on }))
+                if (!on) {
+                  field.onChange((field.value ?? []).filter((s) => s.connection_id !== connectionId))
+                }
+              }
+
+              function handleChange(cents: number) {
+                const next = (field.value ?? []).filter((s) => s.connection_id !== connectionId)
+                next.push({ connection_id: connectionId, amount: cents })
+                field.onChange(next)
+              }
+
+              return (
+                <SplitRow
+                  key={connectionId}
+                  account={account}
+                  currentUserId={currentUserId}
+                  totalAmount={totalAmount}
+                  enabled={enabled}
+                  onToggle={handleToggle}
+                  amount={currentAmount}
+                  onChange={handleChange}
+                  error={indexErrors['amount'] ?? errors?.[`split_settings.${entryIndex}`]}
+                />
+              )
+            })}
+          </Stack>
+        )}
+      />
+    </Stack>
+  )
+}

--- a/frontend/src/components/transactions/form/TransactionForm.tsx
+++ b/frontend/src/components/transactions/form/TransactionForm.tsx
@@ -1,0 +1,364 @@
+import { useRef, forwardRef, useImperativeHandle } from 'react'
+import { useForm, Controller } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  Stack,
+  SegmentedControl,
+  Select,
+  TagsInput,
+  Button,
+  Alert,
+  Group,
+  SimpleGrid,
+} from '@mantine/core'
+import { DatePickerInput } from '@mantine/dates'
+import { useAccounts } from '@/hooks/useAccounts'
+import { useCategories } from '@/hooks/useCategories'
+import { useTags } from '@/hooks/useTags'
+import { useCreateTransaction } from '@/hooks/useCreateTransaction'
+import { Transactions } from '@/types/transactions'
+import { CurrencyInput, CurrencyInputHandle } from './CurrencyInput'
+import { DescriptionAutocomplete } from './DescriptionAutocomplete'
+import { RecurrenceFields } from './RecurrenceFields'
+import { SplitSettingsFields } from './SplitSettingsFields'
+import { transactionFormSchema, TransactionFormValues } from './transactionFormSchema'
+
+export type { TransactionFormValues }
+
+export interface TransactionFormHandle {
+  focusAmount: () => void
+}
+
+interface Props {
+  currentUserId: number
+  initialValues?: Partial<TransactionFormValues>
+  onSuccess: () => void
+  onSavePrefill: (date: string, categoryId: number | null, accountId: number | null) => void
+  onTypeChange?: (type: Transactions.TransactionType) => void
+}
+
+export const TransactionForm = forwardRef<TransactionFormHandle, Props>(function TransactionForm(
+  { currentUserId, initialValues, onSuccess, onSavePrefill, onTypeChange }: Props,
+  ref,
+) {
+  const amountRef = useRef<CurrencyInputHandle>(null)
+
+  useImperativeHandle(ref, () => ({
+    focusAmount: () => amountRef.current?.focus(),
+  }))
+
+  const { query: accountsQuery } = useAccounts()
+  const { query: categoriesQuery } = useCategories()
+  const { query: tagsQuery } = useTags()
+
+  const accounts = accountsQuery.data ?? []
+  const categories = categoriesQuery.data ?? []
+  const existingTags = tagsQuery.data ?? []
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    setValue,
+    setError,
+    getValues,
+    formState: { errors, isSubmitting },
+  } = useForm<TransactionFormValues>({
+    resolver: zodResolver(transactionFormSchema),
+    defaultValues: {
+      transaction_type: 'expense',
+      date: new Date().toISOString().split('T')[0],
+      description: '',
+      amount: 0,
+      account_id: null,
+      category_id: null,
+      destination_account_id: null,
+      tags: [],
+      split_settings: [],
+      recurrenceEnabled: false,
+      recurrenceType: 'monthly',
+      recurrenceEndDateMode: false,
+      recurrenceEndDate: null,
+      recurrenceRepetitions: null,
+      ...initialValues,
+    },
+  })
+
+  const transactionType = watch('transaction_type')
+  const isTransfer = transactionType === 'transfer'
+
+  const { mutation } = useCreateTransaction({
+    onFieldErrors: (fieldErrors) => {
+      for (const [field, message] of Object.entries(fieldErrors)) {
+        if (field === '_general') continue
+        setError(field as keyof TransactionFormValues, { message })
+      }
+    },
+    onSuccess: () => {
+      const values = getValues()
+      onSavePrefill(values.date, values.category_id, values.account_id)
+      onSuccess()
+    },
+  })
+
+  const generalError =
+    (errors as Record<string, { message?: string }>)['_general']?.message
+
+  const onSubmit = (values: TransactionFormValues) => {
+    const resolvedTags = values.tags.map((name) => {
+      const existing = existingTags.find((t) => t.name === name)
+      return existing ? { id: existing.id, name } : { name }
+    })
+
+    const payload: Transactions.CreateTransactionPayload = {
+      transaction_type: values.transaction_type,
+      date: values.date,
+      description: values.description,
+      amount: values.amount,
+      account_id: values.account_id!,
+      category_id: isTransfer || !values.category_id ? undefined : values.category_id,
+      destination_account_id: isTransfer ? values.destination_account_id ?? undefined : undefined,
+      tags: resolvedTags.length > 0 ? resolvedTags : undefined,
+      split_settings:
+        !isTransfer && values.split_settings.length > 0 ? values.split_settings : undefined,
+      recurrence_settings: values.recurrenceEnabled
+        ? {
+            type: values.recurrenceType,
+            repetitions: !values.recurrenceEndDateMode && values.recurrenceRepetitions
+              ? values.recurrenceRepetitions
+              : undefined,
+            end_date: values.recurrenceEndDateMode && values.recurrenceEndDate
+              ? values.recurrenceEndDate
+              : undefined,
+          }
+        : undefined,
+    }
+
+    mutation.mutate(payload)
+  }
+
+  function handleSuggestionSelect(suggestion: Transactions.TransactionSuggestion) {
+    setValue('transaction_type', suggestion.type)
+    setValue('amount', suggestion.amount)
+    if (suggestion.account_id) setValue('account_id', suggestion.account_id)
+    if (suggestion.category_id) setValue('category_id', suggestion.category_id)
+    if (suggestion.tags) setValue('tags', suggestion.tags.map((t) => t.name))
+    // Clear split settings on autocomplete to avoid stale data
+    setValue('split_settings', [])
+  }
+
+  const accountOptions = accounts
+    .filter((a) => !a.user_connection)
+    .map((a) => ({ value: String(a.id), label: a.name }))
+
+  const destinationAccountOptions = [
+    ...accounts
+      .filter((a) => !a.user_connection)
+      .map((a) => ({ value: String(a.id), label: a.name, group: 'Minhas contas' })),
+    ...accounts
+      .filter((a) => a.user_connection?.connection_status === 'accepted')
+      .map((a) => ({ value: String(a.id), label: a.description || a.name, group: 'Contas compartilhadas' })),
+  ]
+
+  const categoryOptions = categories
+    .filter((c) => !c.parent_id)
+    .map((c) => ({ value: String(c.id), label: c.name }))
+
+  const tagNames = existingTags.map((t) => t.name)
+
+  const recurrenceErrors = {
+    type: (errors as Record<string, { message?: string }>)['recurrence_settings.type']?.message,
+    repetitions: (errors as Record<string, { message?: string }>)['recurrence_settings.repetitions']?.message,
+    end_date: (errors as Record<string, { message?: string }>)['recurrence_settings.end_date']?.message,
+    _general: (errors as Record<string, { message?: string }>)['recurrence_settings']?.message,
+  }
+
+  const splitErrors = Object.fromEntries(
+    Object.entries(errors as Record<string, { message?: string }>)
+      .filter(([k]) => k.startsWith('split_settings'))
+      .map(([k, v]) => [k, v?.message ?? '']),
+  )
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack gap="md">
+        {generalError && (
+          <Alert color="red" title="Erro" variant="light">
+            {generalError}
+          </Alert>
+        )}
+
+        <Controller
+          control={control}
+          name="transaction_type"
+          render={({ field }) => (
+            <SegmentedControl
+              data={[
+                { value: 'expense', label: 'Despesa' },
+                { value: 'income', label: 'Receita' },
+                { value: 'transfer', label: 'Transferência' },
+              ]}
+              value={field.value}
+              onChange={(val) => {
+                field.onChange(val)
+                if (val === 'transfer') setValue('split_settings', [])
+                onTypeChange?.(val as Transactions.TransactionType)
+              }}
+              fullWidth
+            />
+          )}
+        />
+
+        <SimpleGrid cols={{ base: 1, sm: 2 }}>
+          <Controller
+            control={control}
+            name="date"
+            render={({ field }) => (
+              <DatePickerInput
+                label="Data"
+                required
+                value={field.value || null}
+                onChange={(date) => field.onChange(date ?? '')}
+                error={errors.date?.message}
+                valueFormat="DD/MM/YYYY"
+              />
+            )}
+          />
+
+          <Controller
+            control={control}
+            name="amount"
+            render={({ field }) => (
+              <CurrencyInput
+                ref={amountRef}
+                label="Valor (R$)"
+                required
+                value={field.value}
+                onChange={field.onChange}
+                error={errors.amount?.message}
+              />
+            )}
+          />
+        </SimpleGrid>
+
+        <Controller
+          control={control}
+          name="description"
+          render={({ field }) => (
+            <DescriptionAutocomplete
+              value={field.value}
+              onChange={field.onChange}
+              onSuggestionSelect={handleSuggestionSelect}
+              error={errors.description?.message}
+              required
+            />
+          )}
+        />
+
+        {isTransfer ? (
+          <SimpleGrid cols={{ base: 1, sm: 2 }}>
+            <Controller
+              control={control}
+              name="account_id"
+              render={({ field }) => (
+                <Select
+                  label="Conta"
+                  required
+                  data={accountOptions}
+                  value={field.value ? String(field.value) : null}
+                  onChange={(val) => field.onChange(val ? Number(val) : null)}
+                  error={errors.account_id?.message}
+                  searchable
+                />
+              )}
+            />
+            <Controller
+              control={control}
+              name="destination_account_id"
+              render={({ field }) => (
+                <Select
+                  label="Conta de destino"
+                  required
+                  data={destinationAccountOptions}
+                  value={field.value ? String(field.value) : null}
+                  onChange={(val) => field.onChange(val ? Number(val) : null)}
+                  error={errors.destination_account_id?.message}
+                  searchable
+                />
+              )}
+            />
+          </SimpleGrid>
+        ) : (
+          <>
+            <SimpleGrid cols={{ base: 1, sm: 2 }}>
+              <Controller
+                control={control}
+                name="category_id"
+                render={({ field }) => (
+                  <Select
+                    label="Categoria"
+                    data={categoryOptions}
+                    value={field.value ? String(field.value) : null}
+                    onChange={(val) => field.onChange(val ? Number(val) : null)}
+                    error={errors.category_id?.message}
+                    searchable
+                    clearable
+                  />
+                )}
+              />
+              <Controller
+                control={control}
+                name="account_id"
+                render={({ field }) => (
+                  <Select
+                    label="Conta"
+                    required
+                    data={accountOptions}
+                    value={field.value ? String(field.value) : null}
+                    onChange={(val) => field.onChange(val ? Number(val) : null)}
+                    error={errors.account_id?.message}
+                    searchable
+                  />
+                )}
+              />
+            </SimpleGrid>
+
+            <SplitSettingsFields
+              control={control}
+              accounts={accounts}
+              currentUserId={currentUserId}
+              errors={splitErrors}
+            />
+          </>
+        )}
+
+        <Controller
+          control={control}
+          name="tags"
+          render={({ field }) => (
+            <TagsInput
+              label="Tags"
+              placeholder="Adicionar tag"
+              data={tagNames}
+              value={field.value}
+              onChange={field.onChange}
+              error={errors.tags?.message}
+              clearable
+            />
+          )}
+        />
+
+        <RecurrenceFields
+          control={control}
+          errors={recurrenceErrors}
+        />
+
+        <Group justify="flex-end" mt="sm">
+          <Button type="submit" loading={isSubmitting || mutation.isPending}>
+            Salvar
+          </Button>
+        </Group>
+      </Stack>
+    </form>
+  )
+})

--- a/frontend/src/components/transactions/form/transactionFormSchema.ts
+++ b/frontend/src/components/transactions/form/transactionFormSchema.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+
+const splitSettingSchema = z.object({
+  connection_id: z.number().int(),
+  percentage: z.number().int().min(1).max(100).optional(),
+  amount: z.number().int().optional(),
+})
+
+export const transactionFormSchema = z
+  .object({
+    transaction_type: z.enum(['expense', 'income', 'transfer']),
+    date: z.string().min(1, 'Data é obrigatória'),
+    description: z.string().min(1, 'Descrição é obrigatória'),
+    amount: z.number().int().min(1, 'Valor deve ser maior que zero'),
+    account_id: z.number().int().nullable(),
+    category_id: z.number().int().nullable(),
+    destination_account_id: z.number().int().nullable(),
+    tags: z.array(z.string()),
+    split_settings: z.array(splitSettingSchema),
+    recurrenceEnabled: z.boolean(),
+    recurrenceType: z.enum(['monthly', 'weekly', 'daily', 'yearly']),
+    recurrenceEndDateMode: z.boolean(),
+    recurrenceEndDate: z.string().nullable(),
+    recurrenceRepetitions: z.number().int().nullable(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.account_id) {
+      ctx.addIssue({ code: 'custom', message: 'Selecione uma conta', path: ['account_id'] })
+    }
+
+    if (data.transaction_type === 'transfer' && !data.destination_account_id) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Selecione a conta de destino',
+        path: ['destination_account_id'],
+      })
+    }
+
+    if (data.recurrenceEnabled) {
+      if (data.recurrenceEndDateMode) {
+        if (!data.recurrenceEndDate) {
+          ctx.addIssue({
+            code: 'custom',
+            message: 'Informe a data de término',
+            path: ['recurrenceEndDate'],
+          })
+        }
+      } else {
+        if (!data.recurrenceRepetitions || data.recurrenceRepetitions < 1) {
+          ctx.addIssue({
+            code: 'custom',
+            message: 'Informe o número de repetições',
+            path: ['recurrenceRepetitions'],
+          })
+        }
+      }
+    }
+  })
+
+export type TransactionFormValues = z.infer<typeof transactionFormSchema>

--- a/frontend/src/hooks/useAccounts.ts
+++ b/frontend/src/hooks/useAccounts.ts
@@ -7,6 +7,7 @@ export function useAccounts() {
   const query = useQuery({
     queryKey: [QueryKeys.Accounts],
     queryFn: fetchAccounts,
+    staleTime: 5 * 60 * 1000,
   })
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: [QueryKeys.Accounts] })

--- a/frontend/src/hooks/useAccounts.ts
+++ b/frontend/src/hooks/useAccounts.ts
@@ -1,13 +1,15 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { fetchAccounts } from '@/api/accounts'
+import { Transactions } from '@/types/transactions'
 import { QueryKeys } from '@/utils/queryKeys'
 
-export function useAccounts() {
+export function useAccounts<T = Transactions.Account[]>(select?: (data: Transactions.Account[]) => T) {
   const queryClient = useQueryClient()
   const query = useQuery({
     queryKey: [QueryKeys.Accounts],
     queryFn: fetchAccounts,
     staleTime: 5 * 60 * 1000,
+    select,
   })
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: [QueryKeys.Accounts] })

--- a/frontend/src/hooks/useActiveFilters.ts
+++ b/frontend/src/hooks/useActiveFilters.ts
@@ -1,12 +1,29 @@
 import { useSearch } from '@tanstack/react-router'
+import { useAccounts } from './useAccounts'
+import { useCategories } from './useCategories'
+import { useTags } from './useTags'
 import { Transactions } from '@/types/transactions'
 
 export function useActiveFilters(): Transactions.ActiveFilters {
   const search = useSearch({ from: '/_authenticated/transactions' })
+
+  const { query: accountsQuery } = useAccounts((accounts) => {
+    const valid = new Set(accounts.map((a) => a.id))
+    return search.accountIds.filter((id) => valid.has(id))
+  })
+  const { query: categoriesQuery } = useCategories((categories) => {
+    const valid = new Set(categories.map((c) => c.id))
+    return search.categoryIds.filter((id) => valid.has(id))
+  })
+  const { query: tagsQuery } = useTags((tags) => {
+    const valid = new Set(tags.map((t) => t.id))
+    return search.tagIds.filter((id) => valid.has(id))
+  })
+
   return {
-    accountIds: search.accountIds,
-    categoryIds: search.categoryIds,
-    tagIds: search.tagIds,
+    accountIds: accountsQuery.data ?? [],
+    categoryIds: categoriesQuery.data ?? [],
+    tagIds: tagsQuery.data ?? [],
     types: search.types,
   }
 }

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -7,6 +7,7 @@ export function useCategories() {
   const query = useQuery({
     queryKey: [QueryKeys.Categories],
     queryFn: fetchCategories,
+    staleTime: 5 * 60 * 1000,
   })
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: [QueryKeys.Categories] })

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -1,13 +1,15 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { fetchCategories } from '@/api/categories'
+import { Transactions } from '@/types/transactions'
 import { QueryKeys } from '@/utils/queryKeys'
 
-export function useCategories() {
+export function useCategories<T = Transactions.Category[]>(select?: (data: Transactions.Category[]) => T) {
   const queryClient = useQueryClient()
   const query = useQuery({
     queryKey: [QueryKeys.Categories],
     queryFn: fetchCategories,
     staleTime: 5 * 60 * 1000,
+    select,
   })
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: [QueryKeys.Categories] })

--- a/frontend/src/hooks/useCreateTransaction.ts
+++ b/frontend/src/hooks/useCreateTransaction.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createTransaction } from '@/api/transactions'
+import { Transactions } from '@/types/transactions'
+import { parseApiError, mapTagsToFieldErrors } from '@/utils/apiErrors'
+import { QueryKeys } from '@/utils/queryKeys'
+
+interface UseCreateTransactionOptions {
+  onFieldErrors?: (errors: Record<string, string>) => void
+  onSuccess?: () => void
+}
+
+export function useCreateTransaction(options: UseCreateTransactionOptions = {}) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: (payload: Transactions.CreateTransactionPayload) => createTransaction(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.Transactions] })
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.Tags] })
+      options.onSuccess?.()
+    },
+    onError: async (err: unknown) => {
+      if (err instanceof Response) {
+        const apiError = await parseApiError(err)
+        const fieldErrors = mapTagsToFieldErrors(apiError.tags, apiError.message)
+        options.onFieldErrors?.(fieldErrors)
+      }
+    },
+  })
+
+  return { mutation }
+}

--- a/frontend/src/hooks/useMe.ts
+++ b/frontend/src/hooks/useMe.ts
@@ -1,10 +1,10 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { fetchMe } from '@/api/auth'
+import { fetchMe, Me } from '@/api/auth'
 import { QueryKeys } from '@/utils/queryKeys'
 
-export function useMe() {
+export function useMe<T = Me>(select?: (data: Me) => T) {
   const queryClient = useQueryClient()
-  const query = useQuery({ queryKey: [QueryKeys.Me], queryFn: fetchMe })
+  const query = useQuery({ queryKey: [QueryKeys.Me], queryFn: fetchMe, staleTime: 5 * 60 * 1000, select })
   const invalidate = () => queryClient.invalidateQueries({ queryKey: [QueryKeys.Me] })
   return { query, invalidate }
 }

--- a/frontend/src/hooks/useTags.ts
+++ b/frontend/src/hooks/useTags.ts
@@ -1,12 +1,14 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { fetchTags } from '@/api/tags'
+import { Transactions } from '@/types/transactions'
 import { QueryKeys } from '@/utils/queryKeys'
 
-export function useTags() {
+export function useTags<T = Transactions.Tag[]>(select?: (data: Transactions.Tag[]) => T) {
   const queryClient = useQueryClient()
   const query = useQuery({
     queryKey: [QueryKeys.Tags],
     queryFn: fetchTags,
+    select,
   })
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: [QueryKeys.Tags] })

--- a/frontend/src/hooks/useTransactionPrefill.ts
+++ b/frontend/src/hooks/useTransactionPrefill.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react'
+import { Transactions } from '@/types/transactions'
+
+interface Prefill {
+  date: string | null
+  categoryId: number | null
+  accountId: number | null
+}
+
+const PREFILL_KEY = (userId: number) => `create-transaction-prefill:${userId}`
+
+function readPrefill(userId: number): Prefill {
+  try {
+    const raw = localStorage.getItem(PREFILL_KEY(userId))
+    if (!raw) return { date: null, categoryId: null, accountId: null }
+    return JSON.parse(raw) as Prefill
+  } catch {
+    return { date: null, categoryId: null, accountId: null }
+  }
+}
+
+interface UseTransactionPrefillOptions {
+  userId: number
+  accounts: Transactions.Account[]
+  categories: Transactions.Category[]
+}
+
+export function useTransactionPrefill({ userId, accounts, categories }: UseTransactionPrefillOptions) {
+  const raw = readPrefill(userId)
+
+  // Validate stored IDs against current data; discard stale values silently
+  const accountExists = raw.accountId !== null && accounts.some((a) => a.id === raw.accountId)
+  const categoryExists = raw.categoryId !== null && categories.some((c) => c.id === raw.categoryId)
+
+  const prefill: Prefill = {
+    date: raw.date,
+    accountId: accountExists ? raw.accountId : null,
+    categoryId: categoryExists ? raw.categoryId : null,
+  }
+
+  const savePrefill = useCallback(
+    (date: string, categoryId: number | null, accountId: number | null) => {
+      try {
+        const value: Prefill = { date, categoryId, accountId }
+        localStorage.setItem(PREFILL_KEY(userId), JSON.stringify(value))
+      } catch {
+        // localStorage may be unavailable; silently ignore
+      }
+    },
+    [userId],
+  )
+
+  return { prefill, savePrefill }
+}

--- a/frontend/src/hooks/useTransactionSuggestions.ts
+++ b/frontend/src/hooks/useTransactionSuggestions.ts
@@ -1,17 +1,20 @@
 import { useQuery } from '@tanstack/react-query'
 import { useDebouncedValue } from '@mantine/hooks'
 import { fetchTransactionSuggestions } from '@/api/transactions'
+import { Transactions } from '@/types/transactions'
 import { QueryKeys } from '@/utils/queryKeys'
 
-export function useTransactionSuggestions(query: string) {
+export function useTransactionSuggestions<T = Transactions.TransactionSuggestion[]>(
+  query: string,
+  select?: (data: Transactions.TransactionSuggestion[]) => T,
+) {
   const [debounced] = useDebouncedValue(query, 300)
 
-  const result = useQuery({
+  return useQuery({
     queryKey: [QueryKeys.Transactions, 'suggestions', debounced],
     queryFn: () => fetchTransactionSuggestions(debounced, 10),
     enabled: debounced.length >= 2,
     staleTime: 30_000,
+    select,
   })
-
-  return result
 }

--- a/frontend/src/hooks/useTransactionSuggestions.ts
+++ b/frontend/src/hooks/useTransactionSuggestions.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { useDebouncedValue } from '@mantine/hooks'
+import { fetchTransactionSuggestions } from '@/api/transactions'
+import { QueryKeys } from '@/utils/queryKeys'
+
+export function useTransactionSuggestions(query: string) {
+  const [debounced] = useDebouncedValue(query, 300)
+
+  const result = useQuery({
+    queryKey: [QueryKeys.Transactions, 'suggestions', debounced],
+    queryFn: () => fetchTransactionSuggestions(debounced, 10),
+    enabled: debounced.length >= 2,
+    staleTime: 30_000,
+  })
+
+  return result
+}

--- a/frontend/src/routes/_authenticated.transactions.tsx
+++ b/frontend/src/routes/_authenticated.transactions.tsx
@@ -1,12 +1,13 @@
-import { ActionIcon, Box, Drawer, Stack } from '@mantine/core'
+import { ActionIcon, Box, Button, Drawer, Group, Stack } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
-import { IconFilter } from '@tabler/icons-react'
+import { IconFilter, IconPlus } from '@tabler/icons-react'
 import { createFileRoute } from '@tanstack/react-router'
 import { zodValidator } from '@tanstack/zod-adapter'
 import { z } from 'zod'
 import { useMe } from '@/hooks/useMe'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { ClearFiltersButton } from '@/components/transactions/ClearFiltersButton'
+import { CreateTransactionDrawer } from '@/components/transactions/CreateTransactionDrawer'
 import { MobileBottomBar } from '@/components/transactions/MobileBottomBar'
 import { PeriodNavigator } from '@/components/transactions/PeriodNavigator'
 import { TransactionFilters } from '@/components/transactions/TransactionFilters'
@@ -35,10 +36,11 @@ export const Route = createFileRoute('/_authenticated/transactions')({
 function TransactionsPage() {
   const search = Route.useSearch()
   const isMobile = useIsMobile()
-  const [drawerOpened, { open: openDrawer, close: closeDrawer }] = useDisclosure(false)
+  const [filtersOpened, { open: openFilters, close: closeFilters }] = useDisclosure(false)
+  const [createOpened, { open: openCreate, close: closeCreate }] = useDisclosure(false)
 
-  const { query: meQuery } = useMe()
-  const currentUserId = meQuery.data?.id ?? 0
+  const { query: meQuery } = useMe((me) => me.id)
+  const currentUserId = meQuery.data ?? 0
 
   if (isMobile) {
     return (
@@ -55,7 +57,16 @@ function TransactionsPage() {
           }}
         >
           <Stack gap="xs">
-            <PeriodNavigator month={search.month} year={search.year} />
+            <Group justify="space-between" align="center">
+              <PeriodNavigator month={search.month} year={search.year} />
+              <Button
+                size="xs"
+                leftSection={<IconPlus size={14} />}
+                onClick={openCreate}
+              >
+                Nova Transação
+              </Button>
+            </Group>
             <TextSearch />
           </Stack>
         </Box>
@@ -68,7 +79,7 @@ function TransactionsPage() {
             size="xl"
             radius="xl"
             variant="filled"
-            onClick={openDrawer}
+            onClick={openFilters}
             aria-label="Abrir filtros"
           >
             <IconFilter size={20} />
@@ -76,8 +87,8 @@ function TransactionsPage() {
         </MobileBottomBar>
 
         <Drawer
-          opened={drawerOpened}
-          onClose={closeDrawer}
+          opened={filtersOpened}
+          onClose={closeFilters}
           position="bottom"
           title="Filtros"
           size="auto"
@@ -87,6 +98,11 @@ function TransactionsPage() {
         >
           <TransactionFilters orientation="column" hideTextSearch />
         </Drawer>
+
+        <CreateTransactionDrawer
+          opened={createOpened}
+          onClose={closeCreate}
+        />
       </Stack>
     )
   }
@@ -105,11 +121,22 @@ function TransactionsPage() {
         }}
       >
         <Stack gap="sm">
-          <PeriodNavigator month={search.month} year={search.year} />
+          <Group justify="space-between" align="center">
+            <PeriodNavigator month={search.month} year={search.year} />
+            <Button leftSection={<IconPlus size={16} />} onClick={openCreate}>
+              Nova Transação
+            </Button>
+          </Group>
           <TransactionFilters orientation="row" />
         </Stack>
       </Box>
+
       <TransactionList currentUserId={currentUserId} />
+
+      <CreateTransactionDrawer
+        opened={createOpened}
+        onClose={closeCreate}
+      />
     </Stack>
   )
 }

--- a/frontend/src/types/transactions.ts
+++ b/frontend/src/types/transactions.ts
@@ -124,4 +124,39 @@ export namespace Transactions {
   export interface BalanceResult {
     balance: number
   }
+
+  export interface TransactionSuggestion {
+    id: number
+    description: string
+    type: TransactionType
+    amount: number
+    account_id: number
+    category_id?: number
+    tags?: Tag[]
+  }
+
+  export interface RecurrenceSettings {
+    type: RecurrenceType
+    repetitions?: number
+    end_date?: string
+  }
+
+  export interface SplitSetting {
+    connection_id: number
+    percentage?: number
+    amount?: number
+  }
+
+  export interface CreateTransactionPayload {
+    transaction_type: TransactionType
+    account_id: number
+    category_id?: number
+    amount: number
+    date: string
+    description: string
+    destination_account_id?: number
+    tags?: { id?: number; name: string }[]
+    recurrence_settings?: RecurrenceSettings
+    split_settings?: SplitSetting[]
+  }
 }

--- a/frontend/src/utils/apiErrors.ts
+++ b/frontend/src/utils/apiErrors.ts
@@ -1,0 +1,87 @@
+export interface ApiErrorResponse {
+  error: string
+  message: string
+  tags: string[]
+}
+
+export async function parseApiError(res: Response): Promise<ApiErrorResponse> {
+  try {
+    const body = await res.json()
+    return {
+      error: body.error ?? res.statusText,
+      message: body.message ?? '',
+      tags: Array.isArray(body.tags) ? body.tags : [],
+    }
+  } catch {
+    return { error: res.statusText, message: '', tags: [] }
+  }
+}
+
+// Maps a backend ErrorTag to a form field path.
+// Indexed split-setting errors carry both a domain tag and an INDEX_N tag;
+// the index is extracted and used to build a path like "split_settings.0.amount".
+export function mapTagsToFieldErrors(
+  tags: string[],
+  message: string,
+): Record<string, string> {
+  const errors: Record<string, string> = {}
+
+  // Extract index from INDEX_N tags (backend uses lowercase "index_N")
+  const indexTag = tags.find((t) => /^index_\d+$/i.test(t))
+  const index = indexTag ? parseInt(indexTag.replace(/^index_/i, ''), 10) : null
+
+  // Simple tag → field map
+  const tagToField: Record<string, string> = {
+    'TRANSACTION.DATE_IS_REQUIRED': 'date',
+    'TRANSACTION.DESCRIPTION_IS_REQUIRED': 'description',
+    'TRANSACTION.AMOUNT_MUST_BE_GREATER_THAN_ZERO': 'amount',
+    'TRANSACTION.INVALID_TRANSACTION_TYPE': 'type',
+    'TRANSACTION.INVALID_ACCOUNT_ID': 'account_id',
+    'TRANSACTION.INVALID_CATEGORY_ID': 'category_id',
+    'TRANSACTION.MISSING_DESTINATION_ACCOUNT': 'destination_account_id',
+    'TRANSACTION.SPLIT_SETTINGS_NOT_ALLOWED_FOR_TRANSFER': 'split_settings',
+    'TRANSACTION.SPLIT_ALLOWED_ONLY_FOR_EXPENSE': 'split_settings',
+    'TRANSACTION.INVALID_RECURRENCE_TYPE': 'recurrence_settings.type',
+    'TRANSACTION.RECURRENCE_END_DATE_OR_REPETITIONS_IS_REQUIRED': 'recurrence_settings',
+    'TRANSACTION.RECURRENCE_END_DATE_MUST_BE_AFTER_TRANSACTION_DATE': 'recurrence_settings.end_date',
+    'TRANSACTION.RECURRENCE_END_DATE_AND_REPETITIONS_CANNOT_BE_USED_TOGETHER': 'recurrence_settings',
+    'TRANSACTION.RECURRENCE_REPETITIONS_MUST_BE_POSITIVE': 'recurrence_settings.repetitions',
+    'TRANSACTION.RECURRENCE_REPETITIONS_MUST_BE_LESS_THAN_OR_EQUAL_TO': 'recurrence_settings.repetitions',
+    'TAG.NAME_CANNOT_BE_EMPTY': 'tags',
+    'TAG.FAILED_TO_CREATE': 'tags',
+  }
+
+  // Indexed split-setting tags (require INDEX_N to resolve field path)
+  const indexedTagToSubfield: Record<string, string> = {
+    'TRANSACTION.SPLIT_SETTING_INVALID_CONNECTION_ID': 'connection_id',
+    'TRANSACTION.SPLIT_SETTING_PERCENTAGE_OR_AMOUNT_IS_REQUIRED': '',
+    'TRANSACTION.SPLIT_SETTING_PERCENTAGE_AND_AMOUNT_CANNOT_BE_USED_TOGETHER': '',
+    'TRANSACTION.SPLIT_SETTING_PERCENTAGE_MUST_BE_BETWEEN_1_AND_100': 'percentage',
+    'TRANSACTION.SPLIT_SETTING_AMOUNT_MUST_BE_GREATER_THAN_ZERO': 'amount',
+    'TRANSACTION.SPLIT_SETTING_INVALID_DESTINATION_ACCOUNT_ID': 'destination_account_id',
+  }
+
+  let mapped = false
+
+  for (const tag of tags) {
+    if (tag in tagToField) {
+      const field = tagToField[tag]
+      errors[field] = errors[field] ?? message
+      mapped = true
+    } else if (tag in indexedTagToSubfield && index !== null) {
+      const subfield = indexedTagToSubfield[tag]
+      const field = subfield ? `split_settings.${index}.${subfield}` : `split_settings.${index}`
+      errors[field] = errors[field] ?? message
+      mapped = true
+    } else if (/^index_\d+$/i.test(tag)) {
+      // INDEX_N is a helper tag, not a standalone error
+      continue
+    }
+  }
+
+  if (!mapped) {
+    errors['_general'] = message
+  }
+
+  return errors
+}

--- a/frontend/src/utils/groupTransactions.ts
+++ b/frontend/src/utils/groupTransactions.ts
@@ -1,4 +1,5 @@
 import { Transactions } from '@/types/transactions'
+import { parseDate } from './parseDate'
 
 export function groupTransactions(
   transactions: Transactions.Transaction[],
@@ -12,7 +13,7 @@ export function groupTransactions(
     let label: string
 
     if (groupBy === 'date') {
-      const date = new Date(tx.date)
+      const date = parseDate(tx.date)
       label = date.toLocaleDateString('pt-BR', {
         weekday: 'long',
         day: '2-digit',
@@ -44,9 +45,7 @@ export function groupTransactions(
 
   if (groupBy === 'date') {
     result.sort((a, b) => {
-      const dateA = new Date(a.transactions[0].date)
-      const dateB = new Date(b.transactions[0].date)
-      return dateB.getTime() - dateA.getTime()
+      return parseDate(b.transactions[0].date).getTime() - parseDate(a.transactions[0].date).getTime()
     })
   } else {
     result.sort((a, b) => a.label.localeCompare(b.label))

--- a/frontend/src/utils/groupTransactions.ts
+++ b/frontend/src/utils/groupTransactions.ts
@@ -45,7 +45,7 @@ export function groupTransactions(
 
   if (groupBy === 'date') {
     result.sort((a, b) => {
-      return parseDate(b.transactions[0].date).getTime() - parseDate(a.transactions[0].date).getTime()
+      return parseDate(a.transactions[0].date).getTime() - parseDate(b.transactions[0].date).getTime()
     })
   } else {
     result.sort((a, b) => a.label.localeCompare(b.label))

--- a/frontend/src/utils/parseDate.ts
+++ b/frontend/src/utils/parseDate.ts
@@ -1,0 +1,11 @@
+/**
+ * Parses an ISO date string from the API (e.g. "2026-03-01T00:00:00Z") as a
+ * local calendar date, ignoring the time/timezone component.
+ *
+ * Using `new Date(isoString)` would interpret the UTC midnight as the previous
+ * day in negative-offset timezones (e.g. UTC-3 → Feb 28 at 21:00).
+ */
+export function parseDate(isoString: string): Date {
+  const [year, month, day] = isoString.substring(0, 10).split('-').map(Number)
+  return new Date(year, month - 1, day)
+}

--- a/openspec/changes/create-transaction-drawer/.openspec.yaml
+++ b/openspec/changes/create-transaction-drawer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-24

--- a/openspec/changes/create-transaction-drawer/design.md
+++ b/openspec/changes/create-transaction-drawer/design.md
@@ -1,0 +1,194 @@
+## Context
+
+The transactions list screen (`_authenticated.transactions.tsx`) has a sticky header row containing `PeriodNavigator` and `TransactionFilters`. The "New Transaction" button will be placed in this row. The form itself opens in a Mantine `Drawer` at `position="right"`.
+
+The backend already exposes `POST /api/transactions` for creation and `GET /api/transactions` with `description.query` text search. A dedicated suggestions endpoint will be added to return a lightweight list of distinct transactions for autocomplete, keeping the response small.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- New transaction button in period filter row on desktop and mobile.
+- Right-side drawer with all required form fields.
+- Autocomplete description field backed by a new backend suggestions endpoint.
+- Tags field with autocomplete over existing tags and inline creation of new tags.
+- Structured error responses from the backend that include error tags.
+- Frontend error parser that maps error tags to specific form fields, showing a red border and error message inline below each affected field.
+- Scalable tag-to-field mapping utility reusable across future forms.
+- Post-submit invalidation of the transactions query.
+- localStorage persistence of date, category, and account for prefill.
+
+**Non-Goals:**
+
+- Editing or deleting existing transactions (out of scope).
+- Real-time collaboration or optimistic updates.
+- Full duplicate detection (autocomplete is suggestion-only).
+
+## Decisions
+
+### Decision: Dedicated suggestions endpoint vs. reusing GET /api/transactions
+
+**Choice**: Add `GET /api/transactions/suggestions?q=<text>&limit=10` returning `[]{id, description, type, amount, category_id, account_id, tag_ids}`.
+**Alternative considered**: Call the full `GET /api/transactions` with a description query and filter client-side. Rejected — the full endpoint requires `month`/`year` and returns the complete transaction object for an unbounded period; a dedicated endpoint avoids over-fetching and can be scoped to distinct descriptions across all time.
+
+### Decision: Autocomplete triggers on keystroke with debounce
+
+**Choice**: Debounce the description input at 300 ms before firing the suggestions request. Use Mantine `Autocomplete` component.
+**Rationale**: Avoids a request per keystroke; 300 ms is fast enough to feel responsive.
+
+### Decision: Suggestion selection copies all fields except date and recurrence
+
+**Choice**: When the user selects a suggestion, populate type, amount, category, account, tags, and split settings from the selected transaction. Leave date and recurrence settings untouched.
+**Rationale**: Matches the stated requirement; date and recurrence are always session-specific.
+
+### Decision: localStorage key per-user
+
+**Choice**: Persist prefill values under the key `create-transaction-prefill:{userId}` so multiple users on the same browser don't share prefills.
+**Rationale**: Couples may share devices; mixing prefill state would be confusing.
+
+### Decision: Split settings UI
+
+**Choice**: When type ≠ `transfer`, show the user's active connections as split targets. Each split entry shows the partner's name, a percentage or amount toggle, and an input. Total must equal 100% (or total amount) before submission.
+**Rationale**: Matches the existing `SplitSettings` domain structure (`connection_id` + `percentage` xor `amount`).
+
+### Decision: Recurrence settings UI
+
+**Choice**: A toggle to enable recurrence. When enabled, show `type` select (`daily`, `weekly`, `monthly`, `yearly`) and a choice between `repetitions` (number input) or `end_date` (date picker) — mutually exclusive.
+**Rationale**: Maps directly to `RecurrenceSettings` domain type.
+
+### Decision: Backend error response must include tags
+
+**Choice**: Extend `ErrorResponse` in `internal/middleware/error_handler.go` to include `tags []string`. Update `pkg/errors.ToHTTPError` to handle `ServiceErrors` (the slice type, currently unhandled — falls through to 500) by collecting all tags from all errors. Fix the `Create` transaction handler to use `pkgErrors.ToHTTPError(err)` instead of the current `echo.NewHTTPError(http.StatusBadRequest, err.Error())` which discards tags entirely.
+**Rationale**: Tags are the stable, machine-readable identifiers for what went wrong. Without them in the response, the frontend must parse free-text messages — brittle and unscalable.
+
+**Updated `ErrorResponse`**:
+
+```go
+type ErrorResponse struct {
+    Error   string   `json:"error"`
+    Message string   `json:"message,omitempty"`
+    Tags    []string `json:"tags,omitempty"`
+}
+```
+
+**Tag collection logic** (in `ToHTTPError` for `ServiceErrors`): iterate all `*ServiceError` entries, collect `.Tags` from each into a deduplicated flat slice, use the first error's code to determine HTTP status. Indexed tags like `INDEX_1` come through naturally since they're just strings in the slice.
+
+### Decision: Frontend error parser utility
+
+**Choice**: Create `src/utils/apiErrors.ts` with:
+
+- `ApiErrorResponse` type matching the updated backend shape
+- `parseApiError(res: Response): Promise<ApiErrorResponse>` — fetches and parses the JSON error body
+- `mapTagsToFieldErrors(tags: string[], message: string): Record<string, string>` — maps known tags to form field paths, returns a dict of `fieldPath → errorMessage`
+
+The mapper handles two tag patterns:
+
+1. **Simple**: `TRANSACTION.DATE_IS_REQUIRED` → `{ date: "Date is required" }`
+2. **Indexed**: tags array contains both `TRANSACTION.SPLIT_SETTING_AMOUNT_MUST_BE_GREATER_THAN_ZERO` and `INDEX_2` → `{ "split_settings.1.amount": "Amount must be greater than zero" }` (index is 0-based in backend, displayed 1-based is irrelevant since it maps to the array position in the form state)
+
+Tags not present in the mapping are collected into a `_general` key shown as a form-level error banner.
+
+**Full tag-to-field map** (all `ErrorTag` values from `pkg/errors/errors.go`):
+
+| Backend tag                                                                           | Form field path                           |
+| ------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `TRANSACTION.DATE_IS_REQUIRED`                                                        | `date`                                    |
+| `TRANSACTION.DESCRIPTION_IS_REQUIRED`                                                 | `description`                             |
+| `TRANSACTION.AMOUNT_MUST_BE_GREATER_THAN_ZERO`                                        | `amount`                                  |
+| `TRANSACTION.INVALID_TRANSACTION_TYPE`                                                | `type`                                    |
+| `TRANSACTION.INVALID_ACCOUNT_ID`                                                      | `account_id`                              |
+| `TRANSACTION.INVALID_CATEGORY_ID`                                                     | `category_id`                             |
+| `TRANSACTION.MISSING_DESTINATION_ACCOUNT`                                             | `destination_account_id`                  |
+| `TRANSACTION.SPLIT_SETTINGS_NOT_ALLOWED_FOR_TRANSFER`                                 | `split_settings`                          |
+| `TRANSACTION.SPLIT_ALLOWED_ONLY_FOR_EXPENSE`                                          | `split_settings`                          |
+| `TRANSACTION.INVALID_RECURRENCE_TYPE`                                                 | `recurrence_settings.type`                |
+| `TRANSACTION.RECURRENCE_END_DATE_OR_REPETITIONS_IS_REQUIRED`                          | `recurrence_settings`                     |
+| `TRANSACTION.RECURRENCE_END_DATE_MUST_BE_AFTER_TRANSACTION_DATE`                      | `recurrence_settings.end_date`            |
+| `TRANSACTION.RECURRENCE_END_DATE_AND_REPETITIONS_CANNOT_BE_USED_TOGETHER`             | `recurrence_settings`                     |
+| `TRANSACTION.RECURRENCE_REPETITIONS_MUST_BE_POSITIVE`                                 | `recurrence_settings.repetitions`         |
+| `TRANSACTION.RECURRENCE_REPETITIONS_MUST_BE_LESS_THAN_OR_EQUAL_TO`                    | `recurrence_settings.repetitions`         |
+| `TRANSACTION.SPLIT_SETTING_INVALID_CONNECTION_ID` + `INDEX_N`                         | `split_settings.N.connection_id`          |
+| `TRANSACTION.SPLIT_SETTING_PERCENTAGE_OR_AMOUNT_IS_REQUIRED` + `INDEX_N`              | `split_settings.N`                        |
+| `TRANSACTION.SPLIT_SETTING_PERCENTAGE_AND_AMOUNT_CANNOT_BE_USED_TOGETHER` + `INDEX_N` | `split_settings.N`                        |
+| `TRANSACTION.SPLIT_SETTING_PERCENTAGE_MUST_BE_BETWEEN_1_AND_100` + `INDEX_N`          | `split_settings.N.percentage`             |
+| `TRANSACTION.SPLIT_SETTING_AMOUNT_MUST_BE_GREATER_THAN_ZERO` + `INDEX_N`              | `split_settings.N.amount`                 |
+| `TRANSACTION.SPLIT_SETTING_INVALID_DESTINATION_ACCOUNT_ID` + `INDEX_N`                | `split_settings.N.destination_account_id` |
+| `TAG.NAME_CANNOT_BE_EMPTY`                                                            | `tags`                                    |
+| `TAG.FAILED_TO_CREATE`                                                                | `tags`                                    |
+
+**Usage in the form**: after a failed mutation, call `mapTagsToFieldErrors(error.tags, error.message)` and pass the result to the form's `setErrors` (Mantine `useForm`) or `setError` (react-hook-form). Each field reads its error from form state and renders red border + message below using the standard Mantine `error` prop pattern.
+
+### Decision: Tags field — autocomplete + inline creation, no pre-flight API call
+
+**Choice**: Use Mantine `TagsInput` (or creatable `MultiSelect`) to filter existing tags by name client-side and allow typing a new name. When submitting, the `tags` array in `CreateTransactionPayload` is sent as `[{ id: <existing>, name: "..." }]` for known tags and `[{ name: "newname" }]` (id omitted / 0) for new ones. The backend's `createTags` method handles creation inline during the transaction create service call — no separate `POST /api/tags` call is needed from the frontend.
+**Alternative considered**: Pre-create tags via `POST /api/tags` before submitting the transaction. Rejected — the backend already handles tag creation within the transaction service; a pre-flight call introduces a partial-failure risk and unnecessary complexity.
+**Rationale**: `TransactionCreateRequest.Tags` is `[]domain.Tag`; the internal `createTags` call is idempotent per submission. The existing `GET /api/tags` provides the full list upfront for client-side filtering.
+
+## Backend: Suggestions Endpoint
+
+**Route**: `GET /api/transactions/suggestions`
+
+**Query params**: `q` (string, required), `limit` (int, default 10, max 50)
+
+**Logic**:
+
+1. Use the existing `TransactionFilter` with `Description: &domain.TextSearch{Query: q}`.
+2. Fetch up to `limit` transactions ordered by `created_at DESC`.
+3. De-duplicate by description client-side is fine at small limit; backend returns raw matches.
+
+**Response**:
+
+```json
+[
+  {
+    "id": 1,
+    "description": "Supermercado",
+    "type": "expense",
+    "amount": 15000,
+    "account_id": 2,
+    "category_id": 5,
+    "tags": [{ "id": 3, "name": "food" }]
+  }
+]
+```
+
+**Auth**: same `AuthMiddleware` as all other transaction routes.
+
+## Frontend Architecture
+
+### New files
+
+- `src/components/transactions/CreateTransactionDrawer.tsx` — Drawer wrapper + form state
+- `src/components/transactions/form/TransactionForm.tsx` — Form layout and field composition
+- `src/components/transactions/form/DescriptionAutocomplete.tsx` — Mantine Autocomplete wrapping suggestions fetch
+- `src/components/transactions/form/RecurrenceFields.tsx` — Recurrence toggle + type/repetitions/end_date
+- `src/components/transactions/form/SplitSettingsFields.tsx` — Split settings per connection
+- `src/api/transactions.ts` — add `fetchTransactionSuggestions(q, limit?)` and `createTransaction(payload)`
+- `src/hooks/useCreateTransaction.ts` — mutation hook wrapping `createTransaction`, invalidates `QueryKeys.Transactions` on success; on error, calls `mapTagsToFieldErrors` and sets form errors
+- `src/hooks/useTransactionPrefill.ts` — reads/writes localStorage prefill for date, category, account
+- `src/utils/apiErrors.ts` — `ApiErrorResponse` type, `parseApiError`, `mapTagsToFieldErrors` utility
+
+### Modified files
+
+- `src/routes/_authenticated.transactions.tsx` — add "New Transaction" button + `useDisclosure` for drawer
+- `src/components/transactions/PeriodNavigator.tsx` (or inline in route) — place button in top-right of the filter row
+- `src/types/transactions.ts` — add `CreateTransactionPayload`, `TransactionSuggestion` types
+### State flow
+
+1. User clicks "New Transaction" → drawer opens.
+2. Form initializes from localStorage prefill (date, category, account).
+3. User types description → debounced fetch to `/api/transactions/suggestions` → Autocomplete shows options.
+4. User selects a suggestion → form fields populated (type, amount, category, account, tags, split settings).
+5. User types in Tags field → filters loaded tag list client-side; if typed name has no match, shows "Create «name»" option; selected item is stored as `{ name }` (no id) in form state.
+6. User submits → `POST /api/transactions` with `tags: [{ id, name }]` for existing and `[{ name }]` for new — backend creates new tags inline.
+   - **On success**: invalidate `QueryKeys.Transactions` and `QueryKeys.Tags` queries, persist date/category/account to localStorage, close drawer.
+   - **On error**: call `parseApiError` → `mapTagsToFieldErrors` → set field errors in form state; known-field errors show red border + message inline below the field; unknown tags surface as a general error banner at the top of the form.
+
+## Risks / Trade-offs
+
+- **Split settings validation**: must ensure percentage splits sum to 100% or amount splits sum to total before allowing submit. Display an error message if they don't.
+- **Transfer + split conflict**: split settings are hidden when type = `transfer`; clear any stored split settings when type changes to `transfer`.
+- **Recurrence repetitions vs end_date**: these are mutually exclusive — switching between them must clear the other field.
+- **localStorage staleness**: stored account or category ID may no longer exist (deleted). Validate IDs against loaded accounts/categories on drawer open and discard stale prefill silently.
+- **Inline tag creation failure**: if a new tag name fails server-side (e.g. empty after trim), the backend returns `TAG.NAME_CANNOT_BE_EMPTY` or `TAG.FAILED_TO_CREATE` tags; `mapTagsToFieldErrors` maps these to the `tags` field so the error appears below the tags input.
+- **`ServiceErrors` currently falls through to 500**: the existing `ToHTTPError` only handles `*ServiceError`, not `ServiceErrors` (the slice). Multi-error responses from validation currently return 500 to the client. This must be fixed as part of this change.

--- a/openspec/changes/create-transaction-drawer/proposal.md
+++ b/openspec/changes/create-transaction-drawer/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Users have no way to create transactions from the transactions list screen. Adding a dedicated "New Transaction" button and form drawer removes the need to navigate away from the list, keeping the user in context while managing finances.
+
+## What Changes
+
+- Add a "New Transaction" button in the period filter row (top right), visible on both desktop and mobile.
+- The button opens a right-side drawer with a form containing all fields required to create a transaction.
+- On successful submission, the transactions query is invalidated so the list refreshes automatically.
+- The date, category, and account values from the last successful submission are persisted in `localStorage` and used to prefill the form the next time it opens.
+- The description field behaves as an autocomplete: as the user types, it queries the backend for transactions with similar descriptions (using PostgreSQL text search). Selecting a suggestion populates all form fields except `date` and recurrence settings.
+- The tags field supports searching existing tags by name (autocomplete) and creating new tags inline by typing a name that doesn't exist yet.
+
+## Form Fields
+
+| Field               | Condition                                |
+| ------------------- | ---------------------------------------- |
+| Type                | Always (`expense`, `income`, `transfer`) |
+| Date                | Always                                   |
+| Description         | Always (autocomplete)                    |
+| Amount              | Always                                   |
+| Category            | Always (except transfer)                 |
+| Account             | Always                                   |
+| Destination Account | Only when type = `transfer`              |
+| Split Settings      | Only when type ≠ `transfer`              |
+| Recurrence Settings | Always                                   |
+| Tags                | Always (autocomplete + create inline)    |
+
+## Capabilities
+
+### New Capabilities
+
+- `create-transaction-drawer`: Frontend capability — right-side drawer form for creating transactions, with autocomplete description, localStorage prefill, and post-submit query invalidation.
+
+### Modified Capabilities
+
+- Backend: new `GET /api/transactions/suggestions` endpoint returning distinct transactions matching a description query (using existing PostgreSQL text search), used by the autocomplete field.
+
+## Impact
+
+- Frontend: new drawer component, new API call for suggestions, localStorage persistence layer.
+- Backend: one new handler method + route for the suggestions endpoint; reuses existing repository text search.
+- No schema or migration changes required.

--- a/openspec/changes/create-transaction-drawer/tasks.md
+++ b/openspec/changes/create-transaction-drawer/tasks.md
@@ -1,0 +1,62 @@
+## 1. Backend: Structured Error Response with Tags
+
+- [x] 1.1 Add `Tags []string` field to `ErrorResponse` in `internal/middleware/error_handler.go` (`json:"tags,omitempty"`) and update the handler to populate it from the HTTP error's `Tags` field when present
+- [x] 1.2 Update `pkg/errors/errors.go`: extend `ToHTTPError` to handle `ServiceErrors` (the slice type) — iterate all entries, collect `.Tags` from each into a flat deduplicated slice, determine HTTP status from the first error's code, return an `echo.HTTPError` that carries the tags so the error handler can serialize them
+- [x] 1.3 Fix `TransactionHandler.Create` in `internal/handler/transaction_handler.go`: replace `echo.NewHTTPError(http.StatusBadRequest, err.Error())` with `pkgErrors.ToHTTPError(err)` so tags are preserved through to the response
+
+## 2. Backend: Transaction Suggestions Endpoint
+
+- [x] 2.1 Add `Suggestions` handler method to `TransactionHandler` in `internal/handler/transaction_handler.go` — query param `q` (required), `limit` (default 10, max 50); use existing `TransactionFilter` with `Description.Query`; return `[]domain.Transaction` (reuse existing JSON shape)
+- [x] 2.2 Register `GET /api/transactions/suggestions` route in the router (same auth middleware group as other transaction routes)
+- [x] 2.3 Add Swagger annotations to the `Suggestions` handler method; run `just generate-docs`
+
+## 3. Frontend: Error Parsing Utility
+
+- [x] 3.1 Create `src/utils/apiErrors.ts`:
+  - `ApiErrorResponse` type: `{ error: string; message: string; tags: string[] }`
+  - `parseApiError(res: Response): Promise<ApiErrorResponse>` — reads JSON body and returns the typed error
+  - `mapTagsToFieldErrors(tags: string[], message: string): Record<string, string>` — maps known error tags to form field paths (see design.md tag-to-field table); handles indexed split-settings tags by extracting the `INDEX_N` value from the tags array and building `split_settings.N.<subfield>` paths; unmapped tags are collected under the `_general` key
+
+## 4. Frontend Types
+
+- [x] 4.1 Add `TransactionSuggestion` type to `src/types/transactions.ts` (fields: `id`, `description`, `type`, `amount`, `account_id`, `category_id`, `tags`)
+- [x] 4.2 Add `CreateTransactionPayload` type to `src/types/transactions.ts` matching `TransactionCreateRequest` from the backend
+
+## 5. Frontend API
+
+- [x] 5.1 Add `fetchTransactionSuggestions(q: string, limit?: number)` to `src/api/transactions.ts` — calls `GET /api/transactions/suggestions`
+- [x] 5.2 Add `createTransaction(payload: Transactions.CreateTransactionPayload)` to `src/api/transactions.ts` — calls `POST /api/transactions`; on non-2xx throws the raw `Response` so the caller can `parseApiError`
+
+## 6. Hooks
+
+- [x] 6.1 Create `src/hooks/useCreateTransaction.ts` — mutation using `createTransaction`; on success calls `queryClient.invalidateQueries` for both `QueryKeys.Transactions` and `QueryKeys.Tags` (tags may have been created server-side); on error, calls `parseApiError` then `mapTagsToFieldErrors` and invokes an `onFieldErrors(errors: Record<string, string>)` callback so the form can call `setErrors`/`setError` directly
+- [x] 6.2 Create `src/hooks/useTransactionPrefill.ts` — reads/writes `localStorage` under key `create-transaction-prefill:{userId}`; exposes `prefill` (date, categoryId, accountId) and `savePrefill(date, categoryId, accountId)`; validates IDs against provided accounts/categories lists and discards stale values
+
+## 7. Description Autocomplete Component
+
+- [x] 7.1 Create `src/components/transactions/form/DescriptionAutocomplete.tsx` — Mantine `Autocomplete` with 300 ms debounce; calls `fetchTransactionSuggestions` on value change; on item select calls `onSuggestionSelect(suggestion: TransactionSuggestion)` prop; accepts `error` prop and forwards it to the Mantine component for red-border + inline message display
+
+## 8. Recurrence Fields Component
+
+- [x] 8.1 Create `src/components/transactions/form/RecurrenceFields.tsx` — toggle to enable recurrence; when enabled: `type` select (`daily`, `weekly`, `monthly`, `yearly`), then mutually exclusive choice of `repetitions` number input OR `end_date` date picker (switching between them clears the other); accepts `errors` prop (`{ type?: string; repetitions?: string; end_date?: string; _general?: string }`) and passes each to the corresponding Mantine field's `error` prop
+
+## 9. Split Settings Fields Component
+
+- [x] 9.1 Create `src/components/transactions/form/SplitSettingsFields.tsx` — renders one row per active user connection; each row: partner name, toggle between percentage/amount mode, numeric input; validates that percentage splits sum to 100 or amount splits sum to the form's total amount; accepts `errors` prop keyed by split index (e.g. `{ "0.amount": "Amount must be greater than zero" }`) and passes each to the corresponding field's `error` prop; shows a general `split_settings` error above the list when present
+
+## 10. Transaction Form Component
+
+- [x] 10.1 Create `src/components/transactions/form/TransactionForm.tsx` — composes all form fields using `useForm` (Mantine or react-hook-form); fields: Type (SegmentedControl or Select), Date (DatePicker), DescriptionAutocomplete, Amount (NumberInput in BRL), Category (Select, hidden for transfer), Account (Select), Destination Account (Select, visible only for transfer), SplitSettingsFields (hidden for transfer), RecurrenceFields, Tags (Mantine `TagsInput` or creatable `MultiSelect`: filters existing tags from `useTags` client-side by typed value; when typed value has no match, shows a "Create «name»" option; selected tags stored as `{ id?, name }` objects — existing tags carry their id, new ones have only name; all sent in the `tags` array of the payload, backend creates new ones inline)
+- [x] 10.2 When type changes to `transfer`, clear split settings and hide Category
+- [x] 10.3 On suggestion select (from DescriptionAutocomplete), populate type, amount, category, account, tags, split settings — leave date and recurrence untouched
+- [x] 10.4 Pass `onFieldErrors` to `useCreateTransaction`; in that callback call the form's `setErrors` (or `setError`) so each field picks up its error state; render a `_general` error banner (Mantine `Alert` with `color="red"`) at the top of the form when `errors._general` is set
+- [x] 10.5 On successful submit, call `savePrefill(date, categoryId, accountId)` and close the drawer
+
+## 11. Create Transaction Drawer
+
+- [x] 11.1 Create `src/components/transactions/CreateTransactionDrawer.tsx` — Mantine `Drawer` at `position="right"`, `size="md"`; renders `TransactionForm`; on open, initializes form from `useTransactionPrefill` (validates IDs against loaded accounts/categories)
+
+## 12. Wire Up in Route
+
+- [x] 12.1 In `src/routes/_authenticated.transactions.tsx`, add `useDisclosure` for the new drawer and render `CreateTransactionDrawer`
+- [x] 12.2 Add "Nova Transação" `Button` (with `+` icon) to the top-right of the period filter row on both desktop and mobile layouts; clicking it calls `openDrawer`


### PR DESCRIPTION
## Summary                                                                                                                                                           
                                                                  
  - Add right-side drawer to create transactions from the transactions page                                                                                            
  - Full form: type, date, amount, description (autocomplete), category, account, destination account (transfer), split settings, recurrence, tags
  - Dynamic drawer title per transaction type; initial focus on amount input after animation                                                                           
  - Prefills last-used date/account/category from localStorage
  - Description autocomplete via Postgres similarity search; selecting a suggestion fills all fields except date and recurrence                                        
                                                                  
  ## Backend                                                                                                                                                           
                                                                  
  - Tagged error system for structured field-level form errors                                                                                                         
  - \`GET /api/transactions/suggestions\` endpoint for description autocomplete
  - Fix nil pointer panic when validating split percentage                                                                                                             
  - Show both sides of same-user transfers (add \`SourceTransactions\` reverse GORM relation)
  - Fix destination account filter not matching credit-side transfers                                                                                                  
   
  ## Frontend                                                                                                                                                          
                                                                  
  - Fix UTC midnight date parsing bug (dates grouping under wrong day in negative-offset timezones)
  - Include \`settlements_from_source\` in group subtotals and running balances
  - \`useMe\` and \`useTransactionSuggestions\` accept a TanStack Query \`select\` callback                                                                            
  - \`CreateTransactionDrawer\` resolves \`currentUserId\` internally via \`useMe\` selector                                                                           
                                                                                                                                                                       
  ## Test plan                                                                                                                                                         
                                                                  
  - [ ] Open drawer, verify focus lands on amount input
  - [ ] Submit expense / income / transfer and verify transaction appears in list
  - [ ] Reopen drawer and verify date/account/category are prefilled                                                                                                   
  - [ ] Type a description and verify autocomplete appears; select one and verify fields populate
  - [ ] Filter by destination account and verify transfers appear                                                                                                      
  - [ ] Verify both sides of a transfer contribute correctly to running balance
                                                                                                                                                                       
  🤖 Generated with [Claude Code](https://claude.com/claude-code)
  EOF  