### PR TITLE
fix(e2e): fix failing import e2e tests

### DIFF
--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -31,7 +31,6 @@ export class ImportPage {
   async selectAccount(accountName: string) {
     const input = this.uploadStep.getByTestId("select_import_account");
     await input.click();
-    await input.fill(accountName);
     await this.page.getByRole("option", { name: accountName }).click();
   }
 
@@ -72,10 +71,15 @@ export class ImportPage {
    */
   async confirmImport() {
     await this.confirmButton.click();
-    // Wait for the summary alert that appears after the import loop finishes
-    await expect(this.finishedStep.getByText("Importação concluída")).toBeVisible({
-      timeout: 30000,
-    });
+    // Wait for the import loop to finish. Two possible completion states:
+    // - allImportedSuccess: finished_import_successfully_step replaces review_step
+    //   ("Importação concluída com sucesso!") — page then navigates away after 3s.
+    // - done with errors: review_step stays and shows an Alert
+    //   ("Importação concluída com erros").
+    // Search the whole page so both cases are covered.
+    await expect(
+      this.page.getByText("Importação concluída", { exact: false }).first(),
+    ).toBeVisible({ timeout: 30000 });
     await this.page.waitForLoadState("networkidle", { timeout: 15000 });
   }
 
@@ -108,6 +112,14 @@ export class ImportPage {
       .inputValue()
       .catch(() => "");
     return value || "pending";
+  }
+
+  /** Set the category for a row via the searchable category select. */
+  async setRowCategory(rowIndex: number, categoryName: string) {
+    const select = this.reviewStep.getByTestId(`select_category_${rowIndex}`);
+    await select.click();
+    await select.fill(categoryName);
+    await this.page.getByRole("option", { name: categoryName }).click();
   }
 
   /** Change the action for a row via the action select. */

--- a/frontend/e2e/tests/import.spec.ts
+++ b/frontend/e2e/tests/import.spec.ts
@@ -85,6 +85,9 @@ test.describe("Import transactions", () => {
     const rowCount = await importPage.getRowCount();
     expect(rowCount).toBe(1);
 
+    // Category is required for non-transfer rows before confirming
+    await importPage.setRowCategory(0, testCategoryName);
+
     await importPage.confirmImport();
 
     // Transaction should appear somewhere on the transactions page
@@ -142,6 +145,9 @@ test.describe("Import transactions", () => {
 
     // Change row 1 action to "skip"
     await importPage.setRowAction(1, "skip");
+
+    // Category is required for the row being imported
+    await importPage.setRowCategory(0, testCategoryName);
 
     await importPage.confirmImport();
 

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -284,6 +284,7 @@ export const ImportReviewRow = memo(
                   clearable
                   placeholder="Selecionar..."
                   withCheckIcon={false}
+                  data-testid={`select_category_${rowIndex}`}
                 />
               )}
             />


### PR DESCRIPTION
Fix 4 failing import e2e tests.
- selectAccount: remove fill() on readonly Mantine Select
- confirmImport: full-page getByText to handle both completion states
- ImportReviewRow: add data-testid to category Select
- ImportPage: add setRowCategory() helper
- import.spec.ts: set category before confirmImport (backend does not resolve categories from CSV)