### PR TITLE
fix: make bottom sheet drawers full-width on all screen sizes

### DIFF
--- a/frontend/src/components/transactions/BulkDeleteProgressDrawer.tsx
+++ b/frontend/src/components/transactions/BulkDeleteProgressDrawer.tsx
@@ -103,7 +103,6 @@ export function BulkDeleteProgressDrawer({
       }
       withCloseButton={!isProcessing}
       styles={{
-        inner: { left: "35vw", right: "35vw", width: "30vw" },
         content: {
           borderRadius: "var(--mantine-radius-lg) var(--mantine-radius-lg) 0 0",
           height: "auto",

--- a/frontend/src/components/transactions/PropagationSettingsDrawer.tsx
+++ b/frontend/src/components/transactions/PropagationSettingsDrawer.tsx
@@ -21,7 +21,6 @@ export function PropagationSettingsDrawer() {
       position="bottom"
       title="Excluir transações recorrentes"
       styles={{
-        inner: { left: '35vw', right: '35vw', width: '30vw' },
         content: {
           borderRadius: 'var(--mantine-radius-lg) var(--mantine-radius-lg) 0 0',
           height: 'auto',


### PR DESCRIPTION
Removes the `inner` container constraints (`left: 35vw`, `right: 35vw`,
`width: 30vw`) from PropagationSettingsDrawer and BulkDeleteProgressDrawer.
Mantine's bottom-position Drawer now spans the full viewport width by
default, fixing the narrow panel on mobile devices.

Closes #33

https://claude.ai/code/session_0183Puk9cBnYAvQyagGoCNpd