### PR TITLE
fix: strip split_settings from transfer transactions during import

### DIFF
--- a/frontend/src/routes/_authenticated.transactions_.import.tsx
+++ b/frontend/src/routes/_authenticated.transactions_.import.tsx
@@ -83,7 +83,7 @@ function buildPayload(row: ImportRowFormValues): Transactions.CreateTransactionP
       total_installments: row.recurrenceTotalInstallments,
     };
   }
-  if (row.split_settings?.length) {
+  if (row.transaction_type !== "transfer" && row.split_settings?.length) {
     payload.split_settings = row.split_settings;
   }
   return payload;

--- a/frontend/src/routes/_authenticated.transactions_.import.tsx
+++ b/frontend/src/routes/_authenticated.transactions_.import.tsx
@@ -67,7 +67,7 @@ function buildPayload(row: ImportRowFormValues): Transactions.CreateTransactionP
     date: row.date,
     description: row.description,
   };
-  if (row.category_id) payload.category_id = row.category_id;
+  if (row.transaction_type !== "transfer" && row.category_id) payload.category_id = row.category_id;
   if (row.transaction_type === "transfer" && row.destination_account_id) {
     payload.destination_account_id = row.destination_account_id;
   }


### PR DESCRIPTION
## Summary
- Strip split_settings from payload when transaction type is transfer during import
- Backend already rejects this combo (`ErrSplitSettingsNotAllowedForTransfer`)
- Regular transaction form already had this guard, import page was missing it

## Test plan
- [ ] Import CSV, set split settings on a row, change type to transfer, confirm import succeeds
- [ ] Import CSV with split settings on expense — verify split still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)