### PR TITLE
feat: add hide settlements filter to advanced filters

### DIFF
--- a/frontend/src/components/transactions/ClearFiltersButton.tsx
+++ b/frontend/src/components/transactions/ClearFiltersButton.tsx
@@ -13,7 +13,8 @@ function useHasActiveFilters() {
     search.categoryIds.length > 0 ||
     search.accountIds.length > 0 ||
     search.types.length > 0 ||
-    search.query !== ''
+    search.query !== '' ||
+    search.hideSettlements === true
   )
 }
 
@@ -32,6 +33,7 @@ export function ClearFiltersButton({ variant = 'button' }: ClearFiltersButtonPro
         accountIds: [],
         types: [],
         query: '',
+        hideSettlements: false,
       }),
     })
   }

--- a/frontend/src/components/transactions/TransactionGroup.tsx
+++ b/frontend/src/components/transactions/TransactionGroup.tsx
@@ -21,6 +21,7 @@ interface TransactionGroupProps {
   isFirst?: boolean;
   selectedIds?: Set<number>;
   onSelectTransaction?: (id: number) => void;
+  hideSettlements?: boolean;
 }
 
 export function TransactionGroup({
@@ -34,6 +35,7 @@ export function TransactionGroup({
   isFirst = false,
   selectedIds,
   onSelectTransaction,
+  hideSettlements,
 }: TransactionGroupProps) {
   const isSelectionActive = (selectedIds?.size ?? 0) > 0;
 
@@ -76,7 +78,7 @@ export function TransactionGroup({
                     : undefined
                 }
               />
-              {(tx.settlements_from_source ?? []).map((s) => (
+              {!hideSettlements && (tx.settlements_from_source ?? []).map((s) => (
                 <SettlementRow
                   key={`settlement-${s.id}`}
                   settlement={s}

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -16,13 +16,15 @@ interface TransactionListProps {
   onSelectTransaction?: (id: number) => void
 }
 
-function groupNetTotal(group: Transactions.TransactionGroup): number {
+function groupNetTotal(group: Transactions.TransactionGroup, hideSettlements: boolean): number {
   return group.transactions.reduce((sum, tx) => {
     const txAmount = tx.operation_type === 'credit' ? tx.amount : -tx.amount
-    const settlementsAmount = (tx.settlements_from_source ?? []).reduce(
-      (s, settlement) => s + (settlement.type === 'credit' ? settlement.amount : -settlement.amount),
-      0,
-    )
+    const settlementsAmount = hideSettlements
+      ? 0
+      : (tx.settlements_from_source ?? []).reduce(
+          (s, settlement) => s + (settlement.type === 'credit' ? settlement.amount : -settlement.amount),
+          0,
+        )
     return sum + txAmount + settlementsAmount
   }, 0)
 }
@@ -61,7 +63,7 @@ export function TransactionList({ currentUserId, selectedIds, onSelectTransactio
     [filtered, search.groupBy, accounts, categories],
   )
 
-  const groupTotals = useMemo(() => groups.map(groupNetTotal), [groups])
+  const groupTotals = useMemo(() => groups.map((g) => groupNetTotal(g, search.hideSettlements)), [groups, search.hideSettlements])
 
   const runningBalances = useMemo(() => {
     return groupTotals.reduce<number[]>((acc, total) => {
@@ -108,6 +110,7 @@ export function TransactionList({ currentUserId, selectedIds, onSelectTransactio
           isFirst={i === 0}
           selectedIds={selectedIds}
           onSelectTransaction={onSelectTransaction}
+          hideSettlements={search.hideSettlements}
         />
       ))}
     </Stack>

--- a/frontend/src/components/transactions/filters/AdvancedFilter.tsx
+++ b/frontend/src/components/transactions/filters/AdvancedFilter.tsx
@@ -38,6 +38,7 @@ export function AdvancedFilter({ inline }: AdvancedFilterProps) {
   const [opened, setOpened] = useState(false)
 
   const selected: Transactions.TransactionType[] = search.types ?? []
+  const hideSettlements = search.hideSettlements ?? false
 
   function toggle(value: Transactions.TransactionType) {
     const next = selected.includes(value)
@@ -46,11 +47,22 @@ export function AdvancedFilter({ inline }: AdvancedFilterProps) {
     navigate({ search: (prev) => ({ ...prev, types: next.length ? next : undefined }) })
   }
 
+  function toggleHideSettlements() {
+    navigate({ search: (prev) => ({ ...prev, hideSettlements: !hideSettlements }) })
+  }
+
+  const advancedCount = selected.length + (hideSettlements ? 1 : 0)
+
   if (inline) {
     return (
       <Stack gap="xs">
         <Text size="sm" fw={500}>Tipo</Text>
         <TypeOptions selected={selected} toggle={toggle} />
+        <Switch
+          label="Ocultar acertos"
+          checked={hideSettlements}
+          onChange={toggleHideSettlements}
+        />
       </Stack>
     )
   }
@@ -58,7 +70,7 @@ export function AdvancedFilter({ inline }: AdvancedFilterProps) {
   return (
     <Popover opened={opened} onChange={setOpened} position="bottom-start" shadow="md">
       <Popover.Target>
-        <Indicator label={selected.length} size={16} disabled={!selected.length}>
+        <Indicator label={advancedCount} size={16} disabled={!advancedCount}>
           <Button
             variant="default"
             leftSection={<IconAdjustments size={16} />}
@@ -71,6 +83,11 @@ export function AdvancedFilter({ inline }: AdvancedFilterProps) {
       <Popover.Dropdown>
         <Stack gap="xs">
           <TypeOptions selected={selected} toggle={toggle} />
+          <Switch
+            label="Ocultar acertos"
+            checked={hideSettlements}
+            onChange={toggleHideSettlements}
+          />
         </Stack>
       </Popover.Dropdown>
     </Popover>

--- a/frontend/src/routes/_authenticated.transactions.tsx
+++ b/frontend/src/routes/_authenticated.transactions.tsx
@@ -33,6 +33,7 @@ const transactionSearchSchema = z.object({
   types: z.array(z.enum(['expense', 'income', 'transfer'])).default([]),
   groupBy: z.enum(['date', 'category', 'account']).default('date'),
   accumulated: z.coerce.boolean().default(false),
+  hideSettlements: z.coerce.boolean().default(false),
 })
 
 export const Route = createFileRoute('/_authenticated/transactions')({


### PR DESCRIPTION
Adds a 'Ocultar acertos' toggle to the advanced filters panel. When active,
settlement rows are hidden from the transaction list and excluded from group
subtotals. The clear filters button is shown when this filter is active.

https://claude.ai/code/session_018TaFmwu1Zg5Hd22A72fByt