### PR TITLE
fix: include settlements in net total when source tx account matches filter

### DIFF
--- a/backend/internal/domain/balance.go
+++ b/backend/internal/domain/balance.go
@@ -1,12 +1,13 @@
 package domain
 
 type BalanceFilter struct {
-	UserID      int
-	Period      Period
-	AccountIDs  []int `query:"account_id[]"`
-	CategoryIDs []int `query:"category_id[]"`
-	TagIDs      []int `query:"tag_id[]"`
-	Accumulated bool  `query:"accumulated"`
+	UserID          int
+	Period          Period
+	AccountIDs      []int `query:"account_id[]"`
+	CategoryIDs     []int `query:"category_id[]"`
+	TagIDs          []int `query:"tag_id[]"`
+	Accumulated     bool  `query:"accumulated"`
+	HideSettlements bool  `query:"hide_settlements"`
 }
 
 type BalanceResult struct {

--- a/backend/internal/handler/transaction_handler.go
+++ b/backend/internal/handler/transaction_handler.go
@@ -205,7 +205,8 @@ func (h *TransactionHandler) GetByID(c echo.Context) error {
 // @Param        account_id[]   query  []int  false  "Filter by account IDs"   collectionFormat(multi)
 // @Param        category_id[]  query  []int  false  "Filter by category IDs"  collectionFormat(multi)
 // @Param        tag_id[]       query  []int  false  "Filter by tag IDs"       collectionFormat(multi)
-// @Param        accumulated    query  bool   false  "Include all prior periods"
+// @Param        accumulated       query  bool   false  "Include all prior periods"
+// @Param        hide_settlements  query  bool   false  "Exclude settlements from balance"
 // @Success      200  {object}  domain.BalanceResult
 // @Failure      400  {object}  middleware.ErrorResponse
 // @Failure      401  {object}  middleware.ErrorResponse

--- a/backend/internal/repository/transaction_repository.go
+++ b/backend/internal/repository/transaction_repository.go
@@ -353,41 +353,61 @@ func (r *transactionRepository) GetBalance(ctx context.Context, filter domain.Ba
 		args = append(args, filter.TagIDs)
 	}
 
-	// Settlements leg — filtered by account_id only (no category/tag columns on settlements)
-	settlementSQL := `SELECT CASE WHEN s.type = 'credit' THEN s.amount ELSE -s.amount END AS amount
-		FROM settlements s
-		JOIN transactions t ON t.id = s.source_transaction_id
-		WHERE s.user_id = ? AND t.date <= ?`
-	args = append(args, filter.UserID, endDate)
-
-	if !filter.Accumulated {
-		startDate := filter.Period.StartDate()
-		settlementSQL += " AND t.date >= ?"
-		args = append(args, startDate)
-	}
-
-	if len(filter.AccountIDs) > 0 {
-		settlementSQL += " AND s.account_id IN ?"
-		args = append(args, filter.AccountIDs)
-	}
-
 	var combined string
-	if filter.Accumulated {
-		initialBalanceSQL := `SELECT initial_balance AS amount FROM accounts WHERE user_id = ?`
-		args = append(args, filter.UserID)
-		if len(filter.AccountIDs) > 0 {
-			initialBalanceSQL += " AND id IN ?"
-			args = append(args, filter.AccountIDs)
+	if filter.HideSettlements {
+		if filter.Accumulated {
+			initialBalanceSQL := `SELECT initial_balance AS amount FROM accounts WHERE user_id = ?`
+			args = append(args, filter.UserID)
+			if len(filter.AccountIDs) > 0 {
+				initialBalanceSQL += " AND id IN ?"
+				args = append(args, filter.AccountIDs)
+			}
+			combined = fmt.Sprintf(
+				"SELECT COALESCE(SUM(amount), 0) FROM ((%s) UNION ALL (%s)) combined",
+				txSQL, initialBalanceSQL,
+			)
+		} else {
+			combined = fmt.Sprintf(
+				"SELECT COALESCE(SUM(amount), 0) FROM (%s) combined",
+				txSQL,
+			)
 		}
-		combined = fmt.Sprintf(
-			"SELECT COALESCE(SUM(amount), 0) FROM ((%s) UNION ALL (%s) UNION ALL (%s)) combined",
-			txSQL, settlementSQL, initialBalanceSQL,
-		)
 	} else {
-		combined = fmt.Sprintf(
-			"SELECT COALESCE(SUM(amount), 0) FROM ((%s) UNION ALL (%s)) combined",
-			txSQL, settlementSQL,
-		)
+		// Settlements leg — filtered by account_id only (no category/tag columns on settlements)
+		settlementSQL := `SELECT CASE WHEN s.type = 'credit' THEN s.amount ELSE -s.amount END AS amount
+			FROM settlements s
+			JOIN transactions t ON t.id = s.source_transaction_id
+			WHERE s.user_id = ? AND t.date <= ?`
+		args = append(args, filter.UserID, endDate)
+
+		if !filter.Accumulated {
+			startDate := filter.Period.StartDate()
+			settlementSQL += " AND t.date >= ?"
+			args = append(args, startDate)
+		}
+
+		if len(filter.AccountIDs) > 0 {
+			settlementSQL += " AND (s.account_id IN ? OR t.account_id IN ?)"
+			args = append(args, filter.AccountIDs, filter.AccountIDs)
+		}
+
+		if filter.Accumulated {
+			initialBalanceSQL := `SELECT initial_balance AS amount FROM accounts WHERE user_id = ?`
+			args = append(args, filter.UserID)
+			if len(filter.AccountIDs) > 0 {
+				initialBalanceSQL += " AND id IN ?"
+				args = append(args, filter.AccountIDs)
+			}
+			combined = fmt.Sprintf(
+				"SELECT COALESCE(SUM(amount), 0) FROM ((%s) UNION ALL (%s) UNION ALL (%s)) combined",
+				txSQL, settlementSQL, initialBalanceSQL,
+			)
+		} else {
+			combined = fmt.Sprintf(
+				"SELECT COALESCE(SUM(amount), 0) FROM ((%s) UNION ALL (%s)) combined",
+				txSQL, settlementSQL,
+			)
+		}
 	}
 
 	var balance int64

--- a/backend/internal/service/transaction_balance_test.go
+++ b/backend/internal/service/transaction_balance_test.go
@@ -418,11 +418,12 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_UpdateSplitExpens
 	})
 	suite.Require().NoError(err)
 
+	// personal1 filter: expense -6000 + settlement credit +3000 (source tx on personal1) = -3000
 	resultAccount1, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
 		AccountIDs: []int{personal1.ID},
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(-6000), resultAccount1.Balance)
+	suite.Assert().Equal(int64(-3000), resultAccount1.Balance)
 
 	// after update, settlement must still land on conn.FromAccountID, not on personal1
 	resultConn, err = suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
@@ -484,12 +485,12 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_SplitExpense_ByTo
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(-500), result1.Balance)
 
-	// user2 personal account: -1000
+	// user2 personal account: expense -1000 + settlement credit +500 (source tx on personal2) = -500
 	result2Personal, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{
 		AccountIDs: []int{personal2.ID},
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(-1000), result2Personal.Balance)
+	suite.Assert().Equal(int64(-500), result2Personal.Balance)
 
 	// user2 connection account (ToAccountID): +500 (settlement credit)
 	result2Conn, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{
@@ -621,12 +622,12 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_SplitExpense_ByTo
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(-2000), result1.Balance)
 
-	// user2 personal: -4000
+	// user2 personal: expense -4000 + settlement credit +2000 (source tx on personal2) = -2000
 	result2Personal, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{
 		AccountIDs: []int{personal2.ID},
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(-4000), result2Personal.Balance)
+	suite.Assert().Equal(int64(-2000), result2Personal.Balance)
 
 	// user2 connection account: +2000 (settlement credit after update)
 	result2Conn, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{

--- a/backend/internal/service/transaction_create_test.go
+++ b/backend/internal/service/transaction_create_test.go
@@ -1108,15 +1108,15 @@ func (suite *TransactionCreateWithDBTestSuite) TestSearchSharedExpenseByFromAcco
 	suite.Assert().Equal(userConnection.FromAccountID, personal.SettlementsFromSource[0].AccountID, "preloaded settlement keeps its own account_id so the frontend can decide to exclude it from the group sum")
 
 	// Case 2b (balance consistency): GetBalance filtered by the personal
-	// account must return exactly the source transaction's contribution
-	// (-amount) — the settlement is NOT part of this leg because its
-	// account_id isn't in the filter. The frontend's group-total must match
-	// this value after excluding out-of-scope nested settlements.
+	// account returns the source transaction plus the settlement whose source
+	// tx lives on that account — this matches the frontend's group-total
+	// behavior, which includes nested settlements when the source tx is in
+	// the filter.
 	balancePersonal, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
 		AccountIDs: []int{account.ID},
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(-amount, balancePersonal.Balance, "personal-only balance must equal just the source tx amount; nested settlement stays informational")
+	suite.Assert().Equal(-amount+amount/2, balancePersonal.Balance, "personal-only balance equals source tx amount plus in-scope settlement credit")
 
 	// Case 3: user1 filters by BOTH personal AND shared accounts — the source
 	// transaction is in the filter AND the settlement's account is in the

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -30,6 +30,9 @@ export async function fetchBalance(params: Transactions.FetchBalanceParams): Pro
   if (params.tagIds?.length) {
     params.tagIds.forEach((id) => url.searchParams.append("tag_id[]", String(id)));
   }
+  if (params.hideSettlements) {
+    url.searchParams.set("hide_settlements", "true");
+  }
 
   const res = await fetch(url.toString(), { credentials: "include" });
   if (!res.ok) throw new Error("Failed to fetch balance");

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -21,11 +21,6 @@ function groupNetTotal(
   hideSettlements: boolean,
   accountFilter: number[],
 ): number {
-  // When an account filter is active, only settlements bound to one of the
-  // filtered accounts contribute to the net total. Out-of-scope settlements
-  // are still rendered inline under their source transaction as context, but
-  // they do not move the balance — this keeps the listing total consistent
-  // with GetBalance, whose settlements leg is filtered by s.account_id.
   const hasAccountFilter = accountFilter.length > 0;
   const filterSet = hasAccountFilter ? new Set(accountFilter) : null;
 
@@ -34,7 +29,8 @@ function groupNetTotal(
     const settlementsAmount = hideSettlements
       ? 0
       : (tx.settlements_from_source ?? []).reduce((s, settlement) => {
-          if (filterSet && !filterSet.has(settlement.account_id)) {
+          // Include settlement if: no account filter, OR source tx account matches, OR settlement account matches
+          if (filterSet && !filterSet.has(tx.account_id) && !filterSet.has(settlement.account_id)) {
             return s;
           }
           return s + (settlement.type === "credit" ? settlement.amount : -settlement.amount);
@@ -56,6 +52,7 @@ export function TransactionList({ currentUserId, selectedIds, onSelectTransactio
     month: search.month,
     year: search.year,
     accumulated: search.accumulated,
+    hideSettlements: search.hideSettlements,
   });
 
   const { query: accountsQuery } = useAccounts();

--- a/frontend/src/hooks/useOpeningBalance.ts
+++ b/frontend/src/hooks/useOpeningBalance.ts
@@ -7,18 +7,19 @@ interface UseOpeningBalanceParams {
   month: number
   year: number
   accumulated: boolean
+  hideSettlements?: boolean
 }
 
-export function useOpeningBalance({ month, year, accumulated }: UseOpeningBalanceParams) {
+export function useOpeningBalance({ month, year, accumulated, hideSettlements }: UseOpeningBalanceParams) {
   const filters = useActiveFilters()
 
   const prevMonth = month === 1 ? 12 : month - 1
   const prevYear = month === 1 ? year - 1 : year
 
   const query = useQuery({
-    queryKey: [QueryKeys.Balance, { month: prevMonth, year: prevYear, accumulated, ...filters }],
+    queryKey: [QueryKeys.Balance, { month: prevMonth, year: prevYear, accumulated, hideSettlements, ...filters }],
     queryFn: () =>
-      fetchBalance({ month: prevMonth, year: prevYear, accumulated, ...filters }),
+      fetchBalance({ month: prevMonth, year: prevYear, accumulated, hideSettlements, ...filters }),
     enabled: accumulated,
   })
 

--- a/frontend/src/types/transactions.ts
+++ b/frontend/src/types/transactions.ts
@@ -134,6 +134,7 @@ export namespace Transactions {
     accountIds?: number[];
     categoryIds?: number[];
     tagIds?: number[];
+    hideSettlements?: boolean;
   }
 
   export interface BalanceResult {


### PR DESCRIPTION
## Summary
- Settlement inclusion in `groupNetTotal` (frontend) and `GetBalance` (backend) now considers both the settlement's `account_id` AND the source transaction's `account_id` when an account filter is active
- Added `hide_settlements` query param to `GetBalance` endpoint — when true, settlements are excluded from the balance calculation entirely
- Frontend passes `hideSettlements` to the balance API so running balance stays consistent with the visible transaction list

## Test plan
- [ ] Filter by account, verify settlements from source transactions on that account are included in group totals
- [ ] Filter by account, verify settlements whose own account matches are also included
- [ ] Toggle "hide settlements" ON, verify settlements excluded from both group totals and balance
- [ ] No account filter, verify all settlements included as before
- [ ] Accumulated balance with `hide_settlements=true` still includes initial account balances

🤖 Generated with [Claude Code](https://claude.com/claude-code)