### PR TITLE
feat(charges): allow arbitrary amount on charge creation

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2274,6 +2274,17 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.ChargeInitiatorRole": {
+            "type": "string",
+            "enum": [
+                "charger",
+                "payer"
+            ],
+            "x-enum-varnames": [
+                "ChargeInitiatorRoleCharger",
+                "ChargeInitiatorRolePayer"
+            ]
+        },
         "domain.CreateChargeRequest": {
             "type": "object",
             "properties": {
@@ -2297,6 +2308,9 @@ const docTemplate = `{
                 },
                 "period_year": {
                     "type": "integer"
+                },
+                "role": {
+                    "$ref": "#/definitions/domain.ChargeInitiatorRole"
                 }
             }
         },

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2195,6 +2195,9 @@ const docTemplate = `{
         "domain.Charge": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "integer"
+                },
                 "charger_account_id": {
                     "type": "integer"
                 },
@@ -2274,6 +2277,9 @@ const docTemplate = `{
         "domain.CreateChargeRequest": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "integer"
+                },
                 "connection_id": {
                     "type": "integer"
                 },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2189,6 +2189,9 @@
         "domain.Charge": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "integer"
+                },
                 "charger_account_id": {
                     "type": "integer"
                 },
@@ -2268,6 +2271,9 @@
         "domain.CreateChargeRequest": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "integer"
+                },
                 "connection_id": {
                     "type": "integer"
                 },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2268,6 +2268,17 @@
                 }
             }
         },
+        "domain.ChargeInitiatorRole": {
+            "type": "string",
+            "enum": [
+                "charger",
+                "payer"
+            ],
+            "x-enum-varnames": [
+                "ChargeInitiatorRoleCharger",
+                "ChargeInitiatorRolePayer"
+            ]
+        },
         "domain.CreateChargeRequest": {
             "type": "object",
             "properties": {
@@ -2291,6 +2302,9 @@
                 },
                 "period_year": {
                     "type": "integer"
+                },
+                "role": {
+                    "$ref": "#/definitions/domain.ChargeInitiatorRole"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -60,6 +60,8 @@ definitions:
     type: object
   domain.Charge:
     properties:
+      amount:
+        type: integer
       charger_account_id:
         type: integer
       charger_user_id:
@@ -115,6 +117,8 @@ definitions:
     type: object
   domain.CreateChargeRequest:
     properties:
+      amount:
+        type: integer
       connection_id:
         type: integer
       date:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -115,6 +115,14 @@ definitions:
       description:
         type: string
     type: object
+  domain.ChargeInitiatorRole:
+    enum:
+      - charger
+      - payer
+    type: string
+    x-enum-varnames:
+      - ChargeInitiatorRoleCharger
+      - ChargeInitiatorRolePayer
   domain.CreateChargeRequest:
     properties:
       amount:
@@ -131,6 +139,8 @@ definitions:
         type: integer
       period_year:
         type: integer
+      role:
+        $ref: '#/definitions/domain.ChargeInitiatorRole'
     type: object
   domain.DeleteCategoryRequest:
     properties:

--- a/backend/internal/domain/charge.go
+++ b/backend/internal/domain/charge.go
@@ -21,6 +21,17 @@ func (s ChargeStatus) IsValid() bool {
 
 var ErrInvalidStatusTransition = errors.New("invalid charge status transition")
 
+type ChargeInitiatorRole string
+
+const (
+	ChargeInitiatorRoleCharger ChargeInitiatorRole = "charger"
+	ChargeInitiatorRolePayer   ChargeInitiatorRole = "payer"
+)
+
+func (r ChargeInitiatorRole) IsValid() bool {
+	return r == ChargeInitiatorRoleCharger || r == ChargeInitiatorRolePayer
+}
+
 type Charge struct {
 	ID               int          `json:"id"`
 	ChargerUserID    int          `json:"charger_user_id"`
@@ -60,13 +71,14 @@ type ChargeSearchOptions struct {
 }
 
 type CreateChargeRequest struct {
-	ConnectionID int       `json:"connection_id"`
-	MyAccountID  int       `json:"my_account_id"`
-	PeriodMonth  int       `json:"period_month"`
-	PeriodYear   int       `json:"period_year"`
-	Description  *string   `json:"description"`
-	Amount       *int64    `json:"amount,omitempty"`
-	Date         time.Time `json:"date"`
+	ConnectionID int                  `json:"connection_id"`
+	MyAccountID  int                  `json:"my_account_id"`
+	PeriodMonth  int                  `json:"period_month"`
+	PeriodYear   int                  `json:"period_year"`
+	Description  *string              `json:"description"`
+	Amount       *int64               `json:"amount,omitempty"`
+	Role         *ChargeInitiatorRole `json:"role,omitempty"`
+	Date         time.Time            `json:"date"`
 }
 
 type AcceptChargeRequest struct {

--- a/backend/internal/domain/charge.go
+++ b/backend/internal/domain/charge.go
@@ -31,6 +31,7 @@ type Charge struct {
 	PeriodMonth      int          `json:"period_month"`
 	PeriodYear       int          `json:"period_year"`
 	Description      *string      `json:"description"`
+	Amount           *int64       `json:"amount,omitempty"`
 	Status           ChargeStatus `json:"status"`
 	Date             *time.Time   `json:"date"`
 	CreatedAt        *time.Time   `json:"created_at"`
@@ -64,6 +65,7 @@ type CreateChargeRequest struct {
 	PeriodMonth  int       `json:"period_month"`
 	PeriodYear   int       `json:"period_year"`
 	Description  *string   `json:"description"`
+	Amount       *int64    `json:"amount,omitempty"`
 	Date         time.Time `json:"date"`
 }
 

--- a/backend/internal/entity/charge.go
+++ b/backend/internal/entity/charge.go
@@ -17,6 +17,7 @@ type Charge struct {
 	PeriodMonth      int                 `gorm:"not null"`
 	PeriodYear       int                 `gorm:"not null"`
 	Description      *string
+	Amount           *int64
 	Status           domain.ChargeStatus `gorm:"not null"`
 	Date             *time.Time
 	CreatedAt        *time.Time
@@ -46,6 +47,7 @@ func (c *Charge) ToDomain() *domain.Charge {
 		PeriodMonth:      c.PeriodMonth,
 		PeriodYear:       c.PeriodYear,
 		Description:      c.Description,
+		Amount:           c.Amount,
 		Status:           c.Status,
 		Date:             c.Date,
 		CreatedAt:        c.CreatedAt,
@@ -64,6 +66,7 @@ func ChargeFromDomain(d *domain.Charge) *Charge {
 		PeriodMonth:      d.PeriodMonth,
 		PeriodYear:       d.PeriodYear,
 		Description:      d.Description,
+		Amount:           d.Amount,
 		Status:           d.Status,
 		Date:             d.Date,
 		CreatedAt:        d.CreatedAt,

--- a/backend/internal/service/charge_accept.go
+++ b/backend/internal/service/charge_accept.go
@@ -61,6 +61,10 @@ func (s *chargeService) Accept(ctx context.Context, callerUserID int, chargeID i
 		return pkgErrors.Forbidden("only the non-initiating party can accept")
 	}
 
+	if err := s.validatePrivateAccount(ctx, req.AccountID, callerUserID); err != nil {
+		return err
+	}
+
 	// ---- Status precondition ----
 	if charge.Status != domain.ChargeStatusPending {
 		return pkgErrors.AlreadyExists("charge")

--- a/backend/internal/service/charge_accept.go
+++ b/backend/internal/service/charge_accept.go
@@ -125,11 +125,15 @@ func (s *chargeService) Accept(ctx context.Context, callerUserID int, chargeID i
 		}
 	}
 
-	// Resolve settlement amount
+	// Resolve settlement amount.
+	// Priority: accept-time override → stored arbitrary amount → live balance.
 	var amount int64
-	if req.Amount != nil {
+	switch {
+	case req.Amount != nil:
 		amount = *req.Amount
-	} else {
+	case charge.Amount != nil:
+		amount = *charge.Amount
+	default:
 		if liveBalance == 0 {
 			return pkgErrors.BadRequest("nothing to settle — balance is zero")
 		}

--- a/backend/internal/service/charge_service.go
+++ b/backend/internal/service/charge_service.go
@@ -12,6 +12,7 @@ type chargeService struct {
 	chargeRepo         repository.ChargeRepository
 	userConnectionRepo repository.UserConnectionRepository
 	transactionRepo    repository.TransactionRepository
+	accountRepo        repository.AccountRepository
 	dbTransaction      repository.DBTransaction
 	services           *Services
 }
@@ -21,9 +22,31 @@ func NewChargeService(repos *repository.Repositories, services *Services) Charge
 		chargeRepo:         repos.Charge,
 		userConnectionRepo: repos.UserConnection,
 		transactionRepo:    repos.Transaction,
+		accountRepo:        repos.Account,
 		dbTransaction:      repos.DBTransaction,
 		services:           services,
 	}
+}
+
+// validatePrivateAccount ensures the given account belongs to userID and is
+// NOT linked to a connection. Charges may only settle against private
+// (non-shared) accounts — connection accounts are the internal ledger used
+// for settlement transfers.
+func (s *chargeService) validatePrivateAccount(ctx context.Context, accountID, userID int) error {
+	accs, err := s.accountRepo.Search(ctx, domain.AccountSearchOptions{
+		IDs:     []int{accountID},
+		UserIDs: []int{userID},
+	})
+	if err != nil {
+		return pkgErrors.Internal("failed to fetch account", err)
+	}
+	if len(accs) == 0 {
+		return pkgErrors.NotFound("account")
+	}
+	if accs[0].UserConnection != nil {
+		return pkgErrors.BadRequest("account linked to a connection cannot be used for charges")
+	}
+	return nil
 }
 
 func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domain.CreateChargeRequest) (*domain.Charge, error) {
@@ -73,6 +96,10 @@ func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domai
 		otherPartyID = conn.ToUserID
 	} else {
 		otherPartyID = conn.FromUserID
+	}
+
+	if err := s.validatePrivateAccount(ctx, req.MyAccountID, callerUserID); err != nil {
+		return nil, err
 	}
 
 	callerIsCharger := *req.Role == domain.ChargeInitiatorRoleCharger

--- a/backend/internal/service/charge_service.go
+++ b/backend/internal/service/charge_service.go
@@ -43,6 +43,9 @@ func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domai
 	if req.Amount != nil && *req.Amount <= 0 {
 		return nil, pkgErrors.BadRequest("amount must be greater than zero")
 	}
+	if req.Role != nil && !req.Role.IsValid() {
+		return nil, pkgErrors.BadRequest("role must be 'charger' or 'payer'")
+	}
 
 	// Fetch connection
 	conns, err := s.userConnectionRepo.Search(ctx, domain.UserConnectionSearchOptions{
@@ -86,6 +89,21 @@ func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domai
 		return nil, pkgErrors.Internal("failed to compute balance", err)
 	}
 
+	// Role resolution — explicit role wins over balance inference.
+	// When unset, fall back to balance sign; zero balance requires either a
+	// role or the legacy "cannot create" error so intent stays unambiguous.
+	var callerIsCharger bool
+	switch {
+	case req.Role != nil:
+		callerIsCharger = *req.Role == domain.ChargeInitiatorRoleCharger
+	case balResult.Balance > 0:
+		callerIsCharger = true
+	case balResult.Balance < 0:
+		callerIsCharger = false
+	default:
+		return nil, pkgErrors.BadRequest("cannot infer role with zero balance; provide 'role'")
+	}
+
 	charge := &domain.Charge{
 		ConnectionID: req.ConnectionID,
 		PeriodMonth:  req.PeriodMonth,
@@ -97,26 +115,14 @@ func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domai
 	}
 
 	myAccID := req.MyAccountID
-	switch {
-	case balResult.Balance > 0:
-		// caller is owed → caller is charger
+	if callerIsCharger {
 		charge.ChargerUserID = callerUserID
 		charge.PayerUserID = otherPartyID
 		charge.ChargerAccountID = &myAccID
-	case balResult.Balance < 0:
-		// caller owes → caller is payer
+	} else {
 		charge.PayerUserID = callerUserID
 		charge.ChargerUserID = otherPartyID
 		charge.PayerAccountID = &myAccID
-	default:
-		// Zero balance: only allowed with an explicit arbitrary amount.
-		// Caller is treated as charger since they initiated the charge.
-		if req.Amount == nil {
-			return nil, pkgErrors.BadRequest("cannot create charge when balance is zero")
-		}
-		charge.ChargerUserID = callerUserID
-		charge.PayerUserID = otherPartyID
-		charge.ChargerAccountID = &myAccID
 	}
 
 	return s.chargeRepo.Create(ctx, charge)

--- a/backend/internal/service/charge_service.go
+++ b/backend/internal/service/charge_service.go
@@ -43,7 +43,7 @@ func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domai
 	if req.Amount != nil && *req.Amount <= 0 {
 		return nil, pkgErrors.BadRequest("amount must be greater than zero")
 	}
-	if req.Role != nil && !req.Role.IsValid() {
+	if req.Role == nil || !req.Role.IsValid() {
 		return nil, pkgErrors.BadRequest("role must be 'charger' or 'payer'")
 	}
 
@@ -75,34 +75,7 @@ func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domai
 		otherPartyID = conn.FromUserID
 	}
 
-	// Resolve caller's connection account via SwapIfNeeded
-	conn.SwapIfNeeded(callerUserID)
-	callerConnAccountID := conn.FromAccountID
-
-	// Infer role from balance in the charge's period
-	period := domain.Period{Month: req.PeriodMonth, Year: req.PeriodYear}
-	balResult, err := s.services.Transaction.GetBalance(ctx, callerUserID, period, domain.BalanceFilter{
-		UserID:     callerUserID,
-		AccountIDs: []int{callerConnAccountID},
-	})
-	if err != nil {
-		return nil, pkgErrors.Internal("failed to compute balance", err)
-	}
-
-	// Role resolution — explicit role wins over balance inference.
-	// When unset, fall back to balance sign; zero balance requires either a
-	// role or the legacy "cannot create" error so intent stays unambiguous.
-	var callerIsCharger bool
-	switch {
-	case req.Role != nil:
-		callerIsCharger = *req.Role == domain.ChargeInitiatorRoleCharger
-	case balResult.Balance > 0:
-		callerIsCharger = true
-	case balResult.Balance < 0:
-		callerIsCharger = false
-	default:
-		return nil, pkgErrors.BadRequest("cannot infer role with zero balance; provide 'role'")
-	}
+	callerIsCharger := *req.Role == domain.ChargeInitiatorRoleCharger
 
 	charge := &domain.Charge{
 		ConnectionID: req.ConnectionID,

--- a/backend/internal/service/charge_service.go
+++ b/backend/internal/service/charge_service.go
@@ -40,6 +40,9 @@ func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domai
 	if req.PeriodYear <= 0 {
 		return nil, pkgErrors.BadRequest("period_year is required")
 	}
+	if req.Amount != nil && *req.Amount <= 0 {
+		return nil, pkgErrors.BadRequest("amount must be greater than zero")
+	}
 
 	// Fetch connection
 	conns, err := s.userConnectionRepo.Search(ctx, domain.UserConnectionSearchOptions{
@@ -88,6 +91,7 @@ func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domai
 		PeriodMonth:  req.PeriodMonth,
 		PeriodYear:   req.PeriodYear,
 		Description:  req.Description,
+		Amount:       req.Amount,
 		Status:       domain.ChargeStatusPending,
 		Date:         &req.Date,
 	}
@@ -105,7 +109,14 @@ func (s *chargeService) Create(ctx context.Context, callerUserID int, req *domai
 		charge.ChargerUserID = otherPartyID
 		charge.PayerAccountID = &myAccID
 	default:
-		return nil, pkgErrors.BadRequest("cannot create charge when balance is zero")
+		// Zero balance: only allowed with an explicit arbitrary amount.
+		// Caller is treated as charger since they initiated the charge.
+		if req.Amount == nil {
+			return nil, pkgErrors.BadRequest("cannot create charge when balance is zero")
+		}
+		charge.ChargerUserID = callerUserID
+		charge.PayerUserID = otherPartyID
+		charge.ChargerAccountID = &myAccID
 	}
 
 	return s.chargeRepo.Create(ctx, charge)

--- a/backend/internal/service/charge_service_test.go
+++ b/backend/internal/service/charge_service_test.go
@@ -512,6 +512,85 @@ func (s *ChargeServiceTestSuite) TestCreate_InvalidAmount() {
 	s.Require().Error(err)
 }
 
+// TestCreate_RejectsConnectionAccount guards against using a shared connection
+// account as the initiator's account — charges must settle into private accounts.
+func (s *ChargeServiceTestSuite) TestCreate_RejectsConnectionAccount() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+
+	// Use the charger's connection account — this is the shared ledger, not private.
+	conn.SwapIfNeeded(charger.ID)
+	chargerConnAccID := conn.FromAccountID
+
+	periodMonth, periodYear := 1, 2027
+	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
+
+	amount := int64(1000)
+	chargerRole := domain.ChargeInitiatorRoleCharger
+	_, err = s.Services.Charge.Create(ctx, charger.ID, &domain.CreateChargeRequest{
+		ConnectionID: conn.ID,
+		MyAccountID:  chargerConnAccID,
+		PeriodMonth:  periodMonth,
+		PeriodYear:   periodYear,
+		Amount:       &amount,
+		Role:         &chargerRole,
+		Date:         chargeDate,
+	})
+	s.Require().Error(err)
+	var svcErr *pkgErrors.ServiceError
+	if assert.ErrorAs(s.T(), err, &svcErr) {
+		assert.Equal(s.T(), pkgErrors.ErrCodeBadRequest, svcErr.Code)
+		assert.Contains(s.T(), svcErr.Message, "connection")
+	}
+}
+
+// TestAccept_RejectsConnectionAccount guards the same invariant at accept time.
+func (s *ChargeServiceTestSuite) TestAccept_RejectsConnectionAccount() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+
+	chargerPrivAcc, err := s.createTestAccount(ctx, charger)
+	s.Require().NoError(err)
+
+	// Create a valid pending charge (charger is initiator).
+	periodMonth, periodYear := 2, 2028
+	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
+	charge := s.createPendingCharge(ctx,
+		charger.ID, payer.ID, chargerPrivAcc.ID, conn.ID,
+		periodMonth, periodYear, chargeDate,
+	)
+
+	// Payer tries to accept with THEIR connection account — must be rejected.
+	conn.SwapIfNeeded(payer.ID)
+	payerConnAccID := conn.FromAccountID
+
+	acceptDate := time.Date(periodYear, time.Month(periodMonth), 2, 0, 0, 0, 0, time.UTC)
+	err = s.Services.Charge.Accept(ctx, payer.ID, charge.ID, &domain.AcceptChargeRequest{
+		AccountID: payerConnAccID,
+		Date:      acceptDate,
+	})
+	s.Require().Error(err)
+	var svcErr *pkgErrors.ServiceError
+	if assert.ErrorAs(s.T(), err, &svcErr) {
+		assert.Equal(s.T(), pkgErrors.ErrCodeBadRequest, svcErr.Code)
+		assert.Contains(s.T(), svcErr.Message, "connection")
+	}
+}
+
 // TestAccept_UsesStoredAmount verifies that a charge created with an arbitrary
 // amount settles for that stored amount when the accepter does not override it.
 func (s *ChargeServiceTestSuite) TestAccept_UsesStoredAmount() {

--- a/backend/internal/service/charge_service_test.go
+++ b/backend/internal/service/charge_service_test.go
@@ -366,6 +366,157 @@ func (s *ChargeServiceTestSuite) TestAccept_RoleReinference_BalanceFlipped() {
 	assert.Equal(s.T(), charger.ID, reloaded.PayerUserID, "original charger should now be payer after balance flip")
 }
 
+// TestCreate_ArbitraryAmount_ZeroBalance verifies that a caller can create a charge
+// with an explicit amount even when their connection-account balance is zero.
+// The caller is treated as the charger (since they initiated).
+func (s *ChargeServiceTestSuite) TestCreate_ArbitraryAmount_ZeroBalance() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+
+	chargerPrivAcc, err := s.createTestAccount(ctx, charger)
+	s.Require().NoError(err)
+
+	periodMonth, periodYear := 9, 2026
+	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
+
+	amount := int64(7500)
+	created, err := s.Services.Charge.Create(ctx, charger.ID, &domain.CreateChargeRequest{
+		ConnectionID: conn.ID,
+		MyAccountID:  chargerPrivAcc.ID,
+		PeriodMonth:  periodMonth,
+		PeriodYear:   periodYear,
+		Amount:       &amount,
+		Date:         chargeDate,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(created.Amount)
+	assert.Equal(s.T(), amount, *created.Amount)
+	assert.Equal(s.T(), charger.ID, created.ChargerUserID)
+	assert.Equal(s.T(), payer.ID, created.PayerUserID)
+	s.Require().NotNil(created.ChargerAccountID)
+	assert.Equal(s.T(), chargerPrivAcc.ID, *created.ChargerAccountID)
+	assert.Nil(s.T(), created.PayerAccountID)
+}
+
+// TestCreate_ZeroBalance_NoAmount preserves the existing behavior: if the balance
+// is zero and no arbitrary amount is provided, creation fails.
+func (s *ChargeServiceTestSuite) TestCreate_ZeroBalance_NoAmount() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+
+	chargerPrivAcc, err := s.createTestAccount(ctx, charger)
+	s.Require().NoError(err)
+
+	periodMonth, periodYear := 10, 2026
+	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
+
+	_, err = s.Services.Charge.Create(ctx, charger.ID, &domain.CreateChargeRequest{
+		ConnectionID: conn.ID,
+		MyAccountID:  chargerPrivAcc.ID,
+		PeriodMonth:  periodMonth,
+		PeriodYear:   periodYear,
+		Date:         chargeDate,
+	})
+	s.Require().Error(err)
+}
+
+// TestCreate_InvalidAmount rejects non-positive arbitrary amounts.
+func (s *ChargeServiceTestSuite) TestCreate_InvalidAmount() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+
+	chargerPrivAcc, err := s.createTestAccount(ctx, charger)
+	s.Require().NoError(err)
+
+	periodMonth, periodYear := 11, 2026
+	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
+
+	badAmount := int64(0)
+	_, err = s.Services.Charge.Create(ctx, charger.ID, &domain.CreateChargeRequest{
+		ConnectionID: conn.ID,
+		MyAccountID:  chargerPrivAcc.ID,
+		PeriodMonth:  periodMonth,
+		PeriodYear:   periodYear,
+		Amount:       &badAmount,
+		Date:         chargeDate,
+	})
+	s.Require().Error(err)
+}
+
+// TestAccept_UsesStoredAmount verifies that a charge created with an arbitrary
+// amount settles for that stored amount when the accepter does not override it.
+func (s *ChargeServiceTestSuite) TestAccept_UsesStoredAmount() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+
+	chargerPrivAcc, err := s.createTestAccount(ctx, charger)
+	s.Require().NoError(err)
+	payerPrivAcc, err := s.createTestAccount(ctx, payer)
+	s.Require().NoError(err)
+
+	periodMonth, periodYear := 12, 2026
+	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
+
+	// Create via service with arbitrary amount + zero balance → caller becomes charger.
+	amount := int64(4200)
+	created, err := s.Services.Charge.Create(ctx, charger.ID, &domain.CreateChargeRequest{
+		ConnectionID: conn.ID,
+		MyAccountID:  chargerPrivAcc.ID,
+		PeriodMonth:  periodMonth,
+		PeriodYear:   periodYear,
+		Amount:       &amount,
+		Date:         chargeDate,
+	})
+	s.Require().NoError(err)
+
+	// Accept as payer without an amount override — stored amount should be used.
+	acceptDate := time.Date(periodYear, time.Month(periodMonth), 2, 0, 0, 0, 0, time.UTC)
+	err = s.Services.Charge.Accept(ctx, payer.ID, created.ID, &domain.AcceptChargeRequest{
+		AccountID: payerPrivAcc.ID,
+		Date:      acceptDate,
+	})
+	s.Require().NoError(err)
+
+	// 4 transaction rows were created (2 mains + 2 linked) — confirm each has amount = 4200.
+	var amounts []int64
+	err = s.DB.WithContext(ctx).
+		Raw("SELECT amount FROM transactions WHERE charge_id = ? AND deleted_at IS NULL", created.ID).
+		Scan(&amounts).Error
+	s.Require().NoError(err)
+	assert.Len(s.T(), amounts, 4)
+	for _, a := range amounts {
+		assert.Equal(s.T(), amount, a)
+	}
+}
+
 func (s *ChargeServiceTestSuite) TestAccept_NonPending() {
 	ctx := context.Background()
 

--- a/backend/internal/service/charge_service_test.go
+++ b/backend/internal/service/charge_service_test.go
@@ -446,9 +446,8 @@ func (s *ChargeServiceTestSuite) TestCreate_PayerRole_ZeroBalance() {
 	assert.Nil(s.T(), created.ChargerAccountID)
 }
 
-// TestCreate_ZeroBalance_NoAmount preserves the existing behavior: if the balance
-// is zero and no arbitrary amount is provided, creation fails.
-func (s *ChargeServiceTestSuite) TestCreate_ZeroBalance_NoAmount() {
+// TestCreate_MissingRole rejects charge creation without an explicit role.
+func (s *ChargeServiceTestSuite) TestCreate_MissingRole() {
 	ctx := context.Background()
 
 	charger, err := s.createTestUser(ctx)
@@ -473,6 +472,12 @@ func (s *ChargeServiceTestSuite) TestCreate_ZeroBalance_NoAmount() {
 		Date:         chargeDate,
 	})
 	s.Require().Error(err)
+
+	var svcErr *pkgErrors.ServiceError
+	if assert.ErrorAs(s.T(), err, &svcErr) {
+		assert.Equal(s.T(), pkgErrors.ErrCodeBadRequest, svcErr.Code)
+		assert.Contains(s.T(), svcErr.Message, "role")
+	}
 }
 
 // TestCreate_InvalidAmount rejects non-positive arbitrary amounts.
@@ -494,12 +499,14 @@ func (s *ChargeServiceTestSuite) TestCreate_InvalidAmount() {
 	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
 
 	badAmount := int64(0)
+	chargerRole := domain.ChargeInitiatorRoleCharger
 	_, err = s.Services.Charge.Create(ctx, charger.ID, &domain.CreateChargeRequest{
 		ConnectionID: conn.ID,
 		MyAccountID:  chargerPrivAcc.ID,
 		PeriodMonth:  periodMonth,
 		PeriodYear:   periodYear,
 		Amount:       &badAmount,
+		Role:         &chargerRole,
 		Date:         chargeDate,
 	})
 	s.Require().Error(err)

--- a/backend/internal/service/charge_service_test.go
+++ b/backend/internal/service/charge_service_test.go
@@ -387,12 +387,14 @@ func (s *ChargeServiceTestSuite) TestCreate_ArbitraryAmount_ZeroBalance() {
 	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
 
 	amount := int64(7500)
+	chargerRole := domain.ChargeInitiatorRoleCharger
 	created, err := s.Services.Charge.Create(ctx, charger.ID, &domain.CreateChargeRequest{
 		ConnectionID: conn.ID,
 		MyAccountID:  chargerPrivAcc.ID,
 		PeriodMonth:  periodMonth,
 		PeriodYear:   periodYear,
 		Amount:       &amount,
+		Role:         &chargerRole,
 		Date:         chargeDate,
 	})
 	s.Require().NoError(err)
@@ -403,6 +405,45 @@ func (s *ChargeServiceTestSuite) TestCreate_ArbitraryAmount_ZeroBalance() {
 	s.Require().NotNil(created.ChargerAccountID)
 	assert.Equal(s.T(), chargerPrivAcc.ID, *created.ChargerAccountID)
 	assert.Nil(s.T(), created.PayerAccountID)
+}
+
+// TestCreate_PayerRole_ZeroBalance verifies that the caller can create a
+// charge where they are the payer ("I owe you X"), not the charger, when
+// the shared-account balance is zero.
+func (s *ChargeServiceTestSuite) TestCreate_PayerRole_ZeroBalance() {
+	ctx := context.Background()
+
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+
+	conn, err := s.createAcceptedTestUserConnection(ctx, payer.ID, charger.ID, 50)
+	s.Require().NoError(err)
+
+	payerPrivAcc, err := s.createTestAccount(ctx, payer)
+	s.Require().NoError(err)
+
+	periodMonth, periodYear := 2, 2027
+	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
+
+	amount := int64(2200)
+	payerRole := domain.ChargeInitiatorRolePayer
+	created, err := s.Services.Charge.Create(ctx, payer.ID, &domain.CreateChargeRequest{
+		ConnectionID: conn.ID,
+		MyAccountID:  payerPrivAcc.ID,
+		PeriodMonth:  periodMonth,
+		PeriodYear:   periodYear,
+		Amount:       &amount,
+		Role:         &payerRole,
+		Date:         chargeDate,
+	})
+	s.Require().NoError(err)
+	assert.Equal(s.T(), payer.ID, created.PayerUserID)
+	assert.Equal(s.T(), charger.ID, created.ChargerUserID)
+	s.Require().NotNil(created.PayerAccountID)
+	assert.Equal(s.T(), payerPrivAcc.ID, *created.PayerAccountID)
+	assert.Nil(s.T(), created.ChargerAccountID)
 }
 
 // TestCreate_ZeroBalance_NoAmount preserves the existing behavior: if the balance
@@ -485,14 +526,16 @@ func (s *ChargeServiceTestSuite) TestAccept_UsesStoredAmount() {
 	periodMonth, periodYear := 12, 2026
 	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
 
-	// Create via service with arbitrary amount + zero balance → caller becomes charger.
+	// Create via service with arbitrary amount + zero balance + explicit charger role.
 	amount := int64(4200)
+	chargerRole := domain.ChargeInitiatorRoleCharger
 	created, err := s.Services.Charge.Create(ctx, charger.ID, &domain.CreateChargeRequest{
 		ConnectionID: conn.ID,
 		MyAccountID:  chargerPrivAcc.ID,
 		PeriodMonth:  periodMonth,
 		PeriodYear:   periodYear,
 		Amount:       &amount,
+		Role:         &chargerRole,
 		Date:         chargeDate,
 	})
 	s.Require().NoError(err)

--- a/backend/migrations/20260418000000_add_amount_to_charges.sql
+++ b/backend/migrations/20260418000000_add_amount_to_charges.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE charges ADD COLUMN amount BIGINT;
+
+-- +goose Down
+ALTER TABLE charges DROP COLUMN amount;

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -147,6 +147,7 @@ export interface ChargePayload {
   period_year: number
   description?: string
   amount?: number
+  role?: 'charger' | 'payer'
   date: string
 }
 

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -146,10 +146,11 @@ export interface ChargePayload {
   period_month: number
   period_year: number
   description?: string
+  amount?: number
   date: string
 }
 
-export async function apiCreateCharge(payload: ChargePayload): Promise<{ id: number }> {
+export async function apiCreateCharge(payload: ChargePayload): Promise<{ id: number; amount?: number; charger_user_id: number; payer_user_id: number }> {
   const res = await apiFetch('/api/charges', {
     method: 'POST',
     body: JSON.stringify(payload),

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -179,6 +179,30 @@ export async function getAuthTokenForUser(email: string): Promise<string> {
   return match[1]
 }
 
+/** Open a new Playwright page authenticated as the given user token. */
+export async function openAuthedPage(browser: import('@playwright/test').Browser, token: string) {
+  const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000'
+  const url = new URL(baseURL)
+  const context = await browser.newContext({
+    storageState: {
+      cookies: [
+        {
+          name: 'auth_token',
+          value: token,
+          domain: url.hostname,
+          path: '/',
+          expires: -1,
+          httpOnly: true,
+          secure: false,
+          sameSite: 'Lax' as const,
+        },
+      ],
+      origins: [],
+    },
+  })
+  return context.newPage()
+}
+
 /** Make an API call authenticated as a specific user */
 export async function apiFetchAs(token: string, path: string, options: RequestInit = {}) {
   const res = await fetch(`${BACKEND_URL}${path}`, {

--- a/frontend/e2e/pages/ChargesPage.ts
+++ b/frontend/e2e/pages/ChargesPage.ts
@@ -59,7 +59,12 @@ export class ChargesPage {
     await expect(this.createDrawer).toBeVisible({ timeout: 5000 });
   }
 
-  async fillCreateForm(opts: { accountName: string; description?: string }) {
+  async fillCreateForm(opts: {
+    accountName: string;
+    role: "charger" | "payer";
+    description?: string;
+    amount?: number;
+  }) {
     // If the connection dropdown is visible (multiple connections or accounts still loading),
     // select the first available option so connection_id gets set.
     const connectionSelect = this.createDrawer.getByRole("textbox", { name: "Conexao" });
@@ -71,6 +76,15 @@ export class ChargesPage {
     const accountSelect = this.createDrawer.getByRole("textbox", { name: "Minha conta" });
     await accountSelect.click();
     await this.page.getByRole("option", { name: opts.accountName }).click();
+
+    const roleLabel =
+      opts.role === "charger" ? "Cobrador (estou cobrando)" : "Pagador (estou pagando)";
+    await this.createDrawer.getByRole("radio", { name: roleLabel }).check();
+
+    if (opts.amount != null) {
+      const amountInput = this.createDrawer.getByRole("textbox", { name: "Valor (opcional)" });
+      await amountInput.fill(opts.amount.toFixed(2).replace(".", ","));
+    }
 
     if (opts.description) {
       await this.createDrawer.getByLabel("Descricao (opcional)").fill(opts.description);

--- a/frontend/e2e/tests/charges.spec.ts
+++ b/frontend/e2e/tests/charges.spec.ts
@@ -11,6 +11,7 @@ import {
   apiDeleteCategory,
   getAuthTokenForUser,
   apiFetchAs,
+  openAuthedPage,
 } from "../helpers/api";
 
 /**
@@ -181,6 +182,7 @@ test.describe("Charges", () => {
     await chargesPage.openCreateDrawer();
     await chargesPage.fillCreateForm({
       accountName: primaryAccountName,
+      role: "charger",
       description,
     });
     await chargesPage.submitCreate();
@@ -204,6 +206,7 @@ test.describe("Charges", () => {
         period_month: PERIOD_MONTH,
         period_year: PERIOD_YEAR,
         description,
+        role: "charger",
         date: new Date().toISOString(),
       }),
     });
@@ -230,6 +233,7 @@ test.describe("Charges", () => {
       period_month: PERIOD_MONTH,
       period_year: PERIOD_YEAR,
       description,
+      role: "charger" as const,
       date: new Date().toISOString(),
     };
     const charge = await apiCreateCharge(chargePayload);
@@ -245,149 +249,128 @@ test.describe("Charges", () => {
     await chargesPage.expectNotification(/Cobrança cancelada/);
   });
 
-  test("create charge with arbitrary amount on zero balance", async () => {
-    // Fresh partner + connection so the shared connection account has zero balance:
-    // no seeded transactions between the two users. Before issue #74 this would fail
-    // with "cannot create charge when balance is zero"; with arbitrary amount it succeeds.
-    const freshPartnerEmail = `e2e-arbitrary-amount-${Date.now()}@financeapp.local`;
+  test("create charge via UI with arbitrary amount + charger role on zero balance", async ({ browser }) => {
+    // Isolated user pair — the fresh primary will have exactly one connection and one account,
+    // so the drawer selectors are unambiguous.
+    const freshPrimaryEmail = `e2e-arb-charger-primary-${Date.now()}@financeapp.local`;
+    const freshPartnerEmail = `e2e-arb-charger-partner-${Date.now()}@financeapp.local`;
+    const freshPrimaryToken = await getAuthTokenForUser(freshPrimaryEmail);
     const freshPartnerToken = await getAuthTokenForUser(freshPartnerEmail);
 
-    const freshPartnerMeRes = await apiFetchAs(freshPartnerToken, "/api/auth/me");
-    const freshPartner = await freshPartnerMeRes.json();
+    const freshPartner = await (await apiFetchAs(freshPartnerToken, "/api/auth/me")).json();
 
-    const freshConn = await apiCreateUserConnection(freshPartner.id, 50);
+    const connRes = await apiFetchAs(freshPrimaryToken, "/api/user-connections", {
+      method: "POST",
+      body: JSON.stringify({ to_user_id: freshPartner.id, from_default_split_percentage: 50 }),
+    });
+    const freshConn = await connRes.json();
     await apiFetchAs(freshPartnerToken, `/api/user-connections/${freshConn.id}/accepted`, {
       method: "PATCH",
     });
 
-    // Primary user private account for the charger side.
-    const chargerPrivAcc = await apiCreateAccount({
-      name: `Arbitrary Amount Charger ${Date.now()}`,
-      initial_balance: 0,
+    const privAccName = `Arb Charger Acc ${Date.now()}`;
+    await apiFetchAs(freshPrimaryToken, "/api/accounts", {
+      method: "POST",
+      body: JSON.stringify({ name: privAccName, initial_balance: 0 }),
     });
 
-    const arbitraryAmount = 12345;
-    const description = `Arbitrary Amount ${Date.now()}`;
-    const charge = await apiCreateCharge({
-      connection_id: freshConn.id,
-      my_account_id: chargerPrivAcc.id,
-      period_month: PERIOD_MONTH,
-      period_year: PERIOD_YEAR,
-      description,
-      amount: arbitraryAmount,
+    // Drive the UI as the fresh primary
+    const page = await openAuthedPage(browser, freshPrimaryToken);
+    const pageCharges = new ChargesPage(page);
+    await pageCharges.gotoMonth(PERIOD_MONTH, PERIOD_YEAR);
+
+    const description = `UI Arb Charger ${Date.now()}`;
+    const arbitraryAmount = 123.45; // reais in the UI → 12345 cents in the DB
+    await pageCharges.openCreateDrawer();
+    await pageCharges.fillCreateForm({
+      accountName: privAccName,
       role: "charger",
-      date: new Date().toISOString(),
-    });
-    createdChargeIds.push(charge.id);
-
-    // Charge exists with the stored arbitrary amount and the caller is the charger
-    // (zero balance → caller defaults to charger).
-    expect(charge.amount).toBe(arbitraryAmount);
-
-    // Verify via the list endpoint too — round-trip through the DB.
-    const listRes = await apiFetchAs(await getAuthTokenForUser("e2e-test@financeapp.local"), "/api/charges?direction=sent");
-    const listBody = await listRes.json();
-    const reloaded = (listBody.charges ?? []).find((c: { id: number }) => c.id === charge.id);
-    expect(reloaded).toBeDefined();
-    expect(reloaded.amount).toBe(arbitraryAmount);
-    expect(reloaded.status).toBe("pending");
-
-    // Partner accepts without overriding → settlement transfers must use stored amount.
-    const partnerPrivAccRes = await apiFetchAs(freshPartnerToken, "/api/accounts", {
-      method: "POST",
-      body: JSON.stringify({
-        name: `Arbitrary Amount Payer ${Date.now()}`,
-        initial_balance: 0,
-      }),
-    });
-    const partnerPrivAcc = await partnerPrivAccRes.json();
-
-    const acceptRes = await apiFetchAs(freshPartnerToken, `/api/charges/${charge.id}/accept`, {
-      method: "POST",
-      body: JSON.stringify({
-        account_id: partnerPrivAcc.id,
-        date: new Date().toISOString(),
-      }),
-    });
-    expect(acceptRes.status).toBe(204);
-
-    // Reload the charge — it should be paid, with amount unchanged.
-    const afterAcceptRes = await apiFetchAs(freshPartnerToken, "/api/charges");
-    const afterAcceptBody = await afterAcceptRes.json();
-    const settled = (afterAcceptBody.charges ?? []).find((c: { id: number }) => c.id === charge.id);
-    expect(settled).toBeDefined();
-    expect(settled.status).toBe("paid");
-    expect(settled.amount).toBe(arbitraryAmount);
-  });
-
-  test("payer can initiate charge with arbitrary amount on zero balance", async () => {
-    // Fresh partner so the shared connection account has zero balance.
-    // Caller explicitly creates as payer ("I owe you X"), bypassing balance-sign inference.
-    const freshPartnerEmail = `e2e-payer-init-${Date.now()}@financeapp.local`;
-    const freshPartnerToken = await getAuthTokenForUser(freshPartnerEmail);
-
-    const freshPartnerMeRes = await apiFetchAs(freshPartnerToken, "/api/auth/me");
-    const freshPartner = await freshPartnerMeRes.json();
-
-    const freshConn = await apiCreateUserConnection(freshPartner.id, 50);
-    await apiFetchAs(freshPartnerToken, `/api/user-connections/${freshConn.id}/accepted`, {
-      method: "PATCH",
-    });
-
-    const payerPrivAcc = await apiCreateAccount({
-      name: `Payer Init ${Date.now()}`,
-      initial_balance: 0,
-    });
-
-    const arbitraryAmount = 6789;
-    const charge = await apiCreateCharge({
-      connection_id: freshConn.id,
-      my_account_id: payerPrivAcc.id,
-      period_month: PERIOD_MONTH,
-      period_year: PERIOD_YEAR,
-      description: `Payer Init ${Date.now()}`,
       amount: arbitraryAmount,
-      role: "payer",
-      date: new Date().toISOString(),
+      description,
     });
-    createdChargeIds.push(charge.id);
+    await pageCharges.submitCreate();
+    await pageCharges.expectNotification(/Cobrança criada/);
 
-    // Caller was saved as the payer, not the charger.
-    const meRes = await apiFetchAs(await getAuthTokenForUser("e2e-test@financeapp.local"), "/api/auth/me");
-    const me = await meRes.json();
-    expect(charge.payer_user_id).toBe(me.id);
-    expect(charge.charger_user_id).toBe(freshPartner.id);
-    expect(charge.amount).toBe(arbitraryAmount);
+    // Verify via API — the charge was saved with caller as charger and stored amount in cents.
+    const listRes = await apiFetchAs(freshPrimaryToken, "/api/charges?direction=sent");
+    const listBody = await listRes.json();
+    const created = (listBody.charges ?? []).find((c: { description?: string }) => c.description === description);
+    expect(created).toBeDefined();
+    expect(created.amount).toBe(12345);
+    expect(created.status).toBe("pending");
+    const me = await (await apiFetchAs(freshPrimaryToken, "/api/auth/me")).json();
+    expect(created.charger_user_id).toBe(me.id);
+    expect(created.payer_user_id).toBe(freshPartner.id);
+
+    await page.context().close();
   });
 
-  test("reject charge creation with zero balance and no role/amount", async () => {
-    // Regression: without an arbitrary amount, zero-balance creation must still fail.
-    const freshPartnerEmail = `e2e-zero-balance-${Date.now()}@financeapp.local`;
+  test("payer can initiate charge via UI on zero balance", async ({ browser }) => {
+    // Isolated pair — caller is the payer ("I owe you X"). Saved with caller in payer fields.
+    const freshPrimaryEmail = `e2e-arb-payer-primary-${Date.now()}@financeapp.local`;
+    const freshPartnerEmail = `e2e-arb-payer-partner-${Date.now()}@financeapp.local`;
+    const freshPrimaryToken = await getAuthTokenForUser(freshPrimaryEmail);
     const freshPartnerToken = await getAuthTokenForUser(freshPartnerEmail);
 
-    const freshPartnerMeRes = await apiFetchAs(freshPartnerToken, "/api/auth/me");
-    const freshPartner = await freshPartnerMeRes.json();
+    const freshPartner = await (await apiFetchAs(freshPartnerToken, "/api/auth/me")).json();
 
-    const freshConn = await apiCreateUserConnection(freshPartner.id, 50);
+    const connRes = await apiFetchAs(freshPrimaryToken, "/api/user-connections", {
+      method: "POST",
+      body: JSON.stringify({ to_user_id: freshPartner.id, from_default_split_percentage: 50 }),
+    });
+    const freshConn = await connRes.json();
     await apiFetchAs(freshPartnerToken, `/api/user-connections/${freshConn.id}/accepted`, {
       method: "PATCH",
     });
 
-    const privAcc = await apiCreateAccount({
-      name: `Zero Balance Guard ${Date.now()}`,
-      initial_balance: 0,
+    const privAccName = `Arb Payer Acc ${Date.now()}`;
+    await apiFetchAs(freshPrimaryToken, "/api/accounts", {
+      method: "POST",
+      body: JSON.stringify({ name: privAccName, initial_balance: 0 }),
     });
 
-    await expect(
-      apiCreateCharge({
-        connection_id: freshConn.id,
-        my_account_id: privAcc.id,
-        period_month: PERIOD_MONTH,
-        period_year: PERIOD_YEAR,
-        description: `Zero balance ${Date.now()}`,
-        date: new Date().toISOString(),
-      }),
-    ).rejects.toThrow(/400/);
+    const page = await openAuthedPage(browser, freshPrimaryToken);
+    const pageCharges = new ChargesPage(page);
+    await pageCharges.gotoMonth(PERIOD_MONTH, PERIOD_YEAR);
+
+    const description = `UI Arb Payer ${Date.now()}`;
+    const arbitraryAmount = 67.89;
+    await pageCharges.openCreateDrawer();
+    await pageCharges.fillCreateForm({
+      accountName: privAccName,
+      role: "payer",
+      amount: arbitraryAmount,
+      description,
+    });
+    await pageCharges.submitCreate();
+    await pageCharges.expectNotification(/Cobrança criada/);
+
+    const me = await (await apiFetchAs(freshPrimaryToken, "/api/auth/me")).json();
+    // Caller is now the payer → the charge lands in "received" for them.
+    const listRes = await apiFetchAs(freshPrimaryToken, "/api/charges?direction=received");
+    const listBody = await listRes.json();
+    const created = (listBody.charges ?? []).find((c: { description?: string }) => c.description === description);
+    expect(created).toBeDefined();
+    expect(created.amount).toBe(6789);
+    expect(created.payer_user_id).toBe(me.id);
+    expect(created.charger_user_id).toBe(freshPartner.id);
+
+    await page.context().close();
+  });
+
+  test("submitting the create drawer without selecting a role is rejected", async () => {
+    // The radio is required in the schema, so submit without picking charger/payer stays on-form.
+    await chargesPage.openCreateDrawer();
+    // Fill everything except role
+    const accountSelect = chargesPage.createDrawer.getByRole("textbox", { name: "Minha conta" });
+    await accountSelect.click();
+    await chargesPage.page.getByRole("option", { name: primaryAccountName }).click();
+
+    await chargesPage.createDrawer.getByRole("button", { name: "Criar Cobrança" }).click();
+
+    // The drawer must stay open and show a validation error for the role field.
+    await expect(chargesPage.createDrawer).toBeVisible();
+    await expect(chargesPage.createDrawer.getByText("Selecione seu papel")).toBeVisible();
   });
 
   test("sidebar badge shows pending count", async ({ page }) => {
@@ -401,6 +384,7 @@ test.describe("Charges", () => {
         period_month: PERIOD_MONTH,
         period_year: PERIOD_YEAR,
         description,
+        role: "charger",
         date: new Date().toISOString(),
       }),
     });

--- a/frontend/e2e/tests/charges.spec.ts
+++ b/frontend/e2e/tests/charges.spec.ts
@@ -245,6 +245,110 @@ test.describe("Charges", () => {
     await chargesPage.expectNotification(/Cobrança cancelada/);
   });
 
+  test("create charge with arbitrary amount on zero balance", async () => {
+    // Fresh partner + connection so the shared connection account has zero balance:
+    // no seeded transactions between the two users. Before issue #74 this would fail
+    // with "cannot create charge when balance is zero"; with arbitrary amount it succeeds.
+    const freshPartnerEmail = `e2e-arbitrary-amount-${Date.now()}@financeapp.local`;
+    const freshPartnerToken = await getAuthTokenForUser(freshPartnerEmail);
+
+    const freshPartnerMeRes = await apiFetchAs(freshPartnerToken, "/api/auth/me");
+    const freshPartner = await freshPartnerMeRes.json();
+
+    const freshConn = await apiCreateUserConnection(freshPartner.id, 50);
+    await apiFetchAs(freshPartnerToken, `/api/user-connections/${freshConn.id}/accepted`, {
+      method: "PATCH",
+    });
+
+    // Primary user private account for the charger side.
+    const chargerPrivAcc = await apiCreateAccount({
+      name: `Arbitrary Amount Charger ${Date.now()}`,
+      initial_balance: 0,
+    });
+
+    const arbitraryAmount = 12345;
+    const description = `Arbitrary Amount ${Date.now()}`;
+    const charge = await apiCreateCharge({
+      connection_id: freshConn.id,
+      my_account_id: chargerPrivAcc.id,
+      period_month: PERIOD_MONTH,
+      period_year: PERIOD_YEAR,
+      description,
+      amount: arbitraryAmount,
+      date: new Date().toISOString(),
+    });
+    createdChargeIds.push(charge.id);
+
+    // Charge exists with the stored arbitrary amount and the caller is the charger
+    // (zero balance → caller defaults to charger).
+    expect(charge.amount).toBe(arbitraryAmount);
+
+    // Verify via the list endpoint too — round-trip through the DB.
+    const listRes = await apiFetchAs(await getAuthTokenForUser("e2e-test@financeapp.local"), "/api/charges?direction=sent");
+    const listBody = await listRes.json();
+    const reloaded = (listBody.charges ?? []).find((c: { id: number }) => c.id === charge.id);
+    expect(reloaded).toBeDefined();
+    expect(reloaded.amount).toBe(arbitraryAmount);
+    expect(reloaded.status).toBe("pending");
+
+    // Partner accepts without overriding → settlement transfers must use stored amount.
+    const partnerPrivAccRes = await apiFetchAs(freshPartnerToken, "/api/accounts", {
+      method: "POST",
+      body: JSON.stringify({
+        name: `Arbitrary Amount Payer ${Date.now()}`,
+        initial_balance: 0,
+      }),
+    });
+    const partnerPrivAcc = await partnerPrivAccRes.json();
+
+    const acceptRes = await apiFetchAs(freshPartnerToken, `/api/charges/${charge.id}/accept`, {
+      method: "POST",
+      body: JSON.stringify({
+        account_id: partnerPrivAcc.id,
+        date: new Date().toISOString(),
+      }),
+    });
+    expect(acceptRes.status).toBe(204);
+
+    // Reload the charge — it should be paid, with amount unchanged.
+    const afterAcceptRes = await apiFetchAs(freshPartnerToken, "/api/charges");
+    const afterAcceptBody = await afterAcceptRes.json();
+    const settled = (afterAcceptBody.charges ?? []).find((c: { id: number }) => c.id === charge.id);
+    expect(settled).toBeDefined();
+    expect(settled.status).toBe("paid");
+    expect(settled.amount).toBe(arbitraryAmount);
+  });
+
+  test("reject charge creation with zero balance and no amount", async () => {
+    // Regression: without an arbitrary amount, zero-balance creation must still fail.
+    const freshPartnerEmail = `e2e-zero-balance-${Date.now()}@financeapp.local`;
+    const freshPartnerToken = await getAuthTokenForUser(freshPartnerEmail);
+
+    const freshPartnerMeRes = await apiFetchAs(freshPartnerToken, "/api/auth/me");
+    const freshPartner = await freshPartnerMeRes.json();
+
+    const freshConn = await apiCreateUserConnection(freshPartner.id, 50);
+    await apiFetchAs(freshPartnerToken, `/api/user-connections/${freshConn.id}/accepted`, {
+      method: "PATCH",
+    });
+
+    const privAcc = await apiCreateAccount({
+      name: `Zero Balance Guard ${Date.now()}`,
+      initial_balance: 0,
+    });
+
+    await expect(
+      apiCreateCharge({
+        connection_id: freshConn.id,
+        my_account_id: privAcc.id,
+        period_month: PERIOD_MONTH,
+        period_year: PERIOD_YEAR,
+        description: `Zero balance ${Date.now()}`,
+        date: new Date().toISOString(),
+      }),
+    ).rejects.toThrow(/400/);
+  });
+
   test("sidebar badge shows pending count", async ({ page }) => {
     // Create a charge from partner where primary is payer
     const description = `Badge Test ${Date.now()}`;

--- a/frontend/e2e/tests/charges.spec.ts
+++ b/frontend/e2e/tests/charges.spec.ts
@@ -275,6 +275,7 @@ test.describe("Charges", () => {
       period_year: PERIOD_YEAR,
       description,
       amount: arbitraryAmount,
+      role: "charger",
       date: new Date().toISOString(),
     });
     createdChargeIds.push(charge.id);
@@ -319,7 +320,47 @@ test.describe("Charges", () => {
     expect(settled.amount).toBe(arbitraryAmount);
   });
 
-  test("reject charge creation with zero balance and no amount", async () => {
+  test("payer can initiate charge with arbitrary amount on zero balance", async () => {
+    // Fresh partner so the shared connection account has zero balance.
+    // Caller explicitly creates as payer ("I owe you X"), bypassing balance-sign inference.
+    const freshPartnerEmail = `e2e-payer-init-${Date.now()}@financeapp.local`;
+    const freshPartnerToken = await getAuthTokenForUser(freshPartnerEmail);
+
+    const freshPartnerMeRes = await apiFetchAs(freshPartnerToken, "/api/auth/me");
+    const freshPartner = await freshPartnerMeRes.json();
+
+    const freshConn = await apiCreateUserConnection(freshPartner.id, 50);
+    await apiFetchAs(freshPartnerToken, `/api/user-connections/${freshConn.id}/accepted`, {
+      method: "PATCH",
+    });
+
+    const payerPrivAcc = await apiCreateAccount({
+      name: `Payer Init ${Date.now()}`,
+      initial_balance: 0,
+    });
+
+    const arbitraryAmount = 6789;
+    const charge = await apiCreateCharge({
+      connection_id: freshConn.id,
+      my_account_id: payerPrivAcc.id,
+      period_month: PERIOD_MONTH,
+      period_year: PERIOD_YEAR,
+      description: `Payer Init ${Date.now()}`,
+      amount: arbitraryAmount,
+      role: "payer",
+      date: new Date().toISOString(),
+    });
+    createdChargeIds.push(charge.id);
+
+    // Caller was saved as the payer, not the charger.
+    const meRes = await apiFetchAs(await getAuthTokenForUser("e2e-test@financeapp.local"), "/api/auth/me");
+    const me = await meRes.json();
+    expect(charge.payer_user_id).toBe(me.id);
+    expect(charge.charger_user_id).toBe(freshPartner.id);
+    expect(charge.amount).toBe(arbitraryAmount);
+  });
+
+  test("reject charge creation with zero balance and no role/amount", async () => {
     // Regression: without an arbitrary amount, zero-balance creation must still fail.
     const freshPartnerEmail = `e2e-zero-balance-${Date.now()}@financeapp.local`;
     const freshPartnerToken = await getAuthTokenForUser(freshPartnerEmail);

--- a/frontend/src/components/charges/AcceptChargeDrawer.tsx
+++ b/frontend/src/components/charges/AcceptChargeDrawer.tsx
@@ -53,9 +53,10 @@ export function AcceptChargeDrawer({ charge, partnerName }: AcceptChargeDrawerPr
 
   const accounts = accountsQuery.data ?? [];
 
-  // User's own active accounts
+  // User's own active private accounts only — connection (shared) accounts
+  // are the internal ledger and must not be used to settle a charge.
   const myAccounts = accounts
-    .filter((a) => a.user_id === currentUserId && a.is_active)
+    .filter((a) => a.user_id === currentUserId && a.is_active && !a.user_connection)
     .map((a) => ({ label: a.name, value: String(a.id) }));
 
   // Balance preview query

--- a/frontend/src/components/charges/CreateChargeDrawer.tsx
+++ b/frontend/src/components/charges/CreateChargeDrawer.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Alert, Button, Drawer, Select, Skeleton, Stack, Text, Textarea } from "@mantine/core";
+import { Alert, Button, Drawer, NumberInput, Radio, Select, Skeleton, Stack, Text, Textarea } from "@mantine/core";
 import { DateInput, MonthPickerInput } from "@mantine/dates";
 import { notifications } from "@mantine/notifications";
 import { useQuery } from "@tanstack/react-query";
@@ -26,6 +26,8 @@ const createChargeSchema = z.object({
   period_month: z.number().min(1).max(12),
   period_year: z.number(),
   description: z.string().optional(),
+  role: z.enum(["charger", "payer"], { error: "Selecione seu papel" }),
+  amount: z.number().positive("Informe um valor maior que zero").optional(),
   date: z.date({ error: "Selecione uma data" }),
 });
 
@@ -84,6 +86,8 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
       period_month: periodMonth,
       period_year: periodYear,
       description: "",
+      role: undefined,
+      amount: undefined,
       date: new Date(),
     },
   });
@@ -107,6 +111,8 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
       period_month: values.period_month,
       period_year: values.period_year,
       description: values.description || undefined,
+      role: values.role,
+      amount: values.amount != null ? Math.round(values.amount * 100) : undefined,
       date: values.date.toISOString(),
     };
     mutation.mutate(payload, {
@@ -215,6 +221,46 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
                 onChange={(date) => field.onChange(date)}
                 error={fieldState.error?.message}
                 required
+              />
+            )}
+          />
+
+          <Controller
+            name="role"
+            control={form.control}
+            render={({ field, fieldState }) => (
+              <Radio.Group
+                label="Sou o..."
+                value={field.value ?? null}
+                onChange={field.onChange}
+                error={fieldState.error?.message}
+                required
+              >
+                <Stack gap="xs" mt="xs">
+                  <Radio value="charger" label="Cobrador (estou cobrando)" />
+                  <Radio value="payer" label="Pagador (estou pagando)" />
+                </Stack>
+              </Radio.Group>
+            )}
+          />
+
+          <Controller
+            name="amount"
+            control={form.control}
+            render={({ field, fieldState }) => (
+              <NumberInput
+                label="Valor (opcional)"
+                description="Deixe em branco para usar o saldo atual"
+                placeholder="0,00"
+                value={field.value ?? ""}
+                onChange={(v) => field.onChange(typeof v === "number" ? v : undefined)}
+                min={0}
+                step={0.01}
+                decimalScale={2}
+                thousandSeparator="."
+                decimalSeparator=","
+                prefix="R$ "
+                error={fieldState.error?.message}
               />
             )}
           />

--- a/frontend/src/components/charges/CreateChargeDrawer.tsx
+++ b/frontend/src/components/charges/CreateChargeDrawer.tsx
@@ -71,9 +71,10 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
   const connectionOptions = Array.from(connectionMap.values());
   const singleConnection = connectionOptions.length === 1 ? connectionOptions[0] : null;
 
-  // User's own active accounts
+  // User's own active private accounts only — connection (shared) accounts
+  // are the internal ledger and must not be used as the charge's destination.
   const myAccounts = accounts
-    .filter((a) => a.user_id === currentUserId && a.is_active)
+    .filter((a) => a.user_id === currentUserId && a.is_active && !a.user_connection)
     .map((a) => ({ label: a.name, value: String(a.id) }));
 
   const defaultPeriod = new Date(periodYear, periodMonth - 1, 1);

--- a/frontend/src/types/charges.ts
+++ b/frontend/src/types/charges.ts
@@ -28,12 +28,16 @@ export namespace Charges {
     charges: Charge[]
   }
 
+  export type InitiatorRole = 'charger' | 'payer'
+
   export interface CreateChargePayload {
     connection_id: number
     my_account_id: number
     period_month: number
     period_year: number
     description?: string
+    amount?: number
+    role: InitiatorRole
     date: string
   }
 


### PR DESCRIPTION
- Add optional Amount field on Charge and CreateChargeRequest
- Migration adds nullable amount column to charges table
- Create accepts arbitrary amount, allowing creation with zero balance
  (caller becomes charger in that case)
- Accept falls back to stored charge.Amount when no accept-time override

Closes #74