### PR TITLE
fix(pwa): consolidate VitePWA plugin and force fresh HTML/SW

### DIFF
--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -15,7 +15,16 @@
     ],
     "headers": [
       {
-        "source": "sw.js",
+        "source": "/index.html",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/@(sw.js|registerSW.js|manifest.webmanifest)",
         "headers": [
           {
             "key": "Cache-Control",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,8 +23,15 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: "autoUpdate",
+      devOptions: {
+        enabled: false,
+      },
       workbox: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+        cleanupOutdatedCaches: true,
+        clientsClaim: true,
+        skipWaiting: true,
+        navigateFallback: "/index.html",
       },
       manifest: {
         name: "FinanceApp",
@@ -50,40 +57,6 @@ export default defineConfig({
         ],
       },
     }),
-    process.env.NODE_ENV === "production" &&
-      VitePWA({
-        registerType: "autoUpdate",
-        devOptions: {
-          enabled: false,
-        },
-        workbox: {
-          globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
-          cleanupOutdatedCaches: true,
-        },
-        manifest: {
-          name: "FinanceApp",
-          short_name: "Finance",
-          description: "Gestão financeira a dois",
-          start_url: "/",
-          display: "standalone",
-          background_color: "#ffffff",
-          theme_color: "#228be6",
-          icons: [
-            {
-              src: "/icon-192.png",
-              sizes: "192x192",
-              type: "image/png",
-              purpose: "any maskable",
-            },
-            {
-              src: "/icon-512.png",
-              sizes: "512x512",
-              type: "image/png",
-              purpose: "any maskable",
-            },
-          ],
-        },
-      }),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
O plugin VitePWA estava registrado duas vezes no vite.config.ts (uma
incondicional, outra só em prod), o que em produção gerava configs
conflitantes para o service worker e deixava o cache antigo preso,
principalmente em PWAs instalados no iOS onde o SW raramente reinicia.

- Remove o registro duplicado e mantém um único VitePWA com
  cleanupOutdatedCaches, clientsClaim e skipWaiting para o novo SW
  assumir imediatamente sem precisar fechar o app.
- Adiciona navigateFallback para /index.html para SPAs.
- Em firebase.json, garante que index.html, sw.js, registerSW.js e
  manifest.webmanifest sejam servidos com no-cache/no-store para que o
  shell novo seja sempre buscado e referencie os bundles com hash.