### PR TITLE
fix(transactions): preserve recurrence on current_and_future edits with unchanged total (#83)

### DIFF
--- a/.claude/rules/transaction-update-installment-scenarios.md
+++ b/.claude/rules/transaction-update-installment-scenarios.md
@@ -379,3 +379,87 @@ recurrence and/or split settings change.
 - 3 installments for userA remain, no split
 - `TransactionRecurrence.Installments` = 3
 - Total transactions in DB: 3
+
+---
+
+## Propagation `current_and_future` on installments > 1 — preserving the recurrence
+
+**Rule of thumb:** `current_and_future` on installment `n > 1` only fragments the
+recurrence when `Type` or `TotalInstallments` differ from the existing values.
+Pure attribute propagation (split/description/amount/account/category/date/tags)
+must keep `TransactionRecurrenceID` intact and preserve every
+`installment_number`. This closes [issue #83](https://github.com/mateusdeitos/finance_app/issues/83).
+
+---
+
+### InstallmentScenario9b — Remove split · propagation=current_and_future · installment > 1 · total unchanged
+
+**Pre-conditions**
+- 2 connected users, each with their own account
+- userA has 4 monthly installments with split (50/50)
+- Target: installment 3
+
+**Update request**
+```json
+{
+  "propagation_settings": "current_and_future",
+  "recurrence_settings": { "type": "monthly", "current_installment": 3, "total_installments": 4 },
+  "split_settings": []
+}
+```
+
+**Expected result**
+- All 4 userA installments remain in the **same** `TransactionRecurrence`
+- `installment_number` preserved (1, 2, 3, 4) — no renumbering
+- Installments 1 and 2 keep the split; 3 and 4 have the split removed
+- `TransactionRecurrence.Installments` stays 4
+- userB: 2 linked transactions remain (for installments 1 and 2); 2 are deleted
+- No new `TransactionRecurrence` row is created
+
+---
+
+### InstallmentScenario10b — Add split · propagation=current_and_future · installment > 1 · total unchanged
+
+**Pre-conditions**
+- 2 connected users, each with their own account
+- userA has 4 monthly installments without split
+- Target: installment 3
+
+**Update request**
+```json
+{
+  "propagation_settings": "current_and_future",
+  "recurrence_settings": { "type": "monthly", "current_installment": 3, "total_installments": 4 },
+  "split_settings": [{ "connection_id": <connectionID>, "percentage": 50 }]
+}
+```
+
+**Expected result**
+- All 4 userA installments remain in the **same** `TransactionRecurrence`
+- `installment_number` preserved (1, 2, 3, 4)
+- Installments 1 and 2 still without split; 3 and 4 gain the split
+- userB: 2 new linked transactions with `installment_number` = 3 and 4
+- `TransactionRecurrence.Installments` stays 4
+
+---
+
+### InstallmentScenario17 — Edit description only · propagation=current_and_future · installment > 1
+
+**Pre-conditions**
+- userA has 4 monthly installments, no split
+- Target: installment 3
+
+**Update request**
+```json
+{
+  "propagation_settings": "current_and_future",
+  "description": "new description",
+  "recurrence_settings": { "type": "monthly", "current_installment": 3, "total_installments": 4 }
+}
+```
+
+**Expected result**
+- `TransactionRecurrence` untouched (same ID, `Installments` = 4)
+- Every `installment_number` preserved
+- Installments 1 and 2 keep the original description
+- Installments 3 and 4 adopt the new description

--- a/backend/internal/service/transaction_update.go
+++ b/backend/internal/service/transaction_update.go
@@ -825,11 +825,20 @@ func (s *transactionService) handlerRecurrenceUpdate(
 
 	// For propagation=current_and_future when past installments exist, the old recurrence
 	// must be shrunk to cover only the past installments, and a new recurrence must be
-	// created for the current+future batch.
+	// created for the current+future batch — but only when the recurrence itself actually
+	// changed. Edits that leave Type and TotalInstallments untouched (e.g. split-only,
+	// description-only) must keep the original recurrence and preserve installment numbers.
 	hasPastInstallments := data.req.PropagationSettings == domain.TransactionPropagationSettingsCurrentAndFuture &&
 		lo.FromPtr(data.previousTransaction.InstallmentNumber) > 1
 
-	if hasPastInstallments && data.previousTransaction.TransactionRecurrenceID != nil {
+	previousRecurrence := data.previousTransaction.TransactionRecurrence
+	recurrenceSettingsChanged := previousRecurrence == nil ||
+		data.req.RecurrenceSettings.Type != previousRecurrence.Type ||
+		data.req.RecurrenceSettings.TotalInstallments != previousRecurrence.Installments
+
+	shouldSplitRecurrence := hasPastInstallments && recurrenceSettingsChanged
+
+	if shouldSplitRecurrence && data.previousTransaction.TransactionRecurrenceID != nil {
 		oldRecurrence := data.previousTransaction.TransactionRecurrence
 		oldRecurrence.Installments = lo.FromPtr(data.previousTransaction.InstallmentNumber) - 1
 		if err := s.transactionRecurRepo.Update(ctx, oldRecurrence); err != nil {
@@ -888,15 +897,17 @@ func (s *transactionService) handlerRecurrenceUpdate(
 		data.transactions[i].TransactionRecurrence = &r
 		data.transactions[i].TransactionRecurrenceID = &r.ID
 
-		if data.scenario.HadRecurrence && !hasPastInstallments {
-			// Preserve existing installment numbers — they already have the correct offset
-			// from creation (e.g., installments 4-12 for current_installment=4, total=12).
+		if data.scenario.HadRecurrence && !shouldSplitRecurrence {
+			// Preserve existing installment numbers — either propagation!=current_and_future
+			// (numbers already correct from creation) or current_and_future where the
+			// recurrence itself is untouched (split-only, description-only, etc.).
 		} else if !data.scenario.HadRecurrence {
 			// Standalone → recurrence: number from CurrentInstallment.
 			startFrom := data.req.RecurrenceSettings.CurrentInstallment
 			data.transactions[i].InstallmentNumber = lo.ToPtr(startFrom + i)
 		} else {
-			// current_and_future with past installments: new recurrence, renumber from 1.
+			// current_and_future with past installments AND the recurrence itself changed
+			// (new type or new total): fresh recurrence, renumber from 1.
 			data.transactions[i].InstallmentNumber = lo.ToPtr(i + 1)
 		}
 

--- a/backend/internal/service/transaction_update_test.go
+++ b/backend/internal/service/transaction_update_test.go
@@ -4393,7 +4393,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestInstallmentScenario9b_RemoveS
 	}
 
 	// Installments 1 and 2 keep the split; 3 and 4 have the split removed.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		suite.Assert().Len(installmentsAfter[i].LinkedTransactions, 1,
 			"installment %d should keep split", i+1)
 	}
@@ -4498,7 +4498,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestInstallmentScenario10b_AddSpl
 	}
 
 	// Installments 1 and 2 remain without split; 3 and 4 gain split.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		suite.Assert().Len(installmentsAfter[i].LinkedTransactions, 0,
 			"installment %d should have no split", i+1)
 	}

--- a/backend/internal/service/transaction_update_test.go
+++ b/backend/internal/service/transaction_update_test.go
@@ -4608,6 +4608,92 @@ func (suite *TransactionUpdateWithDBTestSuite) TestInstallmentScenario17_EditDes
 	suite.Assert().Equal(4, recurrences[0].Installments)
 }
 
+// TestIssue83_EditDescriptionOnInstallment21Of24: regressão literal do reprodutor
+// reportado em https://github.com/mateusdeitos/finance_app/issues/83.
+// Recorrência 24x mensal com installments começando em 21 (21,22,23,24). O usuário
+// abre a parcela 21, edita APENAS a descrição, propagação "Esta e as próximas".
+// Esperado: "21 de 24" continua sendo "21 de 24", recorrência inalterada,
+// installment_numbers preservados, descrição aplicada apenas em 21..24.
+func (suite *TransactionUpdateWithDBTestSuite) TestIssue83_EditDescriptionOnInstallment21Of24() {
+	ctx := context.Background()
+	userA, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	accountA, err := suite.createTestAccount(ctx, userA)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, userA)
+	suite.Require().NoError(err)
+
+	d := now()
+	originalDescription := "Original description"
+	newDescription := "Updated description"
+
+	_, err = suite.Services.Transaction.Create(ctx, userA.ID, &domain.TransactionCreateRequest{
+		AccountID:       accountA.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          100,
+		Date:            d,
+		Description:     originalDescription,
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 21,
+			TotalInstallments:  24,
+		},
+	})
+	suite.Require().NoError(err)
+
+	installmentsBefore, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(installmentsBefore, 4, "should have 4 installments (21..24)")
+
+	originalRecurrenceID := lo.FromPtr(installmentsBefore[0].TransactionRecurrenceID)
+	installment21 := installmentsBefore[0]
+	suite.Require().Equal(21, lo.FromPtr(installment21.InstallmentNumber),
+		"first installment should be number 21")
+
+	err = suite.Services.Transaction.Update(ctx, installment21.ID, userA.ID, &domain.TransactionUpdateRequest{
+		PropagationSettings: domain.TransactionPropagationSettingsCurrentAndFuture,
+		Description:         lo.ToPtr(newDescription),
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 21,
+			TotalInstallments:  24,
+		},
+	})
+	suite.Require().NoError(err)
+
+	installmentsAfter, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(installmentsAfter, 4, "still 4 installments after update")
+
+	for i, t := range installmentsAfter {
+		expectedNumber := 21 + i
+		suite.Assert().Equal(expectedNumber, lo.FromPtr(t.InstallmentNumber),
+			"installment %d must keep its original number (no renumbering from 1)", expectedNumber)
+		suite.Assert().Equal(originalRecurrenceID, lo.FromPtr(t.TransactionRecurrenceID),
+			"installment %d must remain in the original recurrence", expectedNumber)
+		suite.Assert().Equal(newDescription, t.Description,
+			"installment %d description should be updated", expectedNumber)
+	}
+
+	recurrences, err := suite.Repos.TransactionRecurrence.Search(ctx, domain.TransactionRecurrenceFilter{
+		UserID: userA.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(recurrences, 1, "no new recurrence should be created")
+	suite.Assert().Equal(originalRecurrenceID, recurrences[0].ID, "original recurrence ID preserved")
+	suite.Assert().Equal(24, recurrences[0].Installments,
+		"recurrence.Installments must remain 24 (no fragmentation)")
+}
+
 func TestTransactionUpdateWithDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")

--- a/backend/internal/service/transaction_update_test.go
+++ b/backend/internal/service/transaction_update_test.go
@@ -4315,6 +4315,299 @@ func (suite *TransactionUpdateWithDBTestSuite) TestLinkedTransactionPropagation_
 	suite.Equal(newDesc, userBTransactions[0].Description, "userB's linked transaction description should be updated")
 }
 
+// TestInstallmentScenario9b: recorrência 4x mensal com split -> remove split da parcela 3
+// (propagation=current_and_future, installment > 1, total inalterado).
+// Regressão para issue #83: edições de parcela n>1 com current_and_future e total igual
+// ao original NÃO devem fragmentar a recorrência nem renumerar as parcelas.
+func (suite *TransactionUpdateWithDBTestSuite) TestInstallmentScenario9b_RemoveSplitPropagationCurrentAndFutureTotalUnchanged() {
+	ctx := context.Background()
+	userA, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	userB, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	accountA, err := suite.createTestAccount(ctx, userA)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, userA)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, userA.ID, userB.ID, 50)
+	suite.Require().NoError(err)
+
+	d := now()
+
+	_, err = suite.Services.Transaction.Create(ctx, userA.ID, &domain.TransactionCreateRequest{
+		AccountID:       accountA.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          100,
+		Date:            d,
+		Description:     "Test transaction",
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 1,
+			TotalInstallments:  4,
+		},
+		SplitSettings: []domain.SplitSettings{
+			{ConnectionID: conn.ID, Percentage: lo.ToPtr(50)},
+		},
+	})
+	suite.Require().NoError(err)
+
+	installmentsBefore, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(installmentsBefore, 4)
+
+	originalRecurrenceID := lo.FromPtr(installmentsBefore[0].TransactionRecurrenceID)
+	installment3 := installmentsBefore[2]
+	suite.Require().Equal(3, lo.FromPtr(installment3.InstallmentNumber))
+
+	err = suite.Services.Transaction.Update(ctx, installment3.ID, userA.ID, &domain.TransactionUpdateRequest{
+		PropagationSettings: domain.TransactionPropagationSettingsCurrentAndFuture,
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 3,
+			TotalInstallments:  4,
+		},
+		SplitSettings: []domain.SplitSettings{},
+	})
+	suite.Require().NoError(err)
+
+	// All 4 userA installments must remain in the SAME recurrence with ORIGINAL numbers.
+	installmentsAfter, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(installmentsAfter, 4, "userA should still have 4 installments")
+
+	for i, t := range installmentsAfter {
+		suite.Assert().Equal(i+1, lo.FromPtr(t.InstallmentNumber), "installment numbers must be preserved")
+		suite.Assert().Equal(originalRecurrenceID, lo.FromPtr(t.TransactionRecurrenceID),
+			"all installments must stay in the original recurrence")
+	}
+
+	// Installments 1 and 2 keep the split; 3 and 4 have the split removed.
+	for i := 0; i < 2; i++ {
+		suite.Assert().Len(installmentsAfter[i].LinkedTransactions, 1,
+			"installment %d should keep split", i+1)
+	}
+	for i := 2; i < 4; i++ {
+		suite.Assert().Len(installmentsAfter[i].LinkedTransactions, 0,
+			"installment %d should have split removed", i+1)
+	}
+
+	// Recurrence.Installments must remain 4 — no fragmentation.
+	recurrences, err := suite.Repos.TransactionRecurrence.Search(ctx, domain.TransactionRecurrenceFilter{
+		UserID: userA.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(recurrences, 1, "no new recurrence should be created")
+	suite.Assert().Equal(4, recurrences[0].Installments, "original recurrence Installments must stay 4")
+	suite.Assert().Equal(originalRecurrenceID, recurrences[0].ID)
+
+	// userB's 3 and 4 linked transactions must be gone; 1 and 2 remain.
+	userBAfter, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userB.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(userBAfter, 2, "userB should have only 2 linked transactions left")
+	for i, t := range userBAfter {
+		suite.Assert().Equal(i+1, lo.FromPtr(t.InstallmentNumber))
+	}
+}
+
+// TestInstallmentScenario10b: recorrência 4x mensal sem split -> adiciona split na parcela 3
+// (propagation=current_and_future, installment > 1, total inalterado).
+// Gêmeo do 11, mas sem encolher o total: a recorrência deve permanecer íntegra e os
+// installment_numbers preservados.
+func (suite *TransactionUpdateWithDBTestSuite) TestInstallmentScenario10b_AddSplitPropagationCurrentAndFutureTotalUnchanged() {
+	ctx := context.Background()
+	userA, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	userB, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	accountA, err := suite.createTestAccount(ctx, userA)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, userA)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, userA.ID, userB.ID, 50)
+	suite.Require().NoError(err)
+
+	d := now()
+
+	_, err = suite.Services.Transaction.Create(ctx, userA.ID, &domain.TransactionCreateRequest{
+		AccountID:       accountA.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          100,
+		Date:            d,
+		Description:     "Test transaction",
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 1,
+			TotalInstallments:  4,
+		},
+	})
+	suite.Require().NoError(err)
+
+	installmentsBefore, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(installmentsBefore, 4)
+
+	originalRecurrenceID := lo.FromPtr(installmentsBefore[0].TransactionRecurrenceID)
+	installment3 := installmentsBefore[2]
+
+	err = suite.Services.Transaction.Update(ctx, installment3.ID, userA.ID, &domain.TransactionUpdateRequest{
+		PropagationSettings: domain.TransactionPropagationSettingsCurrentAndFuture,
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 3,
+			TotalInstallments:  4,
+		},
+		SplitSettings: []domain.SplitSettings{
+			{ConnectionID: conn.ID, Percentage: lo.ToPtr(50)},
+		},
+	})
+	suite.Require().NoError(err)
+
+	installmentsAfter, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(installmentsAfter, 4, "userA should still have 4 installments")
+
+	for i, t := range installmentsAfter {
+		suite.Assert().Equal(i+1, lo.FromPtr(t.InstallmentNumber), "installment numbers must be preserved")
+		suite.Assert().Equal(originalRecurrenceID, lo.FromPtr(t.TransactionRecurrenceID),
+			"all installments must stay in the original recurrence")
+	}
+
+	// Installments 1 and 2 remain without split; 3 and 4 gain split.
+	for i := 0; i < 2; i++ {
+		suite.Assert().Len(installmentsAfter[i].LinkedTransactions, 0,
+			"installment %d should have no split", i+1)
+	}
+	for i := 2; i < 4; i++ {
+		suite.Assert().Len(installmentsAfter[i].LinkedTransactions, 1,
+			"installment %d should have split", i+1)
+	}
+
+	recurrences, err := suite.Repos.TransactionRecurrence.Search(ctx, domain.TransactionRecurrenceFilter{
+		UserID: userA.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(recurrences, 1, "no new recurrence should be created for userA")
+	suite.Assert().Equal(4, recurrences[0].Installments)
+	suite.Assert().Equal(originalRecurrenceID, recurrences[0].ID)
+
+	userBAfter, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userB.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(userBAfter, 2, "userB should have 2 linked transactions")
+	for i, t := range userBAfter {
+		suite.Assert().Equal(i+3, lo.FromPtr(t.InstallmentNumber),
+			"userB linked installment numbers must match userA (3 and 4)")
+	}
+}
+
+// TestInstallmentScenario17: recorrência 4x mensal, edita APENAS a descrição da parcela 3
+// (propagation=current_and_future, installment > 1).
+// A recorrência deve permanecer intacta, nenhum número de parcela pode ser alterado e
+// apenas as descrições das parcelas 3 e 4 devem mudar.
+func (suite *TransactionUpdateWithDBTestSuite) TestInstallmentScenario17_EditDescriptionOnlyPropagationCurrentAndFuture() {
+	ctx := context.Background()
+	userA, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	accountA, err := suite.createTestAccount(ctx, userA)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, userA)
+	suite.Require().NoError(err)
+
+	d := now()
+	originalDescription := "Original description"
+	newDescription := "Updated description"
+
+	_, err = suite.Services.Transaction.Create(ctx, userA.ID, &domain.TransactionCreateRequest{
+		AccountID:       accountA.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          100,
+		Date:            d,
+		Description:     originalDescription,
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 1,
+			TotalInstallments:  4,
+		},
+	})
+	suite.Require().NoError(err)
+
+	installmentsBefore, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(installmentsBefore, 4)
+
+	originalRecurrenceID := lo.FromPtr(installmentsBefore[0].TransactionRecurrenceID)
+	installment3 := installmentsBefore[2]
+
+	err = suite.Services.Transaction.Update(ctx, installment3.ID, userA.ID, &domain.TransactionUpdateRequest{
+		PropagationSettings: domain.TransactionPropagationSettingsCurrentAndFuture,
+		Description:         lo.ToPtr(newDescription),
+		RecurrenceSettings: &domain.RecurrenceSettings{
+			Type:               domain.RecurrenceTypeMonthly,
+			CurrentInstallment: 3,
+			TotalInstallments:  4,
+		},
+	})
+	suite.Require().NoError(err)
+
+	installmentsAfter, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &userA.ID,
+		SortBy: &domain.SortBy{Field: "installment_number", Order: domain.SortOrderAsc},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(installmentsAfter, 4)
+
+	for i, t := range installmentsAfter {
+		suite.Assert().Equal(i+1, lo.FromPtr(t.InstallmentNumber), "installment numbers must be preserved")
+		suite.Assert().Equal(originalRecurrenceID, lo.FromPtr(t.TransactionRecurrenceID),
+			"recurrence must remain the same")
+	}
+
+	suite.Assert().Equal(originalDescription, installmentsAfter[0].Description, "installment 1 description unchanged")
+	suite.Assert().Equal(originalDescription, installmentsAfter[1].Description, "installment 2 description unchanged")
+	suite.Assert().Equal(newDescription, installmentsAfter[2].Description, "installment 3 description updated")
+	suite.Assert().Equal(newDescription, installmentsAfter[3].Description, "installment 4 description updated")
+
+	recurrences, err := suite.Repos.TransactionRecurrence.Search(ctx, domain.TransactionRecurrenceFilter{
+		UserID: userA.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(recurrences, 1, "no new recurrence should be created")
+	suite.Assert().Equal(4, recurrences[0].Installments)
+}
+
 func TestTransactionUpdateWithDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")


### PR DESCRIPTION
Fixes #83.

## Problem

Editing a recurring installment `n > 1` with propagation `current_and_future` was always fragmenting the recurrence and renumbering the affected installments from 1 — even when the user had only touched an attribute (split, description, amount, account, category, date, tags) and left `Type`/`TotalInstallments` unchanged.

Reproduction from the issue: a 24× recurrence, edit installment 21 removing the split → installment becomes "1 of 24" instead of "21 of 24", and a second `TransactionRecurrence` is spawned with `Installments = 24` while only 4 transactions actually reference it.

## Root cause

[transaction_update.go:829-846](backend/internal/service/transaction_update.go) (`handlerRecurrenceUpdate`) used `hasPastInstallments` alone to decide whether to shrink the old recurrence and renumber from 1. That flag is true for any `current_and_future + installment_number > 1` edit, so pure attribute propagations ran the fragmentation path.

## Fix

Introduced `recurrenceSettingsChanged` (`Type` or `TotalInstallments` differs from the stored recurrence) and gate both the shrink and the renumber on it:

- `shouldSplitRecurrence = hasPastInstallments && recurrenceSettingsChanged`
- When false, the existing `TransactionRecurrence` is reused and `installment_number` is preserved for all transactions in the batch.

No changes to the frontend — it still echoes `total_installments` from the current recurrence, which now correctly signals "no change".

## Impact on existing scenarios

| Scenario | propagation | total changes? | path |
|---|---|---|---|
| 7 (5→2) | `current_and_future` | ✅ | fragment + renumber (unchanged) |
| 11 (3→2) | `current_and_future` | ✅ | fragment + renumber (unchanged) |
| 9/10 | `all` / `current` | n/a | already preserved |

## New test coverage

Integration scenarios added to `transaction_update_test.go` and documented in `.claude/rules/transaction-update-installment-scenarios.md`:

- **9b** — Remove split, `current_and_future`, installment 3 of 4, total unchanged → recurrence intact, numbers preserved, installments 3 and 4 lose split.
- **10b** — Add split, `current_and_future`, installment 3 of 4, total unchanged → recurrence intact, userB gets 2 linked transactions numbered 3 and 4.
- **17** — Description-only edit, `current_and_future`, installment 3 of 4 → recurrence untouched, only installments 3 and 4 adopt the new description.

## Test plan

- [x] `go test -tags=integration -run "TestTransactionUpdateWithDB/TestInstallmentScenario"` — all 18 scenarios pass.
- [x] `go build ./...` clean.
- [ ] Manual sanity: reproduce the exact steps from the issue in dev (24× recurrence, edit installment 21 removing split, propagation `Esta e as próximas`) — installment should remain "21 de 24" and `transaction_recurrences` should show a single row with `installments = 24`.

## Migration / data repair

Records already corrupted by the bug will have `transaction_recurrences.installments != COUNT(transactions referring to it)`. A follow-up SQL repair is out of scope of this PR; the issue has the suggested approach under the workaround section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)