### PR TITLE
fix: preserve installment offset during updates

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -50,7 +50,20 @@ Partners can accurately track shared finances, including in-progress installment
 
 ### Active
 
-(None — planning next milestone)
+- [ ] Backend validation restricts linked transaction edits to date, description, category only
+- [ ] Date propagation for linked transactions reuses existing logic (diff-based inc/dec)
+- [ ] Frontend form: editable fields enabled, non-editable fields disabled, type/recurrence/split hidden
+- [ ] Propagation settings shown when linked transaction has recurrences
+
+## Current Milestone: v1.3 Editing Linked Transactions
+
+**Goal:** Allow users to edit linked transactions with restricted fields, backend validation, and proper frontend UX.
+
+**Target features:**
+- Backend validation: only date, description, category editable on linked transactions
+- Date propagation with recurrences: reuse existing diff-based logic for all/current/current_and_future
+- Frontend form adjustments: disabled non-editable fields, hidden type/recurrence/split sections
+- Propagation settings: shown when recurrences exist
 
 ### Out of Scope
 
@@ -97,4 +110,4 @@ This document evolves at phase transitions and milestone boundaries.
 
 ---
 
-_Last updated: 2026-04-17 after v1.2 Transactions Bulk Actions milestone complete_
+_Last updated: 2026-04-18 after v1.3 milestone started_

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,60 @@
+# Requirements: Couples Finance App — v1.3
+
+**Defined:** 2026-04-18
+**Core Value:** Partners can accurately track shared finances, including in-progress installment purchases, without losing history or requiring manual workarounds.
+
+## v1.3 Requirements
+
+Requirements for editing linked transactions with restricted fields.
+
+### Validation
+
+- [ ] **VAL-01**: Backend rejects edits to non-allowed fields (amount, account, type, recurrence, split) on linked transactions
+- [ ] **VAL-02**: Backend allows edits to date, description, category on linked transactions
+
+### Propagation
+
+- [ ] **PROP-01**: Linked transaction date/description/category edits respect propagation settings (all/current/current_and_future) — reusing existing date diff logic
+
+### Frontend
+
+- [ ] **FE-01**: Non-editable fields (amount, account, etc.) shown as disabled when editing linked transaction
+- [ ] **FE-02**: Type selector hidden when editing linked transaction
+- [ ] **FE-03**: Recurrence toggle hidden when editing linked transaction
+- [ ] **FE-04**: Split settings section hidden when editing linked transaction
+- [ ] **FE-05**: Propagation settings shown when linked transaction has recurrences
+
+## Future Requirements
+
+None — scope is tightly defined for this milestone.
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Editing amount on linked transactions | Would require recalculating both sides of transfer — complex, not needed |
+| Editing account on linked transactions | Would fundamentally change the transfer — create new transfer instead |
+| Editing split settings on linked transactions | Split is set at creation time |
+| Creating new linked transactions from edit form | Out of scope — use create flow |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| VAL-01 | TBD | Pending |
+| VAL-02 | TBD | Pending |
+| PROP-01 | TBD | Pending |
+| FE-01 | TBD | Pending |
+| FE-02 | TBD | Pending |
+| FE-03 | TBD | Pending |
+| FE-04 | TBD | Pending |
+| FE-05 | TBD | Pending |
+
+**Coverage:**
+- v1.3 requirements: 8 total
+- Mapped to phases: 0
+- Unmapped: 8 ⚠️
+
+---
+*Requirements defined: 2026-04-18*
+*Last updated: 2026-04-18 after initial definition*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -41,20 +41,20 @@ None — scope is tightly defined for this milestone.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| VAL-01 | TBD | Pending |
-| VAL-02 | TBD | Pending |
-| PROP-01 | TBD | Pending |
-| FE-01 | TBD | Pending |
-| FE-02 | TBD | Pending |
-| FE-03 | TBD | Pending |
-| FE-04 | TBD | Pending |
-| FE-05 | TBD | Pending |
+| VAL-01 | Phase 11 | Pending |
+| VAL-02 | Phase 11 | Pending |
+| PROP-01 | Phase 11 | Pending |
+| FE-01 | Phase 12 | Pending |
+| FE-02 | Phase 12 | Pending |
+| FE-03 | Phase 12 | Pending |
+| FE-04 | Phase 12 | Pending |
+| FE-05 | Phase 12 | Pending |
 
 **Coverage:**
 - v1.3 requirements: 8 total
-- Mapped to phases: 0
-- Unmapped: 8 ⚠️
+- Mapped to phases: 8
+- Unmapped: 0 ✓
 
 ---
 *Requirements defined: 2026-04-18*
-*Last updated: 2026-04-18 after initial definition*
+*Last updated: 2026-04-18 after roadmap creation*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -5,6 +5,7 @@
 - ✅ **v1.0 Recurrence Redesign** — Phases 1–4 (shipped 2026-04-10)
 - ✅ **v1.1 Charges** — Phases 5–8 (shipped 2026-04-16)
 - ✅ **v1.2 Transactions Bulk Actions** — Phases 9–10 (shipped 2026-04-17)
+- 🔄 **v1.3 Editing Linked Transactions** — Phases 11–12 (active)
 
 ## Phases
 
@@ -42,21 +43,58 @@ Full details: `.planning/milestones/v1.2-ROADMAP.md`
 
 </details>
 
+<details open>
+<summary>🔄 v1.3 Editing Linked Transactions (Phases 11–12) — ACTIVE</summary>
+
+- [ ] **Phase 11: Backend Validation & Propagation** - Backend enforces restricted field edits and propagates changes via existing logic
+- [ ] **Phase 12: Frontend Edit Form** - Edit form disables non-editable fields, hides irrelevant sections, surfaces propagation settings
+
+</details>
+
+## Phase Details
+
+### Phase 11: Backend Validation & Propagation
+**Goal**: The backend correctly enforces that only date, description, and category are editable on linked transactions, and propagates those changes using existing diff-based logic
+**Depends on**: Nothing (first phase of milestone; builds on existing service layer)
+**Requirements**: VAL-01, VAL-02, PROP-01
+**Success Criteria** (what must be TRUE):
+  1. A PUT request to update amount, account, type, recurrence, or split settings on a linked transaction returns an error
+  2. A PUT request to update date, description, or category on a linked transaction succeeds
+  3. When a linked transaction's date is updated with propagation=all, all installments in the series shift by the same diff applied via existing logic
+  4. When propagation=current_and_future is used, only the current and future installments shift; past installments are unaffected
+  5. No new propagation logic is introduced — the existing date diff mechanism is reused for all three propagation modes
+**Plans**: TBD
+
+### Phase 12: Frontend Edit Form
+**Goal**: Users editing a linked transaction see only the fields they can change, with non-editable fields clearly disabled and the propagation drawer available when recurrences exist
+**Depends on**: Phase 11
+**Requirements**: FE-01, FE-02, FE-03, FE-04, FE-05
+**Success Criteria** (what must be TRUE):
+  1. When opening the edit form for a linked transaction, amount and account fields are visible but disabled and cannot be interacted with
+  2. The transaction type selector is not rendered when editing a linked transaction
+  3. The recurrence toggle and its associated inputs are not rendered when editing a linked transaction
+  4. The split settings section is not rendered when editing a linked transaction
+  5. When editing a linked transaction that belongs to a recurring series, the propagation settings drawer appears and the user can select all/current/current_and_future before saving
+**Plans**: TBD
+**UI hint**: yes
+
 ## Progress
 
-| Phase                                                | Milestone | Plans Complete | Status      | Completed  |
-| ---------------------------------------------------- | --------- | -------------- | ----------- | ---------- |
-| 1. Domain & Validation                               | v1.0      | 3/3            | Complete    | 2026-04-09 |
-| 2. Service & API                                     | v1.0      | 2/2            | Complete    | 2026-04-09 |
-| 3. Frontend                                          | v1.0      | 1/1            | Complete    | 2026-04-10 |
-| 4. Tests                                             | v1.0      | 2/2            | Complete    | 2026-04-10 |
-| 5. Charge Domain & DB                                | v1.1      | 2/2            | Complete    | 2026-04-14 |
-| 6. Charge Repository, Service & API (CRUD + Listing) | v1.1      | 2/2            | Complete    | 2026-04-15 |
-| 7. Accept + Atomic Transfer                          | v1.1      | 2/2            | Complete    | 2026-04-16 |
-| 8. Frontend                                          | v1.1      | 3/3            | Complete    | 2026-04-16 |
-| 9. Bulk Actions                                      | v1.2      | 3/3            | Complete    | 2026-04-17 |
-| 10. User Avatar System                               | v1.2      | 3/3 | Complete   | 2026-04-17 |
+| Phase | Milestone | Plans Complete | Status | Completed |
+|-------|-----------|----------------|--------|-----------|
+| 1. Domain & Validation | v1.0 | 3/3 | Complete | 2026-04-09 |
+| 2. Service & API | v1.0 | 2/2 | Complete | 2026-04-09 |
+| 3. Frontend | v1.0 | 1/1 | Complete | 2026-04-10 |
+| 4. Tests | v1.0 | 2/2 | Complete | 2026-04-10 |
+| 5. Charge Domain & DB | v1.1 | 2/2 | Complete | 2026-04-14 |
+| 6. Charge Repository, Service & API (CRUD + Listing) | v1.1 | 2/2 | Complete | 2026-04-15 |
+| 7. Accept + Atomic Transfer | v1.1 | 2/2 | Complete | 2026-04-16 |
+| 8. Frontend | v1.1 | 3/3 | Complete | 2026-04-16 |
+| 9. Bulk Actions | v1.2 | 3/3 | Complete | 2026-04-17 |
+| 10. User Avatar System | v1.2 | 3/3 | Complete | 2026-04-17 |
+| 11. Backend Validation & Propagation | v1.3 | 0/? | Not started | - |
+| 12. Frontend Edit Form | v1.3 | 0/? | Not started | - |
 
 ---
 
-_Roadmap started: 2026-04-09 · v1.0 shipped: 2026-04-10 · v1.1 shipped: 2026-04-16 · v1.2 shipped: 2026-04-17_
+_Roadmap started: 2026-04-09 · v1.0 shipped: 2026-04-10 · v1.1 shipped: 2026-04-16 · v1.2 shipped: 2026-04-17 · v1.3 started: 2026-04-18_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,24 +1,23 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.3
-milestone_name: Editing Linked Transactions
-status: active
-last_updated: "2026-04-18T00:00:00.000Z"
-last_activity: 2026-04-18 -- Roadmap created, ready to plan Phase 11
+milestone: v1.0
+milestone_name: milestone
+status: Not started
+last_updated: "2026-04-18T00:27:21.770Z"
+last_activity: 2026-04-18 — Roadmap created for v1.3
 progress:
   total_phases: 2
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
-  percent: 0
 ---
 
 ## Current Position
 
 Phase: 11 — Backend Validation & Propagation
 Plan: —
-Status: Not started
-Last activity: 2026-04-18 — Roadmap created for v1.3
+Status: Context gathered
+Last activity: 2026-04-18 — Phase 11 context gathered
 
 ```
 [░░░░░░░░░░░░░░░░░░░░] 0% (0/2 phases)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,9 +4,9 @@ milestone: v1.3
 milestone_name: Editing Linked Transactions
 status: active
 last_updated: "2026-04-18T00:00:00.000Z"
-last_activity: 2026-04-18 -- Milestone v1.3 started
+last_activity: 2026-04-18 -- Roadmap created, ready to plan Phase 11
 progress:
-  total_phases: 0
+  total_phases: 2
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -15,17 +15,21 @@ progress:
 
 ## Current Position
 
-Phase: Not started (defining requirements)
+Phase: 11 — Backend Validation & Propagation
 Plan: —
-Status: Defining requirements
-Last activity: 2026-04-18 — Milestone v1.3 started
+Status: Not started
+Last activity: 2026-04-18 — Roadmap created for v1.3
+
+```
+[░░░░░░░░░░░░░░░░░░░░] 0% (0/2 phases)
+```
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-04-18)
 
 **Core value:** Partners can accurately track shared finances, including in-progress installment purchases, without losing history or requiring manual workarounds.
-**Current focus:** Defining requirements for v1.3
+**Current focus:** v1.3 — Editing Linked Transactions. Backend validation (Phase 11) then frontend form adjustments (Phase 12).
 
 ## Performance Metrics
 
@@ -40,6 +44,7 @@ See: .planning/PROJECT.md (updated 2026-04-18)
 - v1.0 shipped 2026-04-10. Archived: `.planning/milestones/v1.0-ROADMAP.md`
 - v1.1 shipped 2026-04-16. Archived: `.planning/milestones/v1.1-ROADMAP.md`
 - v1.2 shipped 2026-04-17. Archived: `.planning/milestones/v1.2-ROADMAP.md`
+- v1.3 roadmap: 2 phases (11–12). Backend-first, then frontend. Propagation logic reused from existing date diff mechanism — do NOT reimplement.
 
 ### Todos
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,28 +1,31 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.2
-milestone_name: Transactions Bulk Actions
-status: archived
-last_updated: "2026-04-17T20:00:00.000Z"
-last_activity: 2026-04-17 -- Milestone v1.2 archived
+milestone: v1.3
+milestone_name: Editing Linked Transactions
+status: active
+last_updated: "2026-04-18T00:00:00.000Z"
+last_activity: 2026-04-18 -- Milestone v1.3 started
 progress:
-  total_phases: 2
-  completed_phases: 2
-  total_plans: 6
-  completed_plans: 6
-  percent: 100
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 0
 ---
 
 ## Current Position
 
-Milestone v1.2 archived. Planning next milestone.
+Phase: Not started (defining requirements)
+Plan: —
+Status: Defining requirements
+Last activity: 2026-04-18 — Milestone v1.3 started
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-04-17)
+See: .planning/PROJECT.md (updated 2026-04-18)
 
 **Core value:** Partners can accurately track shared finances, including in-progress installment purchases, without losing history or requiring manual workarounds.
-**Current focus:** Planning next milestone
+**Current focus:** Defining requirements for v1.3
 
 ## Performance Metrics
 

--- a/.planning/phases/11-backend-validation-propagation/11-CONTEXT.md
+++ b/.planning/phases/11-backend-validation-propagation/11-CONTEXT.md
@@ -1,0 +1,106 @@
+# Phase 11: Backend Validation & Propagation - Context
+
+**Gathered:** 2026-04-18
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+The backend correctly enforces that only date, description, category, and tags are editable on linked transactions, and propagates those changes using existing diff-based logic. Changes only affect the editing user's own transactions — never the partner's side.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Validation strategy
+- **D-01:** Relax the blanket `ErrChildTransactionCannotBeUpdated` block in `validateUpdateTransactionRequest`. Instead of rejecting all edits when `GetSourceTransactionIDs` returns IDs, check which fields the request is changing.
+- **D-02:** Allowed fields for linked transactions: `date`, `description`, `category_id`, `tags`, `propagation_settings`. All other fields (`amount`, `account_id`, `transaction_type`, `recurrence_settings`, `split_settings`, `destination_account_id`) must be nil/empty or return an error.
+- **D-03:** Single error message when disallowed fields are present: "linked transactions can only edit date, description, category, and tags". One error, not per-field.
+
+### Category propagation
+- **D-04:** Category propagates only to the editing user's own installments in the recurrence series. It does NOT propagate to partner's linked transactions — users have different categories.
+- **D-05:** This is different from description propagation (which currently copies to all linked transactions). Category is user-specific like tags.
+
+### Tags behavior
+- **D-06:** Tags are allowed when editing linked transactions. Tags are personal metadata, consistent with category being allowed.
+- **D-07:** Tags already propagate to same-user linked transactions in the existing code (lines 114-118 of transaction_update.go). No change needed for tag propagation logic.
+
+### Propagation scope for linked transactions
+- **D-08:** Propagation settings (all/current/current_and_future) work the same way as regular transactions, BUT only affect the editing user's own installments. Partner's transactions/installments are never modified.
+- **D-09:** Date changes on linked transactions only shift the editing user's installment dates. Partner's linked transaction dates are NOT shifted. This differs from the current behavior where `own.LinkedTransactions[i].Date` is also shifted (lines 101-103).
+- **D-10:** Description changes on linked transactions only update the editing user's installments. Same principle — "edit my side only".
+
+### Claude's Discretion
+- Implementation approach for detecting "is this a linked transaction edit" vs "is this a regular edit"
+- Whether to refactor the validation check inline or extract a helper function
+- Error tag naming for the new validation error
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Transaction update logic
+- `backend/internal/service/transaction_update.go` — Core update logic, validation, propagation, linked transaction handling
+- `backend/internal/service/transaction_update.go:934` — `validateUpdateTransactionRequest` — the validation function to modify
+- `backend/internal/service/transaction_update.go:76-118` — Propagation loop where date/description/category/tags are applied
+
+### Domain model
+- `backend/internal/domain/transaction.go:120-132` — `TransactionUpdateRequest` struct — defines all updateable fields
+- `backend/internal/domain/transaction.go` — `TransactionPropagationSettings` type and constants
+
+### Error system
+- `backend/pkg/errors/errors.go:124` — `ErrChildTransactionCannotBeUpdated` — current blanket error to be replaced/modified
+
+### Linked transactions
+- `backend/internal/repository/transaction_repository.go:319` — `GetSourceTransactionIDs` — determines if a transaction is a linked child
+- `backend/migrations/20260203120000_linked_transactions_and_drop_parent_id.up.sql` — Linked transactions table schema
+
+### Requirements
+- `.planning/REQUIREMENTS.md` — VAL-01, VAL-02, PROP-01 requirements for this phase
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `shouldUpdateTransactionBasedOnPropagationSettings` (line 699): Already handles all/current/current_and_future filtering — reuse directly
+- `fetchRelatedTransactions` (line 885): Fetches installments based on propagation — reuse directly
+- Date diff logic (line 31-32): `dateDiffDays` calculation already exists
+- Description propagation (lines 106-111): Pattern to follow for category (but user-only)
+
+### Established Patterns
+- Pointer fields in `TransactionUpdateRequest`: nil means "don't change", non-nil means "set to this value"
+- `ErrorTag` system for fine-grained error categorization
+- `pkgErrors.NewWithTag` for creating domain-specific errors
+
+### Integration Points
+- `validateUpdateTransactionRequest` is the single entry point for update validation
+- The propagation loop (lines 76-150) is where field changes are applied to each transaction
+- `GetSourceTransactionIDs` is the mechanism to detect linked transactions
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- "Edit my side only" principle: linked transaction edits never affect the partner's data. Consistent with v1.2 silent skip approach for bulk actions.
+- Users have different categories, so category cannot propagate cross-user.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope
+
+</deferred>
+
+---
+
+*Phase: 11-backend-validation-propagation*
+*Context gathered: 2026-04-18*

--- a/.planning/phases/11-backend-validation-propagation/11-DISCUSSION-LOG.md
+++ b/.planning/phases/11-backend-validation-propagation/11-DISCUSSION-LOG.md
@@ -1,0 +1,80 @@
+# Phase 11: Backend Validation & Propagation - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-04-18
+**Phase:** 11-backend-validation-propagation
+**Areas discussed:** Validation strategy, Category propagation, Tags behavior, Edge cases
+
+---
+
+## Validation strategy
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Single error (Recommended) | One error like "linked transactions can only edit date, description, and category" | ✓ |
+| Per-field errors | Return separate error for each disallowed field | |
+| You decide | Claude picks approach fitting existing patterns | |
+
+**User's choice:** Single error
+**Notes:** Simple, clear, consistent with current error patterns.
+
+---
+
+## Category propagation
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Same as description (Recommended) | Copy category to all linked transactions | |
+| Only own side | Category only changes on user's transaction, not partner's | ✓ |
+| You decide | Claude picks based on existing code | |
+
+**User's choice:** Only own side — "it should propagate only for the user, because users have different categories"
+**Notes:** Users have different category sets, so cross-user category propagation doesn't make sense.
+
+---
+
+## Tags behavior
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Allow tags (Recommended) | Tags are personal metadata, let users edit on linked transactions | ✓ |
+| Restrict tags | Stick strictly to requirements (date, description, category only) | |
+
+**User's choice:** Allow tags
+**Notes:** Consistent with category being allowed — both are personal metadata.
+
+---
+
+## Edge cases — Propagation settings
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Same behavior (Recommended) | Propagation settings apply identically for linked transactions | |
+| Current only | Force propagation=current for linked transactions | |
+
+**User's choice:** Same behavior, but only for transactions the user owns — should not affect partner transactions
+**Notes:** "Edit my side only" principle established.
+
+## Edge cases — Partner date shifting
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Yes, shift partner dates (Recommended) | Keep existing behavior | |
+| Only own dates | Only shift editing user's installment dates | ✓ |
+
+**User's choice:** Only own dates
+**Notes:** Consistent with "edit my side only" principle.
+
+---
+
+## Claude's Discretion
+
+- Implementation approach for linked transaction detection
+- Refactoring strategy for validation check
+- Error tag naming
+
+## Deferred Ideas
+
+None

--- a/backend/internal/service/transaction_update.go
+++ b/backend/internal/service/transaction_update.go
@@ -345,9 +345,21 @@ func (s *transactionService) normalizeInstallments(_ context.Context, data *tran
 		}
 	}
 
+	// Determine the starting installment number to compute expected transaction count.
+	// For offset installments (e.g., current_installment=4, total=12), the first
+	// transaction has InstallmentNumber=4, and we expect 9 transactions (not 12).
+	minInstallment := 1
+	if data.transactions[0].InstallmentNumber != nil && *data.transactions[0].InstallmentNumber > 0 {
+		minInstallment = *data.transactions[0].InstallmentNumber
+	}
+	expectedCount := r.Installments - minInstallment + 1
+	if expectedCount < 0 {
+		expectedCount = 0
+	}
+
 	for i := range data.transactions {
 
-		if r.Installments >= i+1 {
+		if expectedCount >= i+1 {
 			continue
 		}
 
@@ -362,13 +374,15 @@ func (s *transactionService) normalizeInstallments(_ context.Context, data *tran
 
 	}
 
-	if r.Installments > len(data.transactions) {
+	if expectedCount > len(data.transactions) {
 		base := data.previousTransaction
-		for i := len(data.transactions); i < r.Installments; i++ {
+		lastInstallment := minInstallment + len(data.transactions) - 1
+		for i := len(data.transactions); i < expectedCount; i++ {
+			installmentNum := lastInstallment + (i - len(data.transactions)) + 1
 			baseDate := lo.CoalesceOrEmpty(data.req.Date, &base.Date)
 			data.transactions = append(data.transactions, &domain.Transaction{
 				ID:                      0,
-				InstallmentNumber:       lo.ToPtr(i + 1),
+				InstallmentNumber:       lo.ToPtr(installmentNum),
 				Date:                    s.incrementInstallmentDate(*baseDate, r.Type, i),
 				UserID:                  base.UserID,
 				OriginalUserID:          base.OriginalUserID,
@@ -808,9 +822,9 @@ func (s *transactionService) handlerRecurrenceUpdate(
 			return r, nil
 		}
 
-		// CurrentInstallment is intentionally ignored on updates — it only controls
-		// which installment number to start from during creation. On updates, all
-		// existing installments are renumbered sequentially by handlerRecurrenceUpdate.
+		// CurrentInstallment is only used when converting a standalone transaction
+		// to a recurrence (sets the starting offset). When the transaction already
+		// had a recurrence, existing installment numbers are preserved.
 		recurrence := domain.RecurrenceFromSettings(*data.req.RecurrenceSettings, userID)
 		if t.TransactionRecurrenceID != nil {
 			recurrence.ID = *t.TransactionRecurrenceID
@@ -843,7 +857,15 @@ func (s *transactionService) handlerRecurrenceUpdate(
 	for i := range data.transactions {
 		data.transactions[i].TransactionRecurrence = &r
 		data.transactions[i].TransactionRecurrenceID = &r.ID
-		data.transactions[i].InstallmentNumber = lo.ToPtr(i + 1)
+
+		if data.scenario.HadRecurrence {
+			// Preserve existing installment numbers — they already have the correct offset
+			// from creation (e.g., installments 4-12 for current_installment=4, total=12).
+		} else {
+			// Standalone → recurrence: number from CurrentInstallment.
+			startFrom := data.req.RecurrenceSettings.CurrentInstallment
+			data.transactions[i].InstallmentNumber = lo.ToPtr(startFrom + i)
+		}
 
 		for j := range data.transactions[i].LinkedTransactions {
 			rlt, err := upsertRecurrence(data.transactions[i].LinkedTransactions[j].UserID, data.transactions[i].LinkedTransactions[j])
@@ -853,7 +875,7 @@ func (s *transactionService) handlerRecurrenceUpdate(
 
 			data.transactions[i].LinkedTransactions[j].TransactionRecurrence = &rlt
 			data.transactions[i].LinkedTransactions[j].TransactionRecurrenceID = &rlt.ID
-			data.transactions[i].LinkedTransactions[j].InstallmentNumber = lo.ToPtr(i + 1)
+			data.transactions[i].LinkedTransactions[j].InstallmentNumber = data.transactions[i].InstallmentNumber
 		}
 	}
 

--- a/backend/internal/service/transaction_update.go
+++ b/backend/internal/service/transaction_update.go
@@ -374,11 +374,12 @@ func (s *transactionService) normalizeInstallments(_ context.Context, data *tran
 
 	}
 
-	if expectedCount > len(data.transactions) {
+	existingCount := len(data.transactions)
+	if expectedCount > existingCount {
 		base := data.previousTransaction
-		lastInstallment := minInstallment + len(data.transactions) - 1
-		for i := len(data.transactions); i < expectedCount; i++ {
-			installmentNum := lastInstallment + (i - len(data.transactions)) + 1
+		lastInstallment := minInstallment + existingCount - 1
+		for i := existingCount; i < expectedCount; i++ {
+			installmentNum := lastInstallment + (i - existingCount) + 1
 			baseDate := lo.CoalesceOrEmpty(data.req.Date, &base.Date)
 			data.transactions = append(data.transactions, &domain.Transaction{
 				ID:                      0,
@@ -858,13 +859,16 @@ func (s *transactionService) handlerRecurrenceUpdate(
 		data.transactions[i].TransactionRecurrence = &r
 		data.transactions[i].TransactionRecurrenceID = &r.ID
 
-		if data.scenario.HadRecurrence {
+		if data.scenario.HadRecurrence && !hasPastInstallments {
 			// Preserve existing installment numbers — they already have the correct offset
 			// from creation (e.g., installments 4-12 for current_installment=4, total=12).
-		} else {
+		} else if !data.scenario.HadRecurrence {
 			// Standalone → recurrence: number from CurrentInstallment.
 			startFrom := data.req.RecurrenceSettings.CurrentInstallment
 			data.transactions[i].InstallmentNumber = lo.ToPtr(startFrom + i)
+		} else {
+			// current_and_future with past installments: new recurrence, renumber from 1.
+			data.transactions[i].InstallmentNumber = lo.ToPtr(i + 1)
 		}
 
 		for j := range data.transactions[i].LinkedTransactions {

--- a/backend/internal/service/transaction_update_test.go
+++ b/backend/internal/service/transaction_update_test.go
@@ -3606,6 +3606,326 @@ func (suite *TransactionUpdateWithDBTestSuite) TestSettlementSync_PropagationAll
 	}
 }
 
+// TestOffsetInstallments_PropagationAll_PreservesNumbers: update a recurrence created with
+// current_installment=4, total=12 using propagation=all — installment numbers must stay 4-12.
+func (suite *TransactionUpdateWithDBTestSuite) TestOffsetInstallments_PropagationAll_PreservesNumbers() {
+	ctx := context.Background()
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	account, err := suite.createTestAccount(ctx, user)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, user)
+	suite.Require().NoError(err)
+
+	d := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+
+	_, err = suite.Services.Transaction.Create(ctx, user.ID, &domain.TransactionCreateRequest{
+		AccountID:       account.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          150000,
+		Date:            d,
+		Description:     "Offset installment test",
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 4,
+			TotalInstallments:  12,
+		},
+	})
+	suite.Require().NoError(err)
+
+	before, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(before, 9, "should create 9 installments (4 through 12)")
+	suite.Assert().Equal(4, lo.FromPtr(before[0].InstallmentNumber))
+	suite.Assert().Equal(12, lo.FromPtr(before[8].InstallmentNumber))
+
+	// Update description with propagation=all — should NOT change installment numbers or count
+	err = suite.Services.Transaction.Update(ctx, before[0].ID, user.ID, &domain.TransactionUpdateRequest{
+		Description:         lo.ToPtr("Updated description"),
+		PropagationSettings: domain.TransactionPropagationSettingsAll,
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 4,
+			TotalInstallments:  12,
+		},
+	})
+	suite.Require().NoError(err)
+
+	after, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(after, 9, "should still have 9 installments after update")
+
+	for i, t := range after {
+		expectedNum := 4 + i
+		suite.Assert().Equal(expectedNum, lo.FromPtr(t.InstallmentNumber), "installment[%d] should be %d", i, expectedNum)
+		suite.Assert().Equal("Updated description", t.Description, "installment[%d] description", i)
+	}
+
+	// Recurrence record should still have Installments=12
+	recurrences, err := suite.Repos.TransactionRecurrence.Search(ctx, domain.TransactionRecurrenceFilter{
+		IDs: []int{*after[0].TransactionRecurrenceID},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(12, recurrences[0].Installments)
+}
+
+// TestOffsetInstallments_PropagationAll_IncreaseTotalInstallments: increase total from 12 to 15
+// on a recurrence with current_installment=4 — should add 3 new installments (13, 14, 15).
+func (suite *TransactionUpdateWithDBTestSuite) TestOffsetInstallments_PropagationAll_IncreaseTotalInstallments() {
+	ctx := context.Background()
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	account, err := suite.createTestAccount(ctx, user)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, user)
+	suite.Require().NoError(err)
+
+	d := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+
+	_, err = suite.Services.Transaction.Create(ctx, user.ID, &domain.TransactionCreateRequest{
+		AccountID:       account.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          100,
+		Date:            d,
+		Description:     "Increase total test",
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 4,
+			TotalInstallments:  12,
+		},
+	})
+	suite.Require().NoError(err)
+
+	before, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(before, 9)
+
+	err = suite.Services.Transaction.Update(ctx, before[0].ID, user.ID, &domain.TransactionUpdateRequest{
+		PropagationSettings: domain.TransactionPropagationSettingsAll,
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 4,
+			TotalInstallments:  15,
+		},
+	})
+	suite.Require().NoError(err)
+
+	after, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(after, 12, "should have 12 installments (4 through 15)")
+	suite.Assert().Equal(4, lo.FromPtr(after[0].InstallmentNumber))
+	suite.Assert().Equal(15, lo.FromPtr(after[11].InstallmentNumber))
+
+	for i, t := range after {
+		suite.Assert().Equal(4+i, lo.FromPtr(t.InstallmentNumber), "installment[%d]", i)
+	}
+}
+
+// TestOffsetInstallments_PropagationAll_DecreaseTotalInstallments: decrease total from 12 to 8
+// on a recurrence with current_installment=4 — should keep 5 installments (4-8), remove 9-12.
+func (suite *TransactionUpdateWithDBTestSuite) TestOffsetInstallments_PropagationAll_DecreaseTotalInstallments() {
+	ctx := context.Background()
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	account, err := suite.createTestAccount(ctx, user)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, user)
+	suite.Require().NoError(err)
+
+	d := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+
+	_, err = suite.Services.Transaction.Create(ctx, user.ID, &domain.TransactionCreateRequest{
+		AccountID:       account.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          100,
+		Date:            d,
+		Description:     "Decrease total test",
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 4,
+			TotalInstallments:  12,
+		},
+	})
+	suite.Require().NoError(err)
+
+	before, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(before, 9)
+
+	err = suite.Services.Transaction.Update(ctx, before[0].ID, user.ID, &domain.TransactionUpdateRequest{
+		PropagationSettings: domain.TransactionPropagationSettingsAll,
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 4,
+			TotalInstallments:  8,
+		},
+	})
+	suite.Require().NoError(err)
+
+	after, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(after, 5, "should have 5 installments (4 through 8)")
+	suite.Assert().Equal(4, lo.FromPtr(after[0].InstallmentNumber))
+	suite.Assert().Equal(8, lo.FromPtr(after[4].InstallmentNumber))
+}
+
+// TestOffsetInstallments_StandaloneToRecurrenceWithOffset: standalone transaction converted to
+// recurrence with current_installment=4, total=12 — should create 9 installments numbered 4-12.
+func (suite *TransactionUpdateWithDBTestSuite) TestOffsetInstallments_StandaloneToRecurrenceWithOffset() {
+	ctx := context.Background()
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	account, err := suite.createTestAccount(ctx, user)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, user)
+	suite.Require().NoError(err)
+
+	d := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+
+	_, err = suite.Services.Transaction.Create(ctx, user.ID, &domain.TransactionCreateRequest{
+		AccountID:       account.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          100,
+		Date:            d,
+		Description:     "Standalone to recurrence test",
+	})
+	suite.Require().NoError(err)
+
+	standalone, err := suite.Repos.Transaction.SearchOne(ctx, domain.TransactionFilter{
+		UserID: &user.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Require().Nil(standalone.TransactionRecurrenceID)
+
+	err = suite.Services.Transaction.Update(ctx, standalone.ID, user.ID, &domain.TransactionUpdateRequest{
+		PropagationSettings: domain.TransactionPropagationSettingsAll,
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 4,
+			TotalInstallments:  12,
+		},
+	})
+	suite.Require().NoError(err)
+
+	after, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(after, 9, "should have 9 installments (4 through 12)")
+
+	for i, t := range after {
+		suite.Assert().Equal(4+i, lo.FromPtr(t.InstallmentNumber), "installment[%d] should be %d", i, 4+i)
+	}
+
+	suite.Assert().Equal(standalone.ID, after[0].ID, "first installment should be the original transaction")
+}
+
+// TestOffsetInstallments_WithSplit_PropagationAll: update a split expense with offset installments
+// — both user's and partner's installment numbers should be preserved.
+func (suite *TransactionUpdateWithDBTestSuite) TestOffsetInstallments_WithSplit_PropagationAll() {
+	ctx := context.Background()
+	userA, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	userB, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	accountA, err := suite.createTestAccount(ctx, userA)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, userA)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, userA.ID, userB.ID, 50)
+	suite.Require().NoError(err)
+
+	d := time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+
+	_, err = suite.Services.Transaction.Create(ctx, userA.ID, &domain.TransactionCreateRequest{
+		AccountID:       accountA.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          150000,
+		Date:            d,
+		Description:     "Split offset test",
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 4,
+			TotalInstallments:  12,
+		},
+		SplitSettings: []domain.SplitSettings{
+			{ConnectionID: conn.ID, Amount: lo.ToPtr(int64(60000))},
+		},
+	})
+	suite.Require().NoError(err)
+
+	beforeA, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(beforeA, 9, "userA should have 9 installments")
+
+	// Update description with propagation=all
+	err = suite.Services.Transaction.Update(ctx, beforeA[0].ID, userA.ID, &domain.TransactionUpdateRequest{
+		Description:         lo.ToPtr("Updated split offset"),
+		PropagationSettings: domain.TransactionPropagationSettingsAll,
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 4,
+			TotalInstallments:  12,
+		},
+		SplitSettings: []domain.SplitSettings{
+			{ConnectionID: conn.ID, Amount: lo.ToPtr(int64(60000))},
+		},
+	})
+	suite.Require().NoError(err)
+
+	afterA, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(afterA, 9, "userA should still have 9 installments")
+
+	for i, t := range afterA {
+		suite.Assert().Equal(4+i, lo.FromPtr(t.InstallmentNumber), "userA installment[%d]", i)
+		suite.Assert().Len(t.LinkedTransactions, 1, "userA installment[%d] should have 1 linked tx", i)
+		suite.Assert().Equal(4+i, lo.FromPtr(t.LinkedTransactions[0].InstallmentNumber), "userB linked installment[%d]", i)
+	}
+}
+
 func TestTransactionUpdateWithDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")


### PR DESCRIPTION
## Summary

- When transactions created with `current_installment > 1` (e.g., 4/12) were updated, `handlerRecurrenceUpdate` renumbered all installments from 1 and `normalizeInstallments` created extra installments to fill up to `total_installments`
- Now preserves existing installment numbers when recurrence already existed, and uses `CurrentInstallment` from request when converting standalone → recurrence
- Fixes the scenario where updating a 4/12 expense produced 12 installments numbered 1-12 instead of keeping 9 installments numbered 4-12

## Test plan

- [ ] Create expense with `current_installment=4, total_installments=12` → verify 9 installments (4-12)
- [ ] Update that expense (e.g., change description) with `propagation=all` → verify still 9 installments numbered 4-12
- [ ] Create standalone expense, update to add recurrence with `current_installment=3, total=10` → verify 8 installments (3-10)
- [ ] Update recurrence with `current_installment=1` (common case) → verify identical behavior to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)