### PR TITLE
fix(test): add missing split settings to linked transaction validation test

### DIFF
--- a/backend/internal/service/transaction_update_test.go
+++ b/backend/internal/service/transaction_update_test.go
@@ -3954,7 +3954,9 @@ func (suite *TransactionUpdateWithDBTestSuite) TestLinkedTransactionValidation_R
 		AccountID:       accountA.ID,
 		TransactionType: domain.TransactionTypeExpense,
 		CategoryID:      categoryA.ID,
-		SplitSettings:   []domain.SplitSettings{},
+		SplitSettings: []domain.SplitSettings{
+			{ConnectionID: connection.ID, Percentage: lo.ToPtr(50)},
+		},
 	}
 
 	_, err = suite.Services.Transaction.Create(ctx, userA.ID, createReq)


### PR DESCRIPTION
## Summary

- `TestLinkedTransactionValidation_RejectsDisallowedFields` at [transaction_update_test.go:3933](backend/internal/service/transaction_update_test.go) has been failing on `main` and blocking every PR's CI.
- The test created a `TransactionCreateRequest` with an empty `SplitSettings` slice, then asserted `Len(parentTx.LinkedTransactions, 1)` — impossible without a split — so the `suite.Require().Len` call panicked.
- Introduced by [#71](https://github.com/mateusdeitos/finance_app/pull/71); the `"shared expense for disallowed fields test"` description and the `createAcceptedTestUserConnection(..., 50)` setup show the author intended a 50/50 split.
- Fix: populate `SplitSettings` with `{ConnectionID: connection.ID, Percentage: lo.ToPtr(50)}` so the parent actually spawns a linked transaction for userB.

No production code changes — test-only fix.

## Test plan

- [x] `go test -tags=integration -count=1 -run "TestTransactionUpdateWithDB/TestLinkedTransactionValidation_RejectsDisallowedFields" ./internal/service/` → PASS
- [x] Full `TestLinkedTransactionValidation` suite (`_RejectsDisallowedFields`, `_AllowsPermittedFields`, `_AllowsTagsOnly`) → all PASS, including all 6 disallowed-field subtests (amount, account_id, transaction_type, recurrence_settings, split_settings, destination_account_id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)