### PR TITLE
fix: simplify selection bar UI with drawer-style close button

### DIFF
--- a/frontend/src/components/transactions/SelectionActionBar.module.css
+++ b/frontend/src/components/transactions/SelectionActionBar.module.css
@@ -8,3 +8,9 @@
   background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
   border-top: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
 }
+
+.closeButton {
+  position: absolute;
+  top: -1rem;
+  right: 1rem;
+}

--- a/frontend/src/components/transactions/SelectionActionBar.tsx
+++ b/frontend/src/components/transactions/SelectionActionBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, Text } from '@mantine/core'
+import { ActionIcon, Button, Group, Text } from '@mantine/core'
 import { IconTrash, IconX } from '@tabler/icons-react'
 import classes from './SelectionActionBar.module.css'
 
@@ -11,30 +11,30 @@ interface SelectionActionBarProps {
 export function SelectionActionBar({ count, onClearSelection, onDelete }: SelectionActionBarProps) {
   return (
     <div className={classes.bar} data-testid="selection_action_bar">
+      <ActionIcon
+        className={classes.closeButton}
+        variant="default"
+        radius="xl"
+        size="md"
+        onClick={onClearSelection}
+        data-testid="btn_clear_selection"
+        aria-label="Limpar seleção"
+      >
+        <IconX size={14} />
+      </ActionIcon>
       <Group justify="space-between" align="center">
-        <Text size="sm" fw={500} data-testid="selection_count">
-          {count} selecionada{count !== 1 ? 's' : ''}
+        <Text size="sm" fw={700} data-testid="selection_count">
+          {count}
         </Text>
-        <Group gap="sm">
-          <Button
-            variant="subtle"
-            size="sm"
-            leftSection={<IconX size={14} />}
-            onClick={onClearSelection}
-            data-testid="btn_clear_selection"
-          >
-            Desmarcar tudo
-          </Button>
-          <Button
-            color="red"
-            size="sm"
-            leftSection={<IconTrash size={14} />}
-            onClick={onDelete}
-            data-testid="btn_bulk_delete"
-          >
-            Excluir
-          </Button>
-        </Group>
+        <Button
+          color="red"
+          size="sm"
+          leftSection={<IconTrash size={14} />}
+          onClick={onDelete}
+          data-testid="btn_bulk_delete"
+        >
+          Excluir
+        </Button>
       </Group>
     </div>
   )


### PR DESCRIPTION
- Show only the count number (remove "selecionada(s)" label)
- Replace "Desmarcar tudo" button with an X icon button at top-right of the bar, styled like a drawer close handle
- Remove clear button from inside the bar actions group

https://claude.ai/code/session_011TGGEWZK3TGYKrWHtD4KcN