### PR TITLE
feat: allow split settings for income transactions

### DIFF
--- a/backend/internal/service/transaction_create.go
+++ b/backend/internal/service/transaction_create.go
@@ -98,9 +98,7 @@ func (s *transactionService) validateCreateTransactionRequest(transaction *domai
 		}
 	}
 
-	if len(transaction.SplitSettings) > 0 && transaction.TransactionType != domain.TransactionTypeExpense {
-		errs = append(errs, pkgErrors.ErrSplitAllowedOnlyForExpense)
-	} else if len(transaction.SplitSettings) > 0 {
+	if len(transaction.SplitSettings) > 0 {
 		for i, splitSetting := range transaction.SplitSettings {
 			if splitSetting.ConnectionID <= 0 {
 				errs = append(errs, pkgErrors.ErrSplitSettingInvalidConnectionID(i))

--- a/backend/internal/service/transaction_create_test.go
+++ b/backend/internal/service/transaction_create_test.go
@@ -912,6 +912,116 @@ func (suite *TransactionCreateWithDBTestSuite) TestCreateSharedExpense() {
 	suite.Assert().Equal(user1.ID, lo.FromPtr(transactionsUser2[0].OriginalUserID))
 }
 
+func (suite *TransactionCreateWithDBTestSuite) TestCreateSharedIncome() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	if err != nil {
+		suite.T().Fatalf("Failed to create test user: %v", err)
+	}
+
+	user2, err := suite.createTestUser(ctx)
+	if err != nil {
+		suite.T().Fatalf("Failed to create test user: %v", err)
+	}
+
+	account, err := suite.createTestAccount(ctx, user1)
+	if err != nil {
+		suite.T().Fatalf("Failed to create test account: %v", err)
+	}
+
+	category, err := suite.createTestCategory(ctx, user1)
+	if err != nil {
+		suite.T().Fatalf("Failed to create test category: %v", err)
+	}
+
+	userConnection, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	if err != nil {
+		suite.T().Fatalf("Failed to create accepted test user connection: %v", err)
+	}
+
+	amount := int64(100)
+
+	d := now()
+
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		AccountID:       account.ID,
+		CategoryID:      category.ID,
+		Amount:          amount,
+		Date:            d,
+		Description:     "Shared income",
+		TransactionType: domain.TransactionTypeIncome,
+		SplitSettings: []domain.SplitSettings{
+			{
+				ConnectionID: userConnection.ID,
+				Percentage:   lo.ToPtr(50),
+			},
+		},
+	})
+	if err != nil {
+		suite.T().Fatalf("Failed to create transaction: %v", err)
+	}
+
+	transactionsUser1, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID:          &user1.ID,
+		WithSettlements: true,
+	})
+	if err != nil {
+		suite.T().Fatalf("Failed to get transaction: %v", err)
+	}
+
+	suite.Assert().Len(transactionsUser1, 1)
+
+	suite.Assert().Greater(transactionsUser1[0].ID, 0)
+	suite.Assert().Equal(account.ID, transactionsUser1[0].AccountID)
+	suite.Assert().Equal(category.ID, lo.FromPtr(transactionsUser1[0].CategoryID))
+	suite.Assert().Equal(amount, int64(transactionsUser1[0].Amount))
+	suite.Assert().Equal(d, transactionsUser1[0].Date)
+	suite.Assert().Equal("Shared income", transactionsUser1[0].Description)
+	suite.Assert().Equal(domain.TransactionTypeIncome, transactionsUser1[0].Type)
+	suite.Assert().Equal(user1.ID, transactionsUser1[0].UserID)
+	suite.Assert().Equal(user1.ID, lo.FromPtr(transactionsUser1[0].OriginalUserID))
+
+	suite.Assert().Len(transactionsUser1[0].LinkedTransactions, 1)
+
+	suite.Assert().Equal(userConnection.ToAccountID, transactionsUser1[0].LinkedTransactions[0].AccountID)
+	suite.Assert().Nil(transactionsUser1[0].LinkedTransactions[0].CategoryID)
+	suite.Assert().Equal(int64(amount/2), int64(transactionsUser1[0].LinkedTransactions[0].Amount))
+	suite.Assert().Equal(d, transactionsUser1[0].LinkedTransactions[0].Date)
+	suite.Assert().Equal("Shared income", transactionsUser1[0].LinkedTransactions[0].Description)
+	suite.Assert().Equal(domain.TransactionTypeIncome, transactionsUser1[0].LinkedTransactions[0].Type)
+	suite.Assert().Equal(user2.ID, transactionsUser1[0].LinkedTransactions[0].UserID)
+	suite.Assert().Equal(user1.ID, lo.FromPtr(transactionsUser1[0].LinkedTransactions[0].OriginalUserID))
+
+	// Settlement should be debit for income (author owes partner)
+	suite.Assert().Len(transactionsUser1[0].SettlementsFromSource, 1)
+	settlement := transactionsUser1[0].SettlementsFromSource[0]
+	suite.Assert().Equal(user1.ID, settlement.UserID)
+	suite.Assert().Equal(domain.SettlementTypeDebit, settlement.Type)
+	suite.Assert().Equal(int64(amount/2), settlement.Amount)
+	suite.Assert().Equal(userConnection.FromAccountID, settlement.AccountID)
+	suite.Assert().Equal(transactionsUser1[0].ID, settlement.SourceTransactionID)
+	suite.Assert().Equal(transactionsUser1[0].LinkedTransactions[0].ID, settlement.ParentTransactionID)
+
+	transactionsUser2, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user2.ID,
+	})
+	if err != nil {
+		suite.T().Fatalf("Failed to get transaction: %v", err)
+	}
+
+	suite.Assert().Len(transactionsUser2, 1)
+
+	suite.Assert().Greater(transactionsUser2[0].ID, 0)
+	suite.Assert().Equal(userConnection.ToAccountID, transactionsUser2[0].AccountID)
+	suite.Assert().Nil(transactionsUser2[0].CategoryID)
+	suite.Assert().Equal(int64(amount/2), int64(transactionsUser2[0].Amount))
+	suite.Assert().Equal(d, transactionsUser2[0].Date)
+	suite.Assert().Equal("Shared income", transactionsUser2[0].Description)
+	suite.Assert().Equal(domain.TransactionTypeIncome, transactionsUser2[0].Type)
+	suite.Assert().Equal(user2.ID, transactionsUser2[0].UserID)
+	suite.Assert().Equal(user1.ID, lo.FromPtr(transactionsUser2[0].OriginalUserID))
+}
+
 func (suite *TransactionCreateWithDBTestSuite) TestSearchSharedExpenseByFromAccountID() {
 	ctx := context.Background()
 	user1, err := suite.createTestUser(ctx)

--- a/backend/internal/service/transaction_validation_test.go
+++ b/backend/internal/service/transaction_validation_test.go
@@ -173,7 +173,9 @@ func (suite *TransactionCreateWithDBTestSuite) TestCreate_ValidationErrors() {
 		assertTag(err, pkgErrors.ErrorTagSplitSettingsNotAllowedForTransfer)
 	})
 
-	suite.Run("income_with_split_settings", func() {
+	suite.Run("income_with_split_settings_is_allowed", func() {
+		// Income with split settings should pass type validation
+		// (will fail later on account/connection lookup, not on type check)
 		_, err := suite.Services.Transaction.Create(ctx, 1, &domain.TransactionCreateRequest{
 			TransactionType: domain.TransactionTypeIncome,
 			AccountID:       1,
@@ -183,7 +185,8 @@ func (suite *TransactionCreateWithDBTestSuite) TestCreate_ValidationErrors() {
 			Description:     "test",
 			SplitSettings:   []domain.SplitSettings{{ConnectionID: 1, Percentage: lo.ToPtr(50)}},
 		})
-		assertTag(err, pkgErrors.ErrorTagSplitAllowedOnlyForExpense)
+		suite.Require().Error(err)
+		suite.Assert().False(hasTag(err, pkgErrors.ErrorTagSplitSettingsNotAllowedForTransfer), "income should allow split settings")
 	})
 }
 

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -36,7 +36,6 @@ const (
 	ErrorTagIndex                                               ErrorTag = "INDEX_%d"
 	ErrorTagMissingDestinationAccount                           ErrorTag = "TRANSACTION.MISSING_DESTINATION_ACCOUNT"
 	ErrorTagSplitSettingsNotAllowedForTransfer                  ErrorTag = "TRANSACTION.SPLIT_SETTINGS_NOT_ALLOWED_FOR_TRANSFER"
-	ErrorTagSplitAllowedOnlyForExpense                          ErrorTag = "TRANSACTION.SPLIT_ALLOWED_ONLY_FOR_EXPENSE"
 	ErrorTagAmountMustBeGreaterThanZero                         ErrorTag = "TRANSACTION.AMOUNT_MUST_BE_GREATER_THAN_ZERO"
 	ErrorTagDateIsRequired                                      ErrorTag = "TRANSACTION.DATE_IS_REQUIRED"
 	ErrorTagDescriptionIsRequired                               ErrorTag = "TRANSACTION.DESCRIPTION_IS_REQUIRED"
@@ -74,7 +73,6 @@ const (
 var (
 	ErrMissingDestinationAccount          = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagMissingDestinationAccount)}, "missing destination account")
 	ErrSplitSettingsNotAllowedForTransfer = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSplitSettingsNotAllowedForTransfer)}, "split settings are not allowed for transfer transactions")
-	ErrSplitAllowedOnlyForExpense         = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSplitAllowedOnlyForExpense)}, "split settings are allowed only for expense transactions")
 	ErrAmountMustBeGreaterThanZero        = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagAmountMustBeGreaterThanZero)}, "amount must be greater than zero")
 	ErrDateIsRequired                     = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagDateIsRequired)}, "date is required")
 	ErrDescriptionIsRequired              = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagDescriptionIsRequired)}, "description is required")


### PR DESCRIPTION
## Summary
- Remove expense-only validation for split settings — income transactions can now be split between connected users
- Settlement logic already mapped income splits to `SettlementTypeDebit` (author owes partner), no changes needed there
- Transfer restriction remains intact
- Add `TestCreateSharedIncome` integration test verifying linked transactions + settlement type

## Test plan
- [ ] Run `just test-integration` — verify `TestCreateSharedIncome` passes (income split creates linked transaction + debit settlement)
- [ ] Run `just test-integration` — verify `TestCreate_ValidationErrors/income_with_split_settings_is_allowed` passes
- [ ] Run `just test-integration` — verify existing `TestCreateSharedExpense` still passes (no regression)
- [ ] Verify transfer + split still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)