### PR TITLE
fix: defer emoji picker save to drawer close

### DIFF
--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -152,16 +152,18 @@ export class ImportPage {
 
     // Optionally set an emoji on the newly created category
     if (opts?.emoji) {
-      // Find the newly created category's emoji button
+      // Find the newly created category's emoji button and extract category ID
       const categoryRow = drawer.getByText(name).locator("..").locator("..");
       const emojiButton = categoryRow.locator("[data-testid^='btn_emoji_']");
+      const emojiTestId = await emojiButton.getAttribute("data-testid");
+      const categoryId = emojiTestId!.replace("btn_emoji_", "");
       await emojiButton.click();
       // Click the emoji option — it exists in exactly one open picker
       const emojiOption = this.page.getByTestId(`emoji_${opts.emoji}`).first();
       await expect(emojiOption).toBeVisible({ timeout: 5000 });
       await emojiOption.click();
       // Close the emoji picker drawer (saves on close)
-      const emojiDrawer = this.page.locator("[data-testid^='drawer_emoji_picker_']");
+      const emojiDrawer = this.page.getByTestId(`drawer_emoji_picker_${categoryId}`);
       await emojiDrawer.getByRole("button", { name: "Fechar" }).click();
       await expect(emojiDrawer).not.toBeVisible({ timeout: 5000 });
       // Wait for save to complete

--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -160,6 +160,10 @@ export class ImportPage {
       const emojiOption = this.page.getByTestId(`emoji_${opts.emoji}`).first();
       await expect(emojiOption).toBeVisible({ timeout: 5000 });
       await emojiOption.click();
+      // Close the emoji picker drawer (saves on close)
+      const emojiDrawer = this.page.locator("[data-testid^='drawer_emoji_picker_']");
+      await emojiDrawer.getByRole("button", { name: "Fechar" }).click();
+      await expect(emojiDrawer).not.toBeVisible({ timeout: 5000 });
       // Wait for save to complete
       await this.page.waitForLoadState("networkidle");
     }

--- a/frontend/src/components/categories/CategoryCard.tsx
+++ b/frontend/src/components/categories/CategoryCard.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { ActionIcon, Box, Collapse, Drawer, Group, Loader, ScrollArea, SimpleGrid, Stack, Text, TextInput, UnstyledButton } from '@mantine/core'
+import { ActionIcon, Box, Button, Collapse, Drawer, Group, Loader, ScrollArea, SimpleGrid, Stack, Text, TextInput, UnstyledButton } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { IconChevronDown, IconChevronRight, IconPlus, IconTrash } from '@tabler/icons-react'
 import { Transactions } from '@/types/transactions'
@@ -41,6 +41,7 @@ export function CategoryCard({
 
   const [expanded, { toggle, open: forceExpand }] = useDisclosure(true)
   const [emojiOpen, { open: openEmoji, close: closeEmoji }] = useDisclosure(false)
+  const [stagedEmoji, setStagedEmoji] = useState<string | undefined>(category.emoji)
 
   // In-place name editing
   const [editingName, setEditingName] = useState(false)
@@ -79,14 +80,23 @@ export function CategoryCard({
     if (e.key === 'Escape') setEditingName(false)
   }
 
-  async function handleEmojiSelect(emoji: string) {
-    const next = emoji === category.emoji ? undefined : emoji
-    await onSaveEmoji(category, next)
-    closeEmoji()
+  function handleOpenEmoji() {
+    setStagedEmoji(category.emoji)
+    openEmoji()
   }
 
-  async function handleClearEmoji() {
-    await onSaveEmoji(category, undefined)
+  function handleEmojiSelect(emoji: string) {
+    setStagedEmoji(prev => prev === emoji ? undefined : emoji)
+  }
+
+  function handleClearEmoji() {
+    setStagedEmoji(undefined)
+  }
+
+  async function handleCloseEmojiDrawer() {
+    if (stagedEmoji !== category.emoji) {
+      await onSaveEmoji(category, stagedEmoji)
+    }
     closeEmoji()
   }
 
@@ -114,7 +124,7 @@ export function CategoryCard({
         )}
 
         {/* emoji button */}
-        <ActionIcon variant="subtle" color="gray" size="md" onClick={openEmoji} title="Mudar emoji" data-testid={`btn_emoji_${category.id}`}>
+        <ActionIcon variant="subtle" color="gray" size="md" onClick={handleOpenEmoji} title="Mudar emoji" data-testid={`btn_emoji_${category.id}`}>
           {category.emoji ? (
             <Text size="md" lh={1}>{category.emoji}</Text>
           ) : (
@@ -194,7 +204,7 @@ export function CategoryCard({
       )}
 
       {/* emoji picker drawer */}
-      <Drawer opened={emojiOpen} onClose={closeEmoji} title="Escolher emoji" position="right" size="sm" data-testid={`drawer_emoji_picker_${category.id}`}>
+      <Drawer opened={emojiOpen} onClose={handleCloseEmojiDrawer} title="Escolher emoji" position="right" size="sm" data-testid={`drawer_emoji_picker_${category.id}`}>
         <Stack gap="md">
           <ScrollArea>
             <SimpleGrid cols={7} spacing="xs">
@@ -208,7 +218,7 @@ export function CategoryCard({
                     textAlign: 'center',
                     padding: 4,
                     borderRadius: 6,
-                    background: e === category.emoji ? 'var(--mantine-color-blue-1)' : undefined,
+                    background: e === stagedEmoji ? 'var(--mantine-color-blue-1)' : undefined,
                   }}
                 >
                   {e}
@@ -216,7 +226,7 @@ export function CategoryCard({
               ))}
             </SimpleGrid>
           </ScrollArea>
-          {category.emoji && (
+          {stagedEmoji && (
             <UnstyledButton
               onClick={handleClearEmoji}
               style={{ color: 'var(--mantine-color-red-6)', fontSize: 14, textAlign: 'center' }}
@@ -224,6 +234,7 @@ export function CategoryCard({
               Remover emoji
             </UnstyledButton>
           )}
+          <Button onClick={handleCloseEmojiDrawer} fullWidth mt="md">Fechar</Button>
         </Stack>
       </Drawer>
     </Stack>


### PR DESCRIPTION
## Summary
- Emoji picker in category drawer was firing a PUT request on every emoji click, causing perceived slowness
- Now stores selection in local state with instant visual highlight feedback
- Single API request fires only when drawer closes (via "Fechar" button or backdrop dismiss)
- No request if emoji didn't change

## Test plan
- [ ] Open import transactions → create category → open emoji picker
- [ ] Click emojis — should highlight instantly with no network request in DevTools
- [ ] Click "Fechar" — single PUT request fires
- [ ] Reopen drawer — shows persisted emoji
- [ ] Open drawer, change nothing, close — no network request

🤖 Generated with [Claude Code](https://claude.com/claude-code)