### PR TITLE
fix(transactions): edit origin side of same-user transfers

### DIFF
--- a/frontend/e2e/tests/transfer-transaction.spec.ts
+++ b/frontend/e2e/tests/transfer-transaction.spec.ts
@@ -87,7 +87,10 @@ test.describe('Transfer Transactions', () => {
     // target to the debit (origin) side, so the form is populated with the
     // source account as "Conta" and destination account as "Conta de destino"
     // — not the other way around.
-    await page.locator(`[data-transaction-id="${creditSideId}"]`).click()
+    await page
+      .locator(`[data-transaction-id="${creditSideId}"]`)
+      .getByText(description)
+      .click()
     await transactionsPage.waitForUpdateDrawer()
 
     await expect(

--- a/frontend/e2e/tests/transfer-transaction.spec.ts
+++ b/frontend/e2e/tests/transfer-transaction.spec.ts
@@ -1,6 +1,12 @@
 import { test, expect } from '@playwright/test'
 import { TransactionsPage } from '../pages/TransactionsPage'
-import { apiCreateAccount, apiDeleteAccount, apiCreateTransaction, apiDeleteTransaction } from '../helpers/api'
+import {
+  apiCreateAccount,
+  apiDeleteAccount,
+  apiCreateTransaction,
+  apiDeleteTransaction,
+  apiGetTransaction,
+} from '../helpers/api'
 
 test.describe('Transfer Transactions', () => {
   let transactionsPage: TransactionsPage
@@ -52,6 +58,57 @@ test.describe('Transfer Transactions', () => {
     await expect(page.getByTestId('select_destination_account')).toBeVisible()
     // Category selector must NOT appear for transfers
     await expect(page.getByTestId('select_category')).not.toBeVisible()
+  })
+
+  test('editing the credit side of a same-user transfer opens the debit (origin) side', async ({ page }) => {
+    const today = new Date().toISOString().slice(0, 10)
+    const description = `Transfer Origin ${Date.now()}`
+
+    const tx = await apiCreateTransaction({
+      transaction_type: 'transfer',
+      account_id: sourceAccountId,
+      destination_account_id: destAccountId,
+      amount: 5000, // R$ 50,00
+      date: today,
+      description,
+    })
+    createdTransactionIds.push(tx.id)
+
+    // apiCreateTransaction returns the debit-side id; fetch to resolve the
+    // linked credit-side id so we can click that specific row.
+    const debitSide = await apiGetTransaction(tx.id)
+    const creditSideId = debitSide.linked_transactions?.[0]?.id
+    expect(creditSideId, 'expected credit-side linked transaction').toBeTruthy()
+
+    await transactionsPage.goto()
+    await expect(page.getByText(description).first()).toBeVisible()
+
+    // Click the credit-side (destination) row. The fix should swap the edit
+    // target to the debit (origin) side, so the form is populated with the
+    // source account as "Conta" and destination account as "Conta de destino"
+    // — not the other way around.
+    await page.locator(`[data-transaction-id="${creditSideId}"]`).click()
+    await transactionsPage.waitForUpdateDrawer()
+
+    await expect(
+      transactionsPage.updateDrawer.getByTestId('select_account'),
+    ).toHaveValue(sourceAccountName)
+    await expect(
+      transactionsPage.updateDrawer.getByTestId('select_destination_account'),
+    ).toHaveValue(destAccountName)
+
+    // Change a restricted-on-linked-tx field (amount). Without the fix, the
+    // drawer would have loaded the credit-side transaction and the backend
+    // would reject this save as a linked-transaction edit.
+    await transactionsPage.clearAndFillAmount(8800) // R$ 88,00
+    await transactionsPage.submitUpdate()
+
+    await expect(
+      page.locator(`[data-transaction-id="${tx.id}"]`).getByText(/88,00/),
+    ).toBeVisible({ timeout: 8000 })
+    await expect(
+      page.locator(`[data-transaction-id="${creditSideId}"]`).getByText(/88,00/),
+    ).toBeVisible({ timeout: 8000 })
   })
 
   test('update transfer description', async ({ page }) => {

--- a/frontend/e2e/tests/transfer-transaction.spec.ts
+++ b/frontend/e2e/tests/transfer-transaction.spec.ts
@@ -106,11 +106,17 @@ test.describe('Transfer Transactions', () => {
     await transactionsPage.clearAndFillAmount(8800) // R$ 88,00
     await transactionsPage.submitUpdate()
 
+    // Updating the amount rebuilds the credit-side linked transaction with a
+    // new id, so re-fetch the debit side to resolve the current credit id.
+    const updatedDebit = await apiGetTransaction(tx.id)
+    const newCreditSideId = updatedDebit.linked_transactions?.[0]?.id
+    expect(newCreditSideId, 'expected new credit-side linked transaction').toBeTruthy()
+
     await expect(
       page.locator(`[data-transaction-id="${tx.id}"]`).getByText(/88,00/),
     ).toBeVisible({ timeout: 8000 })
     await expect(
-      page.locator(`[data-transaction-id="${creditSideId}"]`).getByText(/88,00/),
+      page.locator(`[data-transaction-id="${newCreditSideId}"]`).getByText(/88,00/),
     ).toBeVisible({ timeout: 8000 })
   })
 

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -64,6 +64,12 @@ export async function fetchTransactions(params: Transactions.FetchParams): Promi
   return res.json();
 }
 
+export async function fetchTransaction(id: number): Promise<Transactions.Transaction> {
+  const res = await fetch(`${apiUrl}/api/transactions/${id}`, { credentials: "include" });
+  if (!res.ok) throw new Error("Failed to fetch transaction");
+  return res.json();
+}
+
 export async function fetchTransactionSuggestions(
   q: string,
   limit = 10,

--- a/frontend/src/components/transactions/TransactionGroup.tsx
+++ b/frontend/src/components/transactions/TransactionGroup.tsx
@@ -10,6 +10,18 @@ import { UpdateTransactionDrawer } from "./UpdateTransactionDrawer";
 import { FocusField } from "./form/TransactionForm";
 import classes from "./TransactionGroup.module.css";
 
+// For transfers between accounts of the same user, the debit side is the
+// origin; editing the credit side is rejected by the backend as a linked
+// transaction edit. Always route edits through the origin.
+function resolveTransferEditTarget(
+  tx: Transactions.Transaction
+): Transactions.Transaction {
+  if (tx.type !== "transfer" || tx.operation_type !== "credit") return tx;
+  const linked = tx.linked_transactions?.[0];
+  if (!linked || linked.user_id !== tx.user_id) return tx;
+  return linked;
+}
+
 interface TransactionGroupProps {
   group: Transactions.TransactionGroup;
   groupBy: Transactions.GroupBy;
@@ -43,8 +55,9 @@ export function TransactionGroup({
     tx: Transactions.Transaction,
     focusField?: FocusField
   ) {
+    const target = resolveTransferEditTarget(tx);
     void renderDrawer(() => (
-      <UpdateTransactionDrawer transaction={tx} focusField={focusField} />
+      <UpdateTransactionDrawer transaction={target} focusField={focusField} />
     ));
   }
 

--- a/frontend/src/components/transactions/TransactionGroup.tsx
+++ b/frontend/src/components/transactions/TransactionGroup.tsx
@@ -1,5 +1,7 @@
 import { Box, Group, Text } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
 import { Fragment } from "react";
+import { fetchTransaction } from "@/api/transactions";
 import { Transactions } from "@/types/transactions";
 import { formatBalance, formatSignedCents } from "@/utils/formatCents";
 import { renderDrawer } from "@/utils/renderDrawer";
@@ -14,17 +16,15 @@ import classes from "./TransactionGroup.module.css";
 // origin; editing the credit side is rejected by the backend as a linked
 // transaction edit. Always route edits through the origin.
 //
-// The list endpoint only preloads linked_transactions one level deep, so the
-// debit tx reached via `credit.linked_transactions[0]` has an empty
-// linked_transactions of its own. Reattach the original credit-side tx so
-// the update drawer can still derive the destination account from it.
-function resolveTransferEditTarget(
-  tx: Transactions.Transaction
-): Transactions.Transaction {
-  if (tx.type !== "transfer" || tx.operation_type !== "credit") return tx;
+// The linked relationship is stored unidirectionally (debit → credit), so the
+// credit-side row carries only a shallow reference to the debit side. Fetch
+// the debit tx fresh so its own linked_transactions resolve the destination
+// account in the edit drawer.
+function needsFetchToDebitOrigin(tx: Transactions.Transaction): number | null {
+  if (tx.type !== "transfer" || tx.operation_type !== "credit") return null;
   const linked = tx.linked_transactions?.[0];
-  if (!linked || linked.user_id !== tx.user_id) return tx;
-  return { ...linked, linked_transactions: [tx] };
+  if (!linked || linked.user_id !== tx.user_id) return null;
+  return linked.id;
 }
 
 interface TransactionGroupProps {
@@ -60,10 +60,38 @@ export function TransactionGroup({
     tx: Transactions.Transaction,
     focusField?: FocusField
   ) {
-    const target = resolveTransferEditTarget(tx);
-    void renderDrawer(() => (
-      <UpdateTransactionDrawer transaction={target} focusField={focusField} />
-    ));
+    const debitId = needsFetchToDebitOrigin(tx);
+    if (debitId == null) {
+      void renderDrawer(() => (
+        <UpdateTransactionDrawer transaction={tx} focusField={focusField} />
+      ));
+      return;
+    }
+
+    const notifId = notifications.show({
+      loading: true,
+      title: "Carregando transação...",
+      message: "",
+      autoClose: false,
+      withCloseButton: false,
+    });
+    fetchTransaction(debitId)
+      .then((debit) => {
+        notifications.hide(notifId);
+        void renderDrawer(() => (
+          <UpdateTransactionDrawer transaction={debit} focusField={focusField} />
+        ));
+      })
+      .catch(() => {
+        notifications.update({
+          id: notifId,
+          loading: false,
+          color: "red",
+          title: "Erro",
+          message: "Não foi possível carregar a transação",
+          autoClose: 3000,
+        });
+      });
   }
 
   return (

--- a/frontend/src/components/transactions/TransactionGroup.tsx
+++ b/frontend/src/components/transactions/TransactionGroup.tsx
@@ -13,13 +13,18 @@ import classes from "./TransactionGroup.module.css";
 // For transfers between accounts of the same user, the debit side is the
 // origin; editing the credit side is rejected by the backend as a linked
 // transaction edit. Always route edits through the origin.
+//
+// The list endpoint only preloads linked_transactions one level deep, so the
+// debit tx reached via `credit.linked_transactions[0]` has an empty
+// linked_transactions of its own. Reattach the original credit-side tx so
+// the update drawer can still derive the destination account from it.
 function resolveTransferEditTarget(
   tx: Transactions.Transaction
 ): Transactions.Transaction {
   if (tx.type !== "transfer" || tx.operation_type !== "credit") return tx;
   const linked = tx.linked_transactions?.[0];
   if (!linked || linked.user_id !== tx.user_id) return tx;
-  return linked;
+  return { ...linked, linked_transactions: [tx] };
 }
 
 interface TransactionGroupProps {


### PR DESCRIPTION
Opening the credit side of a same-user transfer in the edit drawer triggers
the backend's linked-transaction edit restriction. Resolve to the debit
(origin) side before opening so the full set of fields remains editable.

Closes #73