### PR TITLE
fix(frontend): adjust mobile layout for transactions and charges (#80)

### DIFF
--- a/frontend/src/components/transactions/ClearFiltersButton.tsx
+++ b/frontend/src/components/transactions/ClearFiltersButton.tsx
@@ -41,7 +41,7 @@ export function ClearFiltersButton({ variant = 'button' }: ClearFiltersButtonPro
   if (variant === 'icon') {
     return (
       <ActionIcon
-        size="xl"
+        size="lg"
         radius="xl"
         variant="filled"
         color="red"
@@ -49,7 +49,7 @@ export function ClearFiltersButton({ variant = 'button' }: ClearFiltersButtonPro
         aria-label="Limpar filtros"
         data-testid="btn_clear_filters"
       >
-        <IconX size={20} />
+        <IconX size={18} />
       </ActionIcon>
     )
   }

--- a/frontend/src/components/transactions/MobileBottomBar.module.css
+++ b/frontend/src/components/transactions/MobileBottomBar.module.css
@@ -4,8 +4,8 @@
   left: 0;
   right: 0;
   z-index: 100;
-  padding: 0.75rem 1rem;
-  padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+  padding: 0.375rem 1rem;
+  padding-bottom: calc(0.375rem + env(safe-area-inset-bottom));
   background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
   border-top: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
 }

--- a/frontend/src/components/transactions/SettlementRow.tsx
+++ b/frontend/src/components/transactions/SettlementRow.tsx
@@ -37,10 +37,10 @@ export function SettlementRow({ settlement, groupBy, accounts, onEdit, descripti
         {groupBy !== 'date' && dateLabel && (
           <Text size="xs" c="dimmed">{dateLabel}</Text>
         )}
-        <Group gap={6} wrap="nowrap">
+        <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
           <IconReceipt size={14} style={{ flexShrink: 0, opacity: 0.6 }} />
-          <Text size="sm" fw={500} lineClamp={1}>{description ?? 'Acerto'}</Text>
-          <Badge size="xs" variant="light" color="violet" radius="sm">acerto</Badge>
+          <Badge size="xs" variant="light" color="violet" radius="sm" style={{ flexShrink: 0 }}>acerto</Badge>
+          <Text size="sm" fw={500} lineClamp={1} style={{ minWidth: 0 }}>{description ?? 'Acerto'}</Text>
         </Group>
       </div>
 

--- a/frontend/src/routes/_authenticated.charges.tsx
+++ b/frontend/src/routes/_authenticated.charges.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Group, Modal, Skeleton, Stack, Tabs, Text } from "@mantine/core";
+import { ActionIcon, Box, Button, Group, Modal, Skeleton, Stack, Tabs, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { IconPlus } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
@@ -145,13 +145,14 @@ function ChargesPage() {
           paddingBottom: "var(--mantine-spacing-xs)",
         }}
       >
-        <Group justify="space-between" align="center">
+        <Group justify="space-between" align="center" wrap="nowrap" gap="xs">
           <PeriodNavigator
             month={search.month}
             year={search.year}
             onPeriodChange={(m, y) => navigate({ search: { ...search, month: m, year: y } })}
           />
           <Button
+            visibleFrom="xs"
             leftSection={<IconPlus size={16} />}
             onClick={() =>
               void renderDrawer(() => <CreateChargeDrawer periodMonth={search.month} periodYear={search.year} />)
@@ -159,6 +160,17 @@ function ChargesPage() {
           >
             Nova Cobrança
           </Button>
+          <ActionIcon
+            hiddenFrom="xs"
+            size="lg"
+            variant="filled"
+            aria-label="Nova Cobrança"
+            onClick={() =>
+              void renderDrawer(() => <CreateChargeDrawer periodMonth={search.month} periodYear={search.year} />)
+            }
+          >
+            <IconPlus size={18} />
+          </ActionIcon>
         </Group>
       </Box>
 

--- a/frontend/src/routes/_authenticated.transactions.tsx
+++ b/frontend/src/routes/_authenticated.transactions.tsx
@@ -307,21 +307,22 @@ function TransactionsPage() {
           }}
         >
           <Stack gap="xs" style={{ visibility: isSelecting ? 'hidden' : undefined }}>
-            <Group justify="space-between" align="center">
+            <Group justify="space-between" align="center" wrap="nowrap" gap="xs">
               <PeriodNavigator month={search.month} year={search.year} onPeriodChange={(m, y) => routeNavigate({ search: { ...search, month: m, year: y } })} />
-              <Group gap="xs">
-                <Button
-                  size="xs"
-                  leftSection={<IconPlus size={14} />}
+              <Group gap="xs" wrap="nowrap">
+                <ActionIcon
+                  size="lg"
+                  variant="filled"
                   onClick={() => void renderDrawer(() => <CreateTransactionDrawer />)}
                   data-testid="btn_new_transaction"
+                  aria-label="Nova Transação"
                 >
-                  Nova Transação
-                </Button>
+                  <IconPlus size={18} />
+                </ActionIcon>
                 <Menu shadow="md" width={200}>
                   <Menu.Target>
-                    <ActionIcon size="sm" variant="default" aria-label="Mais opções">
-                      <IconDots size={14} />
+                    <ActionIcon size="lg" variant="default" aria-label="Mais opções">
+                      <IconDots size={18} />
                     </ActionIcon>
                   </Menu.Target>
                   <Menu.Dropdown>
@@ -357,13 +358,13 @@ function TransactionsPage() {
           <MobileBottomBar>
             <ClearFiltersButton variant="icon" />
             <ActionIcon
-              size="xl"
+              size="lg"
               radius="xl"
               variant="filled"
               onClick={openFilters}
               aria-label="Abrir filtros"
             >
-              <IconFilter size={20} />
+              <IconFilter size={18} />
             </ActionIcon>
           </MobileBottomBar>
         )}


### PR DESCRIPTION
- Prevent the PeriodNavigator and primary action (Nova Transação / Nova
  Cobrança) from wrapping to a new line on narrow screens by replacing
  the full button with an icon-only ActionIcon on mobile and forcing the
  header group to nowrap.
- Reduce the mobile bottom filter bar height by lowering the vertical
  padding and shrinking the filter / clear-filter icons from xl to lg.
- Ensure the "acerto" badge is always visible on settlement rows by
  placing it before the description and marking it as non-shrinkable, so
  long descriptions truncate with an ellipsis instead of pushing the
  badge off-screen.