### PR TITLE
feat: add PWA install banner with iOS support

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -18,7 +18,8 @@ import {
 import { Link, Outlet, useRouterState } from "@tanstack/react-router";
 import { useMe } from "@/hooks/useMe";
 import { useLogout } from "@/hooks/useLogout";
-import { InviteDrawer } from "@/components/InviteDrawer";
+import { InviteDrawer } from "@/components/InviteDrawer"
+import { PWAInstallBanner } from "@/components/PWAInstallBanner";
 
 const navLinks = [
   { label: "Transações", icon: IconReceipt2, to: "/transactions" },
@@ -135,6 +136,7 @@ export function AppLayout() {
       </AppShell.Main>
 
       <InviteDrawer opened={inviteOpened} onClose={closeInvite} />
+      <PWAInstallBanner />
     </AppShell>
   );
 }

--- a/frontend/src/components/PWAInstallBanner.module.css
+++ b/frontend/src/components/PWAInstallBanner.module.css
@@ -1,0 +1,22 @@
+.banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  padding: 12px 16px 12px;
+  padding-bottom: calc(12px + env(safe-area-inset-bottom));
+  background-color: var(--mantine-color-white);
+  border-top: 1px solid var(--mantine-color-gray-2);
+}
+
+.close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.icon {
+  border-radius: 8px;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/PWAInstallBanner.tsx
+++ b/frontend/src/components/PWAInstallBanner.tsx
@@ -1,0 +1,81 @@
+import { ActionIcon, Button, Group, Paper, Text } from '@mantine/core'
+import { IconX, IconShare, IconSquarePlus } from '@tabler/icons-react'
+import { usePWAInstall } from '@/hooks/usePWAInstall'
+import classes from './PWAInstallBanner.module.css'
+
+export function PWAInstallBanner() {
+  const {
+    showIOSBanner,
+    dismissIOSBanner,
+    showAndroidBanner,
+    dismissAndroidBanner,
+    triggerAndroidInstall,
+  } = usePWAInstall()
+
+  if (showIOSBanner) {
+    return (
+      <Paper className={classes.banner} shadow="md" radius={0}>
+        <ActionIcon
+          variant="subtle"
+          color="gray"
+          size="sm"
+          className={classes.close}
+          onClick={dismissIOSBanner}
+          aria-label="Fechar"
+        >
+          <IconX size={16} />
+        </ActionIcon>
+        <Group gap="xs" wrap="nowrap" align="flex-start">
+          <img src="/icon-192.png" width={40} height={40} alt="" className={classes.icon} />
+          <div>
+            <Text size="sm" fw={600} lh={1.3}>
+              Instalar FinanceApp
+            </Text>
+            <Text size="xs" c="dimmed" mt={2}>
+              Toque em{' '}
+              <IconShare size={13} style={{ verticalAlign: 'middle', display: 'inline' }} />{' '}
+              e depois em{' '}
+              <strong>
+                <IconSquarePlus size={13} style={{ verticalAlign: 'middle', display: 'inline' }} />{' '}
+                Adicionar à Tela de Início
+              </strong>
+            </Text>
+          </div>
+        </Group>
+      </Paper>
+    )
+  }
+
+  if (showAndroidBanner) {
+    return (
+      <Paper className={classes.banner} shadow="md" radius={0}>
+        <ActionIcon
+          variant="subtle"
+          color="gray"
+          size="sm"
+          className={classes.close}
+          onClick={dismissAndroidBanner}
+          aria-label="Fechar"
+        >
+          <IconX size={16} />
+        </ActionIcon>
+        <Group gap="xs" wrap="nowrap" align="center">
+          <img src="/icon-192.png" width={40} height={40} alt="" className={classes.icon} />
+          <div style={{ flex: 1 }}>
+            <Text size="sm" fw={600} lh={1.3}>
+              Instalar FinanceApp
+            </Text>
+            <Text size="xs" c="dimmed" mt={2}>
+              Adicione à tela inicial para acesso rápido
+            </Text>
+          </div>
+          <Button size="xs" onClick={triggerAndroidInstall}>
+            Instalar
+          </Button>
+        </Group>
+      </Paper>
+    )
+  }
+
+  return null
+}

--- a/frontend/src/hooks/usePWAInstall.ts
+++ b/frontend/src/hooks/usePWAInstall.ts
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react'
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+function isIOS(): boolean {
+  return /iphone|ipad|ipod/i.test(navigator.userAgent)
+}
+
+function isInStandaloneMode(): boolean {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    ('standalone' in window.navigator && (window.navigator as { standalone?: boolean }).standalone === true)
+  )
+}
+
+const DISMISSED_KEY = 'pwa-install-dismissed'
+
+export function usePWAInstall() {
+  const [showIOSBanner, setShowIOSBanner] = useState(false)
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null)
+  const [showAndroidBanner, setShowAndroidBanner] = useState(false)
+
+  useEffect(() => {
+    if (isInStandaloneMode()) return
+    if (sessionStorage.getItem(DISMISSED_KEY)) return
+
+    if (isIOS()) {
+      setShowIOSBanner(true)
+      return
+    }
+
+    const handler = (e: Event) => {
+      e.preventDefault()
+      setDeferredPrompt(e as BeforeInstallPromptEvent)
+      setShowAndroidBanner(true)
+    }
+
+    window.addEventListener('beforeinstallprompt', handler)
+    return () => window.removeEventListener('beforeinstallprompt', handler)
+  }, [])
+
+  const dismissIOSBanner = () => {
+    sessionStorage.setItem(DISMISSED_KEY, '1')
+    setShowIOSBanner(false)
+  }
+
+  const triggerAndroidInstall = async () => {
+    if (!deferredPrompt) return
+    await deferredPrompt.prompt()
+    const { outcome } = await deferredPrompt.userChoice
+    if (outcome === 'accepted' || outcome === 'dismissed') {
+      sessionStorage.setItem(DISMISSED_KEY, '1')
+      setShowAndroidBanner(false)
+      setDeferredPrompt(null)
+    }
+  }
+
+  const dismissAndroidBanner = () => {
+    sessionStorage.setItem(DISMISSED_KEY, '1')
+    setShowAndroidBanner(false)
+    setDeferredPrompt(null)
+  }
+
+  return {
+    showIOSBanner,
+    dismissIOSBanner,
+    showAndroidBanner,
+    dismissAndroidBanner,
+    triggerAndroidInstall,
+  }
+}


### PR DESCRIPTION
iOS (including Edge on iOS) does not fire beforeinstallprompt, so users
had no way to discover the install option. This adds a fixed bottom banner
that guides iOS users to use the share menu > Add to Home Screen, and
shows a native install button on Android/Chrome via beforeinstallprompt.

The banner is dismissed per-session and hidden when already running in
standalone mode.

https://claude.ai/code/session_01Ew7yBgemqo8F47kGepMbfW