### PR TITLE
refactor(frontend): introduce TestIds registry for src + e2e (Phase 8)

### DIFF
--- a/frontend/e2e/pages/AccountsPage.ts
+++ b/frontend/e2e/pages/AccountsPage.ts
@@ -1,4 +1,5 @@
 import { type Page, type Locator, expect } from '@playwright/test'
+import { AccountsTestIds } from '@/testIds'
 
 export class AccountsPage {
   readonly page: Page
@@ -6,7 +7,7 @@ export class AccountsPage {
 
   constructor(page: Page) {
     this.page = page
-    this.newAccountButton = page.getByTestId('btn_new_account')
+    this.newAccountButton = page.getByTestId(AccountsTestIds.BtnNew)
   }
 
   async goto() {
@@ -16,14 +17,14 @@ export class AccountsPage {
 
   async openCreateForm() {
     await this.newAccountButton.click()
-    await expect(this.page.getByTestId('account_form')).toBeVisible()
+    await expect(this.page.getByTestId(AccountsTestIds.Form)).toBeVisible()
   }
 
   async fillForm(name: string, balanceCents = 0) {
-    const form = this.page.getByTestId('account_form')
-    await form.getByTestId('input_account_name').fill(name)
+    const form = this.page.getByTestId(AccountsTestIds.Form)
+    await form.getByTestId(AccountsTestIds.InputName).fill(name)
     if (balanceCents !== 0) {
-      const balanceInput = form.getByTestId('input_initial_balance')
+      const balanceInput = form.getByTestId(AccountsTestIds.InputInitialBalance)
       await balanceInput.click()
       for (const digit of String(balanceCents)) {
         await balanceInput.press(digit)
@@ -32,8 +33,8 @@ export class AccountsPage {
   }
 
   async submitForm() {
-    await this.page.getByTestId('btn_account_save').click()
-    await expect(this.page.getByTestId('account_form')).not.toBeVisible({ timeout: 5000 })
+    await this.page.getByTestId(AccountsTestIds.BtnSave).click()
+    await expect(this.page.getByTestId(AccountsTestIds.Form)).not.toBeVisible({ timeout: 5000 })
   }
 
   private getCardByName(name: string): Locator {
@@ -41,12 +42,12 @@ export class AccountsPage {
   }
 
   async editAccount(accountName: string) {
-    await this.getCardByName(accountName).getByTestId('btn_account_edit').click()
-    await expect(this.page.getByTestId('account_form')).toBeVisible()
+    await this.getCardByName(accountName).getByTestId(AccountsTestIds.BtnEdit).click()
+    await expect(this.page.getByTestId(AccountsTestIds.Form)).toBeVisible()
   }
 
   async clickAccountAction(accountName: string) {
-    await this.getCardByName(accountName).getByTestId('btn_account_action').click()
+    await this.getCardByName(accountName).getByTestId(AccountsTestIds.BtnAction).click()
   }
 
   async deactivateAccount(accountName: string) {

--- a/frontend/e2e/pages/CategoriesPage.ts
+++ b/frontend/e2e/pages/CategoriesPage.ts
@@ -1,4 +1,5 @@
 import { type Page, type Locator, expect } from '@playwright/test'
+import { CategoriesTestIds } from '@/testIds'
 
 export class CategoriesPage {
   readonly page: Page
@@ -13,8 +14,8 @@ export class CategoriesPage {
   }
 
   async createRootCategory(name: string) {
-    const firstCatButton = this.page.getByTestId('btn_create_first_category')
-    const newCatButton = this.page.getByTestId('btn_new_category')
+    const firstCatButton = this.page.getByTestId(CategoriesTestIds.BtnCreateFirst)
+    const newCatButton = this.page.getByTestId(CategoriesTestIds.BtnNew)
 
     if (await firstCatButton.isVisible()) {
       await firstCatButton.click()
@@ -22,7 +23,7 @@ export class CategoriesPage {
       await newCatButton.click()
     }
 
-    const input = this.page.getByTestId('input_new_category_name')
+    const input = this.page.getByTestId(CategoriesTestIds.InputNewName)
     await expect(input).toBeVisible()
     await input.fill(name)
     await input.press('Enter')
@@ -30,9 +31,9 @@ export class CategoriesPage {
   }
 
   async createSubcategory(parentName: string, childName: string) {
-    await this.getCategoryRow(parentName).getByTestId('btn_add_subcategory').click()
+    await this.getCategoryRow(parentName).getByTestId(CategoriesTestIds.BtnAddSubcategory).click()
 
-    const input = this.page.getByTestId('input_new_category_name')
+    const input = this.page.getByTestId(CategoriesTestIds.InputNewName)
     await expect(input).toBeVisible()
     await input.fill(childName)
     await input.press('Enter')
@@ -40,9 +41,9 @@ export class CategoriesPage {
   }
 
   async editCategoryName(oldName: string, newName: string) {
-    await this.getCategoryRow(oldName).getByTestId('btn_category_name').click()
+    await this.getCategoryRow(oldName).getByTestId(CategoriesTestIds.BtnName).click()
 
-    const input = this.page.getByTestId('input_category_name')
+    const input = this.page.getByTestId(CategoriesTestIds.InputName)
     await expect(input).toBeVisible()
     await input.fill(newName)
     await input.press('Enter')
@@ -50,9 +51,9 @@ export class CategoriesPage {
   }
 
   async deleteCategory(name: string) {
-    await this.getCategoryRow(name).getByTestId('btn_category_delete').click()
-    await this.page.getByTestId('btn_confirm_delete_category').click()
-    await expect(this.page.getByTestId('btn_confirm_delete_category')).not.toBeVisible({ timeout: 5000 })
+    await this.getCategoryRow(name).getByTestId(CategoriesTestIds.BtnDelete).click()
+    await this.page.getByTestId(CategoriesTestIds.BtnConfirmDelete).click()
+    await expect(this.page.getByTestId(CategoriesTestIds.BtnConfirmDelete)).not.toBeVisible({ timeout: 5000 })
   }
 
   private getCategoryRow(name: string): Locator {

--- a/frontend/e2e/pages/ChargesPage.ts
+++ b/frontend/e2e/pages/ChargesPage.ts
@@ -1,4 +1,5 @@
 import { type Page, type Locator, expect } from "@playwright/test";
+import { ChargesTestIds, CommonTestIds } from '@/testIds'
 
 export class ChargesPage {
   readonly page: Page;
@@ -9,10 +10,10 @@ export class ChargesPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.createDrawer = page.getByTestId("drawer_create_charge");
-    this.acceptDrawer = page.getByTestId("drawer_accept_charge");
-    this.rejectModal = page.getByTestId("modal_confirm_reject_charge");
-    this.cancelModal = page.getByTestId("modal_confirm_cancel_charge");
+    this.createDrawer = page.getByTestId(ChargesTestIds.DrawerCreate);
+    this.acceptDrawer = page.getByTestId(ChargesTestIds.DrawerAccept);
+    this.rejectModal = page.getByTestId(ChargesTestIds.ModalConfirm('reject'));
+    this.cancelModal = page.getByTestId(ChargesTestIds.ModalConfirm('cancel'));
   }
 
   async goto() {
@@ -28,12 +29,12 @@ export class ChargesPage {
   // --- Tabs ---
 
   async selectReceivedTab() {
-    await this.page.getByTestId("tab_charges_received").click();
+    await this.page.getByTestId(ChargesTestIds.Tab('received')).click();
     await this.page.waitForLoadState("networkidle");
   }
 
   async selectSentTab() {
-    await this.page.getByTestId("tab_charges_sent").click();
+    await this.page.getByTestId(ChargesTestIds.Tab('sent')).click();
     await this.page.waitForLoadState("networkidle");
   }
 
@@ -57,7 +58,7 @@ export class ChargesPage {
     // Wait for network to settle first so accounts/connections are loaded before the drawer mounts.
     // This ensures singleConnection is computed correctly in the drawer's defaultValues.
     await this.page.waitForLoadState("networkidle");
-    await this.page.getByTestId("btn_new_charge").first().click();
+    await this.page.getByTestId(ChargesTestIds.BtnNew).first().click();
     await expect(this.createDrawer).toBeVisible({ timeout: 5000 });
   }
 
@@ -69,13 +70,13 @@ export class ChargesPage {
   }) {
     // If the connection dropdown is visible (multiple connections or accounts still loading),
     // select the first available option so connection_id gets set.
-    const connectionSelect = this.createDrawer.getByTestId("select_connection");
+    const connectionSelect = this.createDrawer.getByTestId(ChargesTestIds.SelectConnection);
     if (await connectionSelect.isVisible({ timeout: 1000 }).catch(() => false)) {
       await connectionSelect.click();
       await this.page.getByRole("option").first().click();
     }
 
-    const accountSelect = this.createDrawer.getByTestId("select_my_account");
+    const accountSelect = this.createDrawer.getByTestId(ChargesTestIds.SelectMyAccount);
     await accountSelect.click();
     await this.page.getByRole("option", { name: opts.accountName }).click();
 
@@ -83,64 +84,64 @@ export class ChargesPage {
     await this.createDrawer.getByTestId(radioTestId).check();
 
     if (opts.amount != null) {
-      const amountInput = this.createDrawer.getByTestId("input_charge_amount");
+      const amountInput = this.createDrawer.getByTestId(ChargesTestIds.InputAmount);
       await amountInput.fill(opts.amount.toFixed(2).replace(".", ","));
     }
 
     if (opts.description) {
-      await this.createDrawer.getByTestId("input_charge_description").fill(opts.description);
+      await this.createDrawer.getByTestId(ChargesTestIds.InputDescription).fill(opts.description);
     }
   }
 
   async submitCreate() {
-    await this.createDrawer.getByTestId("btn_submit_create_charge").click();
+    await this.createDrawer.getByTestId(ChargesTestIds.BtnSubmitCreate).click();
     await expect(this.createDrawer).not.toBeVisible({ timeout: 10000 });
   }
 
   // --- Accept ---
 
   async clickAccept() {
-    await this.page.getByTestId("btn_accept_charge").first().click();
+    await this.page.getByTestId(ChargesTestIds.BtnAccept).first().click();
     await expect(this.acceptDrawer).toBeVisible({ timeout: 5000 });
   }
 
   async fillAcceptForm(accountName: string) {
-    const accountSelect = this.acceptDrawer.getByTestId("select_accept_account");
+    const accountSelect = this.acceptDrawer.getByTestId(ChargesTestIds.SelectAcceptAccount);
     await accountSelect.click();
     await this.page.getByRole("option", { name: accountName }).click();
   }
 
   async submitAccept() {
-    await this.acceptDrawer.getByTestId("btn_submit_accept_charge").click();
+    await this.acceptDrawer.getByTestId(ChargesTestIds.BtnSubmitAccept).click();
     await expect(this.acceptDrawer).not.toBeVisible({ timeout: 10000 });
   }
 
   // --- Reject / Cancel ---
 
   async clickReject() {
-    await this.page.getByTestId("btn_reject_charge").first().click();
+    await this.page.getByTestId(ChargesTestIds.BtnReject).first().click();
     await expect(this.rejectModal).toBeVisible({ timeout: 5000 });
   }
 
   async confirmReject() {
-    await this.rejectModal.getByTestId("btn_confirm_reject_charge").click();
+    await this.rejectModal.getByTestId(ChargesTestIds.BtnConfirm('reject')).click();
     await expect(this.rejectModal).not.toBeVisible({ timeout: 10000 });
   }
 
   async clickCancel() {
-    await this.page.getByTestId("btn_cancel_charge").first().click();
+    await this.page.getByTestId(ChargesTestIds.BtnCancel).first().click();
     await expect(this.cancelModal).toBeVisible({ timeout: 5000 });
   }
 
   async confirmCancel() {
-    await this.cancelModal.getByTestId("btn_confirm_cancel_charge").click();
+    await this.cancelModal.getByTestId(ChargesTestIds.BtnConfirm('cancel')).click();
     await expect(this.cancelModal).not.toBeVisible({ timeout: 10000 });
   }
 
   // --- Sidebar Badge ---
 
   async getSidebarBadgeCount(): Promise<number | null> {
-    const badge = this.page.getByTestId("nav_badge_charges");
+    const badge = this.page.getByTestId(CommonTestIds.NavBadge("charges"));
     if (await badge.isVisible({ timeout: 3000 }).catch(() => false)) {
       const text = await badge.textContent();
       return text ? parseInt(text) : null;

--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -1,5 +1,5 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-
+import { AccountsTestIds, CategoriesTestIds, ImportTestIds, TransactionsTestIds } from '@/testIds'
 export class ImportPage {
   readonly page: Page;
   readonly uploadStep: Locator;
@@ -10,25 +10,25 @@ export class ImportPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.uploadStep = page.getByTestId("import_upload_step");
-    this.reviewStep = page.getByTestId("import_review_step");
-    this.finishedStep = page.getByTestId("finished_import_successfully_step");
-    this.processButton = page.getByTestId("btn_process_csv");
-    this.confirmButton = page.getByTestId("btn_confirm_import");
+    this.uploadStep = page.getByTestId(ImportTestIds.UploadStep);
+    this.reviewStep = page.getByTestId(ImportTestIds.ReviewStep);
+    this.finishedStep = page.getByTestId(ImportTestIds.FinishedStep);
+    this.processButton = page.getByTestId(ImportTestIds.BtnProcessCSV);
+    this.confirmButton = page.getByTestId(ImportTestIds.BtnConfirm);
   }
 
   /** Navigate to /transactions and click "Importar transações" in the overflow menu. */
   async goto() {
     await this.page.goto("/transactions");
     await this.page.waitForLoadState("networkidle");
-    await this.page.getByTestId("btn_more_options").first().click();
-    await this.page.getByTestId("menu_item_import_transactions").click();
+    await this.page.getByTestId(TransactionsTestIds.BtnMoreOptions).first().click();
+    await this.page.getByTestId(TransactionsTestIds.MenuItemImportTransactions).click();
     await expect(this.uploadStep).toBeVisible({ timeout: 8000 });
   }
 
   /** Select the account in the upload step (Mantine Select is readonly, use click+option). */
   async selectAccount(accountName: string) {
-    const input = this.uploadStep.getByTestId("select_import_account");
+    const input = this.uploadStep.getByTestId(ImportTestIds.SelectAccount);
     await input.click();
     // Mantine Select options are portalled — documented escape (see Phase 7 plan).
     await this.page.getByRole("option", { name: accountName }).click();
@@ -42,7 +42,7 @@ export class ImportPage {
     // probe. This is native HTML (not Mantine internals), scoped to the
     // testid wrapper — survives Mantine upgrades.
     const fileInput = this.uploadStep
-      .getByTestId("input_csv_file")
+      .getByTestId(ImportTestIds.InputCsvFile)
       .locator('input[type="file"]');
     await fileInput.setInputFiles({
       name: "import.csv",
@@ -109,11 +109,11 @@ export class ImportPage {
    * Returns: "idle" | "loading" | "success" | "error" (plus "pending" fallback).
    */
   async getRowStatus(rowIndex: number): Promise<string> {
-    const statusCell = this.reviewStep.getByTestId(`import_status_${rowIndex}`);
+    const statusCell = this.reviewStep.getByTestId(ImportTestIds.RowStatus(rowIndex));
     const status = await statusCell.getAttribute("data-status");
     if (status && status !== "idle") return status;
     // idle → fall back to the row's action (e.g. "duplicate", "skip")
-    const actionSelect = this.reviewStep.getByTestId(`select_import_action_${rowIndex}`);
+    const actionSelect = this.reviewStep.getByTestId(ImportTestIds.RowSelectAction(rowIndex));
     const value = await actionSelect
       .locator("input")
       .inputValue()
@@ -123,7 +123,7 @@ export class ImportPage {
 
   /** Set the category for a row via the searchable category select. */
   async setRowCategory(rowIndex: number, categoryName: string) {
-    const select = this.reviewStep.getByTestId(`select_category_${rowIndex}`);
+    const select = this.reviewStep.getByTestId(ImportTestIds.RowSelectCategory(rowIndex));
     await select.click();
     await select.fill(categoryName);
     await this.page.getByRole("option", { name: categoryName }).click();
@@ -131,30 +131,30 @@ export class ImportPage {
 
   /** Click the + button next to the category select to open the category creation drawer. */
   async openCreateCategoryDrawer(rowIndex: number) {
-    await this.reviewStep.getByTestId(`btn_create_category_row_${rowIndex}`).click();
+    await this.reviewStep.getByTestId(ImportTestIds.RowBtnCreateCategory(rowIndex)).click();
     await expect(
       this.page
-        .getByTestId("drawer_create_category")
-        .getByTestId("btn_new_category_in_drawer"),
+        .getByTestId(ImportTestIds.DrawerCreateCategory)
+        .getByTestId(ImportTestIds.BtnNewCategoryInDrawer),
     ).toBeVisible({ timeout: 5000 });
   }
 
   /** Click the + button next to the account select in the upload step header. */
   async openCreateAccountDrawerFromHeader() {
-    await this.uploadStep.getByTestId("btn_create_account_header").click();
-    await expect(this.page.getByTestId("account_form")).toBeVisible({ timeout: 5000 });
+    await this.uploadStep.getByTestId(ImportTestIds.BtnCreateAccountHeader).click();
+    await expect(this.page.getByTestId(AccountsTestIds.Form)).toBeVisible({ timeout: 5000 });
   }
 
   /** Create a new category inside the category drawer and close it. */
   async createCategoryInDrawer(name: string, opts?: { emoji?: string }) {
-    const drawer = this.page.getByTestId("drawer_create_category");
+    const drawer = this.page.getByTestId(ImportTestIds.DrawerCreateCategory);
     // Click "Nova Categoria" to show the inline input (may already be visible)
-    const newButton = drawer.getByTestId("btn_new_category_in_drawer");
+    const newButton = drawer.getByTestId(ImportTestIds.BtnNewCategoryInDrawer);
     if (await newButton.isVisible()) {
       await newButton.click();
     }
     // Wait for and fill the inline input
-    const input = drawer.getByTestId("input_new_category_name");
+    const input = drawer.getByTestId(CategoriesTestIds.InputNewName);
     await expect(input).toBeVisible({ timeout: 5000 });
     await input.fill(name);
     await input.press("Enter");
@@ -169,11 +169,11 @@ export class ImportPage {
       const emojiTestId = await emojiButton.getAttribute("data-testid");
       const categoryId = emojiTestId!.replace("btn_emoji_", "");
       await emojiButton.click();
-      const emojiOption = this.page.getByTestId(`emoji_${opts.emoji}`).first();
+      const emojiOption = this.page.getByTestId(CategoriesTestIds.EmojiOption(opts.emoji)).first();
       await expect(emojiOption).toBeVisible({ timeout: 5000 });
       await emojiOption.click();
       // Close the emoji picker drawer (saves on close)
-      const emojiDrawer = this.page.getByTestId(`drawer_emoji_picker_${categoryId}`);
+      const emojiDrawer = this.page.getByTestId(CategoriesTestIds.DrawerEmojiPicker(categoryId));
       await emojiDrawer.getByRole("button", { name: "Fechar" }).click();
       await expect(emojiDrawer).not.toBeVisible({ timeout: 5000 });
       // Wait for save to complete
@@ -181,34 +181,34 @@ export class ImportPage {
     }
 
     // Close the drawer
-    await drawer.getByTestId("btn_close_create_category_drawer").click();
+    await drawer.getByTestId(ImportTestIds.BtnCloseCreateCategoryDrawer).click();
     await expect(drawer).not.toBeVisible({ timeout: 5000 });
   }
 
   /** Create a new account inside the account drawer. */
   async createAccountInDrawer(name: string) {
-    const form = this.page.getByTestId("account_form");
-    await form.getByTestId("input_account_name").fill(name);
-    await form.getByTestId("btn_account_save").click();
+    const form = this.page.getByTestId(AccountsTestIds.Form);
+    await form.getByTestId(AccountsTestIds.InputName).fill(name);
+    await form.getByTestId(AccountsTestIds.BtnSave).click();
     await expect(form).not.toBeVisible({ timeout: 10000 });
   }
 
   /** Get the current value of the category select for a row. */
   async getRowCategoryValue(rowIndex: number): Promise<string> {
-    const select = this.reviewStep.getByTestId(`select_category_${rowIndex}`);
+    const select = this.reviewStep.getByTestId(ImportTestIds.RowSelectCategory(rowIndex));
     return select.inputValue();
   }
 
   /** Get the current value of the main account select in the upload step. */
   async getHeaderAccountValue(): Promise<string> {
-    const select = this.uploadStep.getByTestId("select_import_account");
+    const select = this.uploadStep.getByTestId(ImportTestIds.SelectAccount);
     return select.inputValue();
   }
 
   /** Click a row's checkbox, optionally holding Shift. */
   async toggleRowCheckbox(rowIndex: number, options?: { shiftKey?: boolean }) {
     const checkbox = this.reviewStep
-      .getByTestId(`checkbox_import_row_${rowIndex}`)
+      .getByTestId(ImportTestIds.RowCheckbox(rowIndex))
       .locator("input");
     if (options?.shiftKey) {
       await checkbox.click({ modifiers: ["Shift"] });
@@ -220,7 +220,7 @@ export class ImportPage {
   /** Return whether a row's checkbox is checked. */
   async isRowSelected(rowIndex: number): Promise<boolean> {
     return this.reviewStep
-      .getByTestId(`checkbox_import_row_${rowIndex}`)
+      .getByTestId(ImportTestIds.RowCheckbox(rowIndex))
       .locator("input")
       .isChecked();
   }
@@ -232,14 +232,14 @@ export class ImportPage {
       skip: "Não importar",
       duplicate: "Duplicado",
     };
-    const select = this.reviewStep.getByTestId(`select_import_action_${rowIndex}`);
+    const select = this.reviewStep.getByTestId(ImportTestIds.RowSelectAction(rowIndex));
     await select.click();
     await this.page.getByRole("option", { name: labels[action] }).click();
   }
 
   /** Check whether a row's action select shows a particular value (by visible label). */
   async getRowActionLabel(rowIndex: number): Promise<string> {
-    const select = this.reviewStep.getByTestId(`select_import_action_${rowIndex}`);
+    const select = this.reviewStep.getByTestId(ImportTestIds.RowSelectAction(rowIndex));
     return select.locator("input").inputValue();
   }
 }

--- a/frontend/e2e/pages/TransactionsPage.ts
+++ b/frontend/e2e/pages/TransactionsPage.ts
@@ -1,5 +1,5 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-
+import { TransactionsTestIds, type PropagationOption } from '@/testIds'
 export class TransactionsPage {
   readonly page: Page;
   readonly formDrawer: Locator;
@@ -7,8 +7,8 @@ export class TransactionsPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.formDrawer = page.getByTestId("drawer_create_transaction");
-    this.updateDrawer = page.getByTestId("drawer_update_transaction");
+    this.formDrawer = page.getByTestId(TransactionsTestIds.DrawerCreate);
+    this.updateDrawer = page.getByTestId(TransactionsTestIds.DrawerUpdate);
   }
 
   async goto() {
@@ -22,12 +22,12 @@ export class TransactionsPage {
   }
 
   async openAdvancedFilters() {
-    await this.page.getByTestId("open_advanced_filters").click();
+    await this.page.getByTestId(TransactionsTestIds.BtnOpenAdvancedFilters).click();
   }
 
   async selectGroupBy(option: 'date' | 'category' | 'account') {
     const labelMap: Record<string, string> = { date: 'Data', category: 'Categoria', account: 'Conta' }
-    await this.page.getByTestId('segmented_group_by').getByText(labelMap[option]).click()
+    await this.page.getByTestId(TransactionsTestIds.SegmentedGroupBy).getByText(labelMap[option]).click()
     await this.page.waitForLoadState('networkidle')
   }
 
@@ -43,13 +43,13 @@ export class TransactionsPage {
 
   /** Clear the description input and type a new value. */
   async clearAndFillDescription(description: string) {
-    const input = this.updateDrawer.getByTestId("input_description");
+    const input = this.updateDrawer.getByTestId(TransactionsTestIds.InputDescription);
     await input.fill(description);
   }
 
   /** Replace amount in the update form by selecting all and pressing digits. */
   async clearAndFillAmount(amountCents: number) {
-    const input = this.updateDrawer.getByTestId("input_amount");
+    const input = this.updateDrawer.getByTestId(TransactionsTestIds.InputAmount);
     await input.click();
     await input.press("Control+a");
     for (const digit of String(amountCents)) {
@@ -59,7 +59,7 @@ export class TransactionsPage {
 
   /** Click save in the update drawer and wait for it to close. */
   async submitUpdate() {
-    await this.updateDrawer.getByTestId("btn_save_transaction").click();
+    await this.updateDrawer.getByTestId(TransactionsTestIds.BtnSave).click();
     await expect(this.updateDrawer).not.toBeVisible({ timeout: 10000 });
   }
 
@@ -68,18 +68,18 @@ export class TransactionsPage {
     option: "current" | "current_and_future" | "all"
   ) {
     await this.updateDrawer
-      .getByTestId(`propagation_update_option_${option}`)
+      .getByTestId(TransactionsTestIds.PropagationUpdateOption(option))
       .click();
   }
 
   async isUpdatePropagationVisible(): Promise<boolean> {
     return this.updateDrawer
-      .getByTestId("propagation_update_option_current")
+      .getByTestId(TransactionsTestIds.PropagationUpdateOption('current'))
       .isVisible();
   }
 
   async openCreateForm() {
-    await this.page.getByTestId("btn_new_transaction").first().click();
+    await this.page.getByTestId(TransactionsTestIds.BtnNew).first().click();
     await expect(this.formDrawer).toBeVisible();
   }
 
@@ -90,13 +90,13 @@ export class TransactionsPage {
       transfer: "Transferência",
     };
     await this.page
-      .getByTestId("segmented_transaction_type")
+      .getByTestId(TransactionsTestIds.SegmentedTransactionType)
       .getByText(labels[type])
       .click();
   }
 
   async fillAmount(amountCents: number) {
-    const amountInput = this.page.getByTestId("input_amount");
+    const amountInput = this.page.getByTestId(TransactionsTestIds.InputAmount);
     await amountInput.click();
     for (const digit of String(amountCents)) {
       await amountInput.press(digit);
@@ -104,11 +104,11 @@ export class TransactionsPage {
   }
 
   async fillDescription(description: string) {
-    await this.page.getByTestId("input_description").fill(description);
+    await this.page.getByTestId(TransactionsTestIds.InputDescription).fill(description);
   }
 
   async selectAccount(accountName: string) {
-    const input = this.page.getByTestId("select_account");
+    const input = this.page.getByTestId(TransactionsTestIds.SelectAccount);
     await input.click();
     await input.fill(accountName);
     // Mantine Select options are portalled and aren't instrumented with a
@@ -118,7 +118,7 @@ export class TransactionsPage {
   }
 
   async selectCategory(categoryName: string) {
-    const input = this.page.getByTestId("select_category");
+    const input = this.page.getByTestId(TransactionsTestIds.SelectCategory);
     await input.click();
     await input.fill(categoryName);
     await this.page
@@ -127,7 +127,7 @@ export class TransactionsPage {
   }
 
   async submitForm() {
-    await this.page.getByTestId("btn_save_transaction").click();
+    await this.page.getByTestId(TransactionsTestIds.BtnSave).click();
     await expect(this.formDrawer).not.toBeVisible({ timeout: 8000 });
   }
 
@@ -158,7 +158,7 @@ export class TransactionsPage {
   }
 
   async selectDestinationAccount(accountName: string) {
-    const input = this.page.getByTestId("select_destination_account");
+    const input = this.page.getByTestId(TransactionsTestIds.SelectDestinationAccount);
     await input.click();
     await input.fill(accountName);
     await this.page.getByRole("option", { name: accountName }).click();
@@ -178,23 +178,23 @@ export class TransactionsPage {
   }
 
   async selectTransaction(transactionId: number) {
-    await this.page.getByTestId(`checkbox_${transactionId}`).first().click();
+    await this.page.getByTestId(TransactionsTestIds.Checkbox(transactionId)).first().click();
   }
 
   async getSelectedCount(): Promise<number> {
-    const text = await this.page.getByTestId("selection_count").textContent();
+    const text = await this.page.getByTestId(TransactionsTestIds.SelectionCount).textContent();
     const match = text?.match(/(\d+)/);
     return match ? parseInt(match[1]) : 0;
   }
 
   async openBulkActionsMenu() {
-    await this.page.getByTestId("btn_bulk_actions_menu").click();
+    await this.page.getByTestId(TransactionsTestIds.BtnBulkActionsMenu).click();
   }
 
   async confirmBulkDelete() {
     await this.openBulkActionsMenu();
-    await this.page.getByTestId("btn_bulk_delete").click();
-    await expect(this.page.getByTestId("bulk_success")).toBeVisible({
+    await this.page.getByTestId(TransactionsTestIds.BtnBulkDelete).click();
+    await expect(this.page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible({
       timeout: 15000,
     });
     await this.page.waitForLoadState("networkidle");
@@ -204,23 +204,23 @@ export class TransactionsPage {
     option: "Somente esta" | "Esta e as próximas" | "Todas",
     action: "delete" | "update" = "delete"
   ) {
-    const valueMap: Record<string, string> = {
+    const valueMap: Record<string, PropagationOption> = {
       "Somente esta": "current",
       "Esta e as próximas": "current_and_future",
       Todas: "all",
     };
     await this.page
-      .getByTestId(`propagation_option_${valueMap[option]}`)
+      .getByTestId(TransactionsTestIds.PropagationOption(valueMap[option]))
       .click();
     const confirmTestId = action === "delete" ? "btn_propagation_confirm" : "btn_propagation_confirm_update";
     await this.page.getByTestId(confirmTestId).click();
-    await expect(this.page.getByTestId("bulk_success")).toBeVisible({
+    await expect(this.page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible({
       timeout: 15000,
     });
     await this.page.waitForLoadState("networkidle");
   }
 
   async closeBulkDeleteDrawer() {
-    await this.page.getByTestId("btn_bulk_done").click();
+    await this.page.getByTestId(TransactionsTestIds.BtnBulkDone).click();
   }
 }

--- a/frontend/e2e/tests/accounts-advanced.spec.ts
+++ b/frontend/e2e/tests/accounts-advanced.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { AccountsPage } from '../pages/AccountsPage'
 import { apiCreateAccount, apiDeleteAccount } from '../helpers/api'
+import { AccountsTestIds } from '@/testIds'
 
 test.describe('Accounts Advanced', () => {
   let accountsPage: AccountsPage
@@ -29,15 +30,15 @@ test.describe('Accounts Advanced', () => {
     await page.waitForLoadState('networkidle')
 
     // Confirm account is in inactive section
-    await expect(page.getByTestId('section_inactive').getByText(name)).toBeVisible()
+    await expect(page.getByTestId(AccountsTestIds.SectionInactive).getByText(name)).toBeVisible()
 
     // Reactivate
     await accountsPage.reactivateAccount(name)
     await page.waitForLoadState('networkidle')
 
     // Account should now be in active section
-    await expect(page.getByTestId('section_active').getByText(name)).toBeVisible({ timeout: 8000 })
-    await expect(page.getByTestId('section_inactive').getByText(name)).not.toBeVisible()
+    await expect(page.getByTestId(AccountsTestIds.SectionActive).getByText(name)).toBeVisible({ timeout: 8000 })
+    await expect(page.getByTestId(AccountsTestIds.SectionInactive).getByText(name)).not.toBeVisible()
   })
 
   // ── Create with initial balance ───────────────────────────────────────────
@@ -94,13 +95,13 @@ test.describe('Accounts Advanced', () => {
     // Deactivate A
     await accountsPage.deactivateAccount(nameA)
     await page.waitForLoadState('networkidle')
-    await expect(page.getByTestId('section_inactive').getByText(nameA)).toBeVisible()
+    await expect(page.getByTestId(AccountsTestIds.SectionInactive).getByText(nameA)).toBeVisible()
     // B still active
-    await expect(page.getByTestId('section_active').getByText(nameB)).toBeVisible()
+    await expect(page.getByTestId(AccountsTestIds.SectionActive).getByText(nameB)).toBeVisible()
 
     // Deactivate B
     await accountsPage.deactivateAccount(nameB)
     await page.waitForLoadState('networkidle')
-    await expect(page.getByTestId('section_inactive').getByText(nameB)).toBeVisible({ timeout: 8000 })
+    await expect(page.getByTestId(AccountsTestIds.SectionInactive).getByText(nameB)).toBeVisible({ timeout: 8000 })
   })
 })

--- a/frontend/e2e/tests/accounts.spec.ts
+++ b/frontend/e2e/tests/accounts.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { AccountsPage } from '../pages/AccountsPage'
 import { apiCreateAccount, apiDeleteAccount } from '../helpers/api'
+import { AccountsTestIds } from '@/testIds'
 
 test.describe('Accounts', () => {
   let accountsPage: AccountsPage
@@ -50,7 +51,7 @@ test.describe('Accounts', () => {
     await accountsPage.deactivateAccount(name)
     await accountsPage.page.waitForLoadState('networkidle')
 
-    await expect(accountsPage.page.getByTestId('section_inactive').getByText(name)).toBeVisible()
+    await expect(accountsPage.page.getByTestId(AccountsTestIds.SectionInactive).getByText(name)).toBeVisible()
   })
 
   test('delete (deactivate) an account and verify it moves to inactive', async () => {
@@ -62,6 +63,6 @@ test.describe('Accounts', () => {
     await accountsPage.deleteAccount(name)
     await accountsPage.page.waitForLoadState('networkidle')
 
-    await expect(accountsPage.page.getByTestId('section_active').getByText(name)).not.toBeVisible()
+    await expect(accountsPage.page.getByTestId(AccountsTestIds.SectionActive).getByText(name)).not.toBeVisible()
   })
 })

--- a/frontend/e2e/tests/avatars.spec.ts
+++ b/frontend/e2e/tests/avatars.spec.ts
@@ -9,6 +9,7 @@ import {
   apiCreateCategory,
   apiDeleteCategory,
 } from '../helpers/api'
+import { AccountsTestIds, CommonTestIds, TransactionsTestIds } from '@/testIds'
 
 test.describe('Avatar System', () => {
   const createdAccountIds: number[] = []
@@ -40,7 +41,7 @@ test.describe('Avatar System', () => {
     // (which has data-testid="avatar_user"); we drill with native descendant
     // class narrowing as a last resort since Mantine does not expose the
     // placeholder separately.
-    const headerAvatar = page.locator('header').getByTestId('avatar_user').first()
+    const headerAvatar = page.locator('header').getByTestId(CommonTestIds.AvatarUser).first()
     await expect(headerAvatar).toBeVisible()
 
     const placeholder = headerAvatar.locator('.mantine-Avatar-placeholder')
@@ -72,7 +73,7 @@ test.describe('Avatar System', () => {
     const row = page.locator(`[data-transaction-id="${tx.id}"]`)
     await expect(row).toBeVisible()
 
-    const avatar = row.getByTestId('avatar_account').first()
+    const avatar = row.getByTestId(CommonTestIds.AvatarAccount).first()
     await expect(avatar).toBeVisible()
 
     // Hover to trigger tooltip with account name
@@ -106,10 +107,10 @@ test.describe('Avatar System', () => {
     await expect(row).toBeVisible()
 
     // Transfer rows wrap both avatars in a group with its own testid.
-    const group = row.getByTestId('transfer_avatar_group')
+    const group = row.getByTestId(TransactionsTestIds.TransferAvatarGroup)
     await expect(group).toBeVisible()
-    await expect(group.getByTestId('avatar_account')).toHaveCount(2)
-    await expect(group.getByTestId('icon_transfer_arrow')).toBeVisible()
+    await expect(group.getByTestId(CommonTestIds.AvatarAccount)).toHaveCount(2)
+    await expect(group.getByTestId(TransactionsTestIds.IconTransferArrow)).toBeVisible()
   })
 
   // ── AVA-07: Account card shows avatar ────────────────────────────────────
@@ -128,7 +129,7 @@ test.describe('Avatar System', () => {
     const card = page.locator(`[data-account-name="${accountName}"]`)
     await expect(card).toBeVisible()
 
-    const avatar = card.getByTestId('avatar_account').first()
+    const avatar = card.getByTestId(CommonTestIds.AvatarAccount).first()
     await expect(avatar).toBeVisible()
 
     const placeholder = avatar.locator('.mantine-Avatar-placeholder')
@@ -144,7 +145,7 @@ test.describe('Avatar System', () => {
     await accountsPage.goto()
     await accountsPage.openCreateForm()
 
-    const picker = page.getByTestId('color_swatch_picker')
+    const picker = page.getByTestId(AccountsTestIds.ColorSwatchPicker)
     await expect(picker).toBeVisible()
 
     const swatches = picker.locator('[data-testid^="swatch_color_"]')
@@ -175,7 +176,7 @@ test.describe('Avatar System', () => {
     await expect(card).toBeVisible()
 
     // The avatar on the card should have the red background color
-    const avatar = card.getByTestId('avatar_account').first()
+    const avatar = card.getByTestId(CommonTestIds.AvatarAccount).first()
     const bgColor = await avatar
       .locator('.mantine-Avatar-placeholder')
       .evaluate((el) => getComputedStyle(el).backgroundColor)
@@ -205,7 +206,7 @@ test.describe('Avatar System', () => {
 
     const card = page.locator(`[data-account-name="${accountName}"]`)
     await expect(card).toBeVisible()
-    const avatar = card.getByTestId('avatar_account').first()
+    const avatar = card.getByTestId(CommonTestIds.AvatarAccount).first()
     const bgColor = await avatar
       .locator('.mantine-Avatar-placeholder')
       .evaluate((el) => getComputedStyle(el).backgroundColor)

--- a/frontend/e2e/tests/bulk-delete-transactions.spec.ts
+++ b/frontend/e2e/tests/bulk-delete-transactions.spec.ts
@@ -8,6 +8,7 @@ import {
   apiCreateTransaction,
   apiDeleteTransaction,
 } from '../helpers/api'
+import { TransactionsTestIds } from '@/testIds'
 
 test.describe('Bulk Delete Transactions', () => {
   let transactionsPage: TransactionsPage
@@ -104,8 +105,8 @@ test.describe('Bulk Delete Transactions', () => {
 
     // Tap delete — open menu first, then propagation drawer should appear
     await transactionsPage.openBulkActionsMenu()
-    await transactionsPage.page.getByTestId('btn_bulk_delete').click()
-    await expect(transactionsPage.page.getByTestId('propagation_drawer_body')).toBeVisible()
+    await transactionsPage.page.getByTestId(TransactionsTestIds.BtnBulkDelete).click()
+    await expect(transactionsPage.page.getByTestId(TransactionsTestIds.PropagationDrawerBody)).toBeVisible()
 
     // Choose "Somente esta" and confirm
     await transactionsPage.selectPropagation('Somente esta')

--- a/frontend/e2e/tests/bulk-division.spec.ts
+++ b/frontend/e2e/tests/bulk-division.spec.ts
@@ -29,6 +29,7 @@ import {
   openAuthedPage,
 } from '../helpers/api'
 import { setupPartnerConnection } from '../helpers/fixtures'
+import { TransactionsTestIds } from '@/testIds'
 
 test.describe('Bulk Division', () => {
   let transactionsPage: TransactionsPage
@@ -127,18 +128,18 @@ test.describe('Bulk Division', () => {
     await transactionsPage.selectTransaction(txA.id)
     await transactionsPage.selectTransaction(txB.id)
     await transactionsPage.selectTransaction(txC.id)
-    await expect(page.getByTestId('selection_count')).toHaveText('3')
+    await expect(page.getByTestId(TransactionsTestIds.SelectionCount)).toHaveText('3')
 
     // Open bulk menu → click Divisão
     await transactionsPage.openBulkActionsMenu()
-    await page.getByTestId('btn_bulk_division').click()
+    await page.getByTestId(TransactionsTestIds.BtnBulkDivision).click()
 
     // Wait for drawer to be ready (Mantine Drawer may keep root hidden during animation)
-    await expect(page.getByTestId('btn_apply_bulk_division')).toBeVisible({ timeout: 8000 })
+    await expect(page.getByTestId(TransactionsTestIds.BtnApplyBulkDivision)).toBeVisible({ timeout: 8000 })
 
     // With 2 connected accounts, BulkDivisionDrawer seeds row 1 with empty {connection_id: 0}.
     // We must pick the first connection and set 30%, then add a second row for 70%.
-    const drawer = page.getByTestId('drawer_bulk_division')
+    const drawer = page.getByTestId(TransactionsTestIds.DrawerBulkDivision)
 
     // Row 1: select partner 1's connection, set to 30%
     const firstSelect = drawer.getByPlaceholder('Selecionar conta').first()
@@ -147,11 +148,11 @@ test.describe('Bulk Division', () => {
     await page.getByRole('option').first().click()
 
     // Set row 1 percentage to 30
-    const percentInputs = drawer.getByTestId('input_split_percentage')
+    const percentInputs = drawer.getByTestId(TransactionsTestIds.InputSplitPercentage)
     await percentInputs.nth(0).fill('30')
 
     // Add a second row
-    await drawer.getByTestId('btn_add_split_row').click()
+    await drawer.getByTestId(TransactionsTestIds.BtnAddSplitRow).click()
 
     // Row 2: select the remaining available connection (partner 2)
     const secondSelect = drawer.getByPlaceholder('Selecionar conta').last()
@@ -162,7 +163,7 @@ test.describe('Bulk Division', () => {
     await percentInputs.nth(1).fill('70')
 
     // Verify the sum badge shows 100%
-    await expect(drawer.getByTestId('badge_bulk_division_sum')).toHaveText(/Total: 100% \/ 100%/)
+    await expect(drawer.getByTestId(TransactionsTestIds.BadgeBulkDivisionSum)).toHaveText(/Total: 100% \/ 100%/)
 
     // --- Arm network capture BEFORE clicking submit (playwright-best-practices) ---
     const capturedPuts: Array<{
@@ -180,13 +181,13 @@ test.describe('Bulk Division', () => {
     page.on('request', onRequest)
 
     try {
-      await page.getByTestId('btn_apply_bulk_division').click()
-      await expect(page.getByTestId('bulk_success')).toBeVisible({ timeout: 15000 })
+      await page.getByTestId(TransactionsTestIds.BtnApplyBulkDivision).click()
+      await expect(page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible({ timeout: 15000 })
     } finally {
       page.off('request', onRequest)
     }
 
-    await page.getByTestId('btn_bulk_done').click()
+    await page.getByTestId(TransactionsTestIds.BtnBulkDone).click()
 
     // --- Wire-format assertions on each captured PUT body ---
     // PAY-02: each split_settings row must have ONLY 'amount' and 'connection_id' keys
@@ -276,13 +277,13 @@ test.describe('Bulk Division', () => {
       await soloTransactionsPage.openBulkActionsMenu()
 
       // Key assertions (HUMAN-UAT#2):
-      const divBtn = soloPage.getByTestId('btn_bulk_division')
+      const divBtn = soloPage.getByTestId(TransactionsTestIds.BtnBulkDivision)
       await expect(divBtn).toBeVisible()
       // Playwright's toBeDisabled() works for buttons AND elements with aria-disabled="true"
       await expect(divBtn).toBeDisabled()
 
       // The hint text must be visible with exact Portuguese copy
-      const hint = soloPage.getByTestId('hint_bulk_division_no_connection')
+      const hint = soloPage.getByTestId(TransactionsTestIds.HintBulkDivisionNoConnection)
       await expect(hint).toBeVisible()
       await expect(hint).toHaveText('Conecte uma conta para usar esta ação.')
 
@@ -291,7 +292,7 @@ test.describe('Bulk Division', () => {
       // Note: Mantine renders disabled Menu.Item as a button[disabled], so click() may throw
       // or be intercepted; either way the drawer should not open.
       await divBtn.click({ force: true }).catch(() => undefined)
-      await expect(soloPage.getByTestId('drawer_bulk_division')).not.toBeVisible()
+      await expect(soloPage.getByTestId(TransactionsTestIds.DrawerBulkDivision)).not.toBeVisible()
 
       // Cleanup solo user resources
       await apiFetchAs(soloToken, `/api/transactions/${soloTxId}`, { method: 'DELETE' }).catch(() => undefined)
@@ -349,27 +350,27 @@ test.describe('Bulk Division', () => {
     await transactionsPage.selectTransaction(txD.id)
     await transactionsPage.selectTransaction(txE.id)
     await transactionsPage.selectTransaction(txF.id)
-    await expect(page.getByTestId('selection_count')).toHaveText('3')
+    await expect(page.getByTestId(TransactionsTestIds.SelectionCount)).toHaveText('3')
 
     // Open bulk menu → click Divisão
     await transactionsPage.openBulkActionsMenu()
-    await page.getByTestId('btn_bulk_division').click()
+    await page.getByTestId(TransactionsTestIds.BtnBulkDivision).click()
 
     // Wait for drawer to be ready
-    await expect(page.getByTestId('btn_apply_bulk_division')).toBeVisible({ timeout: 8000 })
+    await expect(page.getByTestId(TransactionsTestIds.BtnApplyBulkDivision)).toBeVisible({ timeout: 8000 })
 
     // With 2+ connections, the first row starts empty; pick partner 1's connection for 100%
-    const drawer = page.getByTestId('drawer_bulk_division')
+    const drawer = page.getByTestId(TransactionsTestIds.DrawerBulkDivision)
     const firstSelect = drawer.getByPlaceholder('Selecionar conta').first()
     await firstSelect.click()
     await page.getByRole('option').first().click()
 
     // Set percentage to 100 (single-row, 100% split is valid)
-    const percentInputs = drawer.getByTestId('input_split_percentage')
+    const percentInputs = drawer.getByTestId(TransactionsTestIds.InputSplitPercentage)
     await percentInputs.nth(0).fill('100')
 
     // Verify sum badge shows 100%
-    await expect(drawer.getByTestId('badge_bulk_division_sum')).toHaveText(/Total: 100% \/ 100%/)
+    await expect(drawer.getByTestId(TransactionsTestIds.BadgeBulkDivisionSum)).toHaveText(/Total: 100% \/ 100%/)
 
     // --- Arm network capture BEFORE clicking submit ---
     const capturedPuts: Array<{ amount: number; split_settings: unknown }> = []
@@ -382,8 +383,8 @@ test.describe('Bulk Division', () => {
     page.on('request', onRequest)
 
     try {
-      await page.getByTestId('btn_apply_bulk_division').click()
-      await expect(page.getByTestId('bulk_success')).toBeVisible({ timeout: 15000 })
+      await page.getByTestId(TransactionsTestIds.BtnApplyBulkDivision).click()
+      await expect(page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible({ timeout: 15000 })
     } finally {
       page.off('request', onRequest)
     }
@@ -393,9 +394,9 @@ test.describe('Bulk Division', () => {
     expect(capturedPuts.length).toBe(2)
 
     // No error row surfaced in the progress drawer
-    await expect(page.getByTestId('bulk_error')).not.toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.BulkError)).not.toBeVisible()
 
-    await page.getByTestId('btn_bulk_done').click()
+    await page.getByTestId(TransactionsTestIds.BtnBulkDone).click()
 
     // --- API re-read assertions ---
     // Persisted splits surface via `linked_transactions` (the GET endpoint does not

--- a/frontend/e2e/tests/bulk-update-transfer.spec.ts
+++ b/frontend/e2e/tests/bulk-update-transfer.spec.ts
@@ -14,6 +14,7 @@ import {
   getAuthTokenForUser,
   apiFetchAs,
 } from '../helpers/api'
+import { TransactionsTestIds } from '@/testIds'
 
 /**
  * Bulk Update — regression tests for data loss prevention
@@ -123,34 +124,34 @@ test.describe('Bulk Update — data preservation', () => {
   async function bulkChangeCategory(page: TransactionsPage['page'], txId: number, targetCategoryId: number) {
     await transactionsPage.selectTransaction(txId)
     await transactionsPage.openBulkActionsMenu()
-    await page.getByTestId('btn_bulk_category').click()
+    await page.getByTestId(TransactionsTestIds.BtnBulkCategory).click()
 
     // Wait for a category option to appear (Mantine Drawer root stays hidden during animation)
-    const categoryOption = page.getByTestId(`category_option_${targetCategoryId}`)
+    const categoryOption = page.getByTestId(TransactionsTestIds.CategoryOption(targetCategoryId))
     await expect(categoryOption).toBeVisible({ timeout: 8000 })
     await categoryOption.click()
 
-    await expect(page.getByTestId('bulk_success').or(page.getByTestId('bulk_error'))).toBeVisible({ timeout: 15000 })
-    await expect(page.getByTestId('bulk_error')).not.toBeVisible()
-    await expect(page.getByTestId('bulk_success')).toBeVisible()
-    await page.getByTestId('btn_bulk_done').click()
+    await expect(page.getByTestId(TransactionsTestIds.BulkSuccess).or(page.getByTestId(TransactionsTestIds.BulkError))).toBeVisible({ timeout: 15000 })
+    await expect(page.getByTestId(TransactionsTestIds.BulkError)).not.toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible()
+    await page.getByTestId(TransactionsTestIds.BtnBulkDone).click()
   }
 
   // ── Helper: select transaction and do bulk date change via UI ──
   async function bulkChangeDate(page: TransactionsPage['page'], txId: number) {
     await transactionsPage.selectTransaction(txId)
     await transactionsPage.openBulkActionsMenu()
-    await page.getByTestId('btn_bulk_date').click()
+    await page.getByTestId(TransactionsTestIds.BtnBulkDate).click()
 
     // Wait for the apply button inside the date drawer (Mantine Drawer root stays hidden during animation)
-    const applyBtn = page.getByTestId('btn_apply_date')
+    const applyBtn = page.getByTestId(TransactionsTestIds.BtnApplyDate)
     await expect(applyBtn).toBeVisible({ timeout: 8000 })
     await applyBtn.click()
 
-    await expect(page.getByTestId('bulk_success').or(page.getByTestId('bulk_error'))).toBeVisible({ timeout: 15000 })
-    await expect(page.getByTestId('bulk_error')).not.toBeVisible()
-    await expect(page.getByTestId('bulk_success')).toBeVisible()
-    await page.getByTestId('btn_bulk_done').click()
+    await expect(page.getByTestId(TransactionsTestIds.BulkSuccess).or(page.getByTestId(TransactionsTestIds.BulkError))).toBeVisible({ timeout: 15000 })
+    await expect(page.getByTestId(TransactionsTestIds.BulkError)).not.toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible()
+    await page.getByTestId(TransactionsTestIds.BtnBulkDone).click()
   }
 
   // ─────────────────────────────────────────────────────────────────────
@@ -269,16 +270,16 @@ test.describe('Bulk Update — data preservation', () => {
     // Select, open bulk menu, change category — propagation drawer will appear
     await transactionsPage.selectTransaction(tx.id)
     await transactionsPage.openBulkActionsMenu()
-    await page.getByTestId('btn_bulk_category').click()
+    await page.getByTestId(TransactionsTestIds.BtnBulkCategory).click()
 
     // Wait for category option inside drawer
-    const catOption = page.getByTestId(`category_option_${newCategoryId}`)
+    const catOption = page.getByTestId(TransactionsTestIds.CategoryOption(newCategoryId))
     await expect(catOption).toBeVisible({ timeout: 8000 })
     await catOption.click()
 
     // Propagation drawer should appear for recurring tx — wait for option inside it
-    const propagationOption = page.getByTestId('propagation_option_current')
-    await expect(propagationOption.or(page.getByTestId('bulk_success'))).toBeVisible({ timeout: 8000 })
+    const propagationOption = page.getByTestId(TransactionsTestIds.PropagationOption('current'))
+    await expect(propagationOption.or(page.getByTestId(TransactionsTestIds.BulkSuccess))).toBeVisible({ timeout: 8000 })
 
     // If propagation appears, select "Somente esta"
     const propagationVisible = await propagationOption.isVisible().catch(() => false)
@@ -286,8 +287,8 @@ test.describe('Bulk Update — data preservation', () => {
       await transactionsPage.selectPropagation('Somente esta', 'update')
     }
 
-    await expect(page.getByTestId('bulk_success')).toBeVisible({ timeout: 15000 })
-    await page.getByTestId('btn_bulk_done').click()
+    await expect(page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible({ timeout: 15000 })
+    await page.getByTestId(TransactionsTestIds.BtnBulkDone).click()
 
     const updated = await apiGetTransaction(tx.id)
     expect(updated.description).toBe(desc)

--- a/frontend/e2e/tests/categories-advanced.spec.ts
+++ b/frontend/e2e/tests/categories-advanced.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { CategoriesPage } from '../pages/CategoriesPage'
 import { apiCreateCategory, apiDeleteCategory } from '../helpers/api'
+import { CategoriesTestIds } from '@/testIds'
 
 test.describe('Categories Advanced', () => {
   let categoriesPage: CategoriesPage
@@ -31,8 +32,8 @@ test.describe('Categories Advanced', () => {
     await expect(page.getByText(catReplacement)).toBeVisible()
 
     // Open delete dialog for catToDelete
-    await page.locator(`[data-category-name="${catToDelete}"]`).getByTestId('btn_category_delete').click()
-    await expect(page.getByTestId('btn_confirm_delete_category')).toBeVisible()
+    await page.locator(`[data-category-name="${catToDelete}"]`).getByTestId(CategoriesTestIds.BtnDelete).click()
+    await expect(page.getByTestId(CategoriesTestIds.BtnConfirmDelete)).toBeVisible()
 
     // Select replacement category via the searchable input (placeholder = "Deixar sem categoria")
     // Note: the modal is defined inline in _authenticated.categories.tsx, not in DeleteCategoryDialog.tsx
@@ -41,8 +42,8 @@ test.describe('Categories Advanced', () => {
     await page.getByRole('option', { name: catReplacement }).click()
 
     // Confirm deletion
-    await page.getByTestId('btn_confirm_delete_category').click()
-    await expect(page.getByTestId('btn_confirm_delete_category')).not.toBeVisible({ timeout: 5000 })
+    await page.getByTestId(CategoriesTestIds.BtnConfirmDelete).click()
+    await expect(page.getByTestId(CategoriesTestIds.BtnConfirmDelete)).not.toBeVisible({ timeout: 5000 })
 
     // Deleted category is gone, replacement still present
     await expect(page.getByText(catToDelete)).not.toBeVisible()
@@ -64,10 +65,10 @@ test.describe('Categories Advanced', () => {
     await expect(page.getByText(catToDelete)).toBeVisible()
 
     // Delete catToDelete without replacement
-    await page.locator(`[data-category-name="${catToDelete}"]`).getByTestId('btn_category_delete').click()
-    await expect(page.getByTestId('btn_confirm_delete_category')).toBeVisible()
-    await page.getByTestId('btn_confirm_delete_category').click()
-    await expect(page.getByTestId('btn_confirm_delete_category')).not.toBeVisible({ timeout: 5000 })
+    await page.locator(`[data-category-name="${catToDelete}"]`).getByTestId(CategoriesTestIds.BtnDelete).click()
+    await expect(page.getByTestId(CategoriesTestIds.BtnConfirmDelete)).toBeVisible()
+    await page.getByTestId(CategoriesTestIds.BtnConfirmDelete).click()
+    await expect(page.getByTestId(CategoriesTestIds.BtnConfirmDelete)).not.toBeVisible({ timeout: 5000 })
 
     // Deleted category gone, other category still present
     await expect(page.getByText(catToDelete)).not.toBeVisible()
@@ -88,10 +89,10 @@ test.describe('Categories Advanced', () => {
     await expect(page.getByText(childName)).toBeVisible()
 
     // Delete only the child
-    await page.locator(`[data-category-name="${childName}"]`).getByTestId('btn_category_delete').click()
-    await expect(page.getByTestId('btn_confirm_delete_category')).toBeVisible()
-    await page.getByTestId('btn_confirm_delete_category').click()
-    await expect(page.getByTestId('btn_confirm_delete_category')).not.toBeVisible({ timeout: 5000 })
+    await page.locator(`[data-category-name="${childName}"]`).getByTestId(CategoriesTestIds.BtnDelete).click()
+    await expect(page.getByTestId(CategoriesTestIds.BtnConfirmDelete)).toBeVisible()
+    await page.getByTestId(CategoriesTestIds.BtnConfirmDelete).click()
+    await expect(page.getByTestId(CategoriesTestIds.BtnConfirmDelete)).not.toBeVisible({ timeout: 5000 })
 
     // Child gone, parent remains
     await expect(page.getByText(childName)).not.toBeVisible()

--- a/frontend/e2e/tests/filter-transactions.spec.ts
+++ b/frontend/e2e/tests/filter-transactions.spec.ts
@@ -8,6 +8,7 @@ import {
   apiCreateTransaction,
   apiDeleteTransaction,
 } from "../helpers/api";
+import { TransactionsTestIds } from '@/testIds'
 
 const today = new Date().toISOString().slice(0, 10);
 
@@ -96,7 +97,7 @@ test.describe("Transaction Filters", () => {
     await expect(page.getByText(otherDesc)).toBeVisible();
 
     // Type in search box
-    const searchInput = page.getByTestId("input_text_search");
+    const searchInput = page.getByTestId(TransactionsTestIds.InputTextSearch);
     await searchInput.fill(uniqueDesc);
     await page.waitForLoadState("networkidle");
 
@@ -132,8 +133,8 @@ test.describe("Transaction Filters", () => {
     await expect(page.getByText(descB)).toBeVisible();
 
     // Open account filter popover and select accountA
-    await page.getByTestId("btn_filter_accounts").click();
-    await page.getByTestId("popover_filter_accounts").locator(`[data-account-name="${accountAName}"] input`).check();
+    await page.getByTestId(TransactionsTestIds.BtnFilter('accounts')).click();
+    await page.getByTestId(TransactionsTestIds.PopoverFilter('accounts')).locator(`[data-account-name="${accountAName}"] input`).check();
     await page.waitForLoadState("networkidle");
 
     await expect(page.getByText(descA)).toBeVisible({ timeout: 8000 });
@@ -168,8 +169,8 @@ test.describe("Transaction Filters", () => {
     await expect(page.getByText(descB)).toBeVisible();
 
     // Open category filter popover and select categoryA
-    await page.getByTestId("btn_filter_categories").click();
-    await page.getByTestId("popover_filter_categories").locator(`[data-category-name="${categoryAName}"] input`).check();
+    await page.getByTestId(TransactionsTestIds.BtnFilter('categories')).click();
+    await page.getByTestId(TransactionsTestIds.PopoverFilter('categories')).locator(`[data-category-name="${categoryAName}"] input`).check();
     await page.waitForLoadState("networkidle");
 
     await expect(page.getByText(descA)).toBeVisible({ timeout: 8000 });
@@ -206,9 +207,9 @@ test.describe("Transaction Filters", () => {
     // Open advanced filter and toggle "Apenas despesas"
     // getByTestId finds the Mantine Switch root <label> element, which is visible
     await transactionsPage.openAdvancedFilters();
-    await page.getByTestId("advanced_filters_popover").waitFor({ state: "visible", timeout: 5000 });
+    await page.getByTestId(TransactionsTestIds.AdvancedFiltersPopover).waitFor({ state: "visible", timeout: 5000 });
     await page
-      .getByTestId("switch_type_expense")
+      .getByTestId(TransactionsTestIds.SwitchType('expense'))
       .locator("xpath=ancestor::label")
       .click({ timeout: 3000, force: true });
     await page.waitForLoadState("networkidle");
@@ -245,8 +246,8 @@ test.describe("Transaction Filters", () => {
     await expect(page.getByText(incomeDesc)).toBeVisible();
 
     await transactionsPage.openAdvancedFilters();
-    await page.getByTestId("advanced_filters_popover").waitFor({ state: "visible", timeout: 5000 });
-    await page.getByTestId("switch_type_income").locator("xpath=ancestor::label").click({ timeout: 3000, force: true });
+    await page.getByTestId(TransactionsTestIds.AdvancedFiltersPopover).waitFor({ state: "visible", timeout: 5000 });
+    await page.getByTestId(TransactionsTestIds.SwitchType('income')).locator("xpath=ancestor::label").click({ timeout: 3000, force: true });
     await page.waitForLoadState("networkidle");
 
     await expect(page.getByText(incomeDesc)).toBeVisible({ timeout: 8000 });
@@ -281,9 +282,9 @@ test.describe("Transaction Filters", () => {
     await expect(page.getByText(expenseDesc)).toBeVisible();
 
     await transactionsPage.openAdvancedFilters();
-    await page.getByTestId("advanced_filters_popover").waitFor({ state: "visible", timeout: 5000 });
+    await page.getByTestId(TransactionsTestIds.AdvancedFiltersPopover).waitFor({ state: "visible", timeout: 5000 });
     await page
-      .getByTestId("switch_type_transfer")
+      .getByTestId(TransactionsTestIds.SwitchType('transfer'))
       .locator("xpath=ancestor::label")
       .click({ timeout: 3000, force: true });
     await page.waitForLoadState("networkidle");
@@ -321,8 +322,8 @@ test.describe("Transaction Filters", () => {
     await expect(page.getByText(taggedDesc)).toBeVisible();
     await expect(page.getByText(untaggedDesc)).toBeVisible();
 
-    await page.getByTestId("btn_filter_tags").click();
-    await page.getByTestId("popover_filter_tags").locator(`[data-tag-name="${tagName}"]`).click();
+    await page.getByTestId(TransactionsTestIds.BtnFilter('tags')).click();
+    await page.getByTestId(TransactionsTestIds.PopoverFilter('tags')).locator(`[data-tag-name="${tagName}"]`).click();
     await page.waitForLoadState("networkidle");
 
     await expect(page.getByText(taggedDesc)).toBeVisible({ timeout: 8000 });
@@ -436,17 +437,17 @@ test.describe("Transaction Filters", () => {
 
     // Apply expense type filter
     await transactionsPage.openAdvancedFilters();
-    await page.getByTestId("advanced_filters_popover").waitFor({ state: "visible", timeout: 5000 });
+    await page.getByTestId(TransactionsTestIds.AdvancedFiltersPopover).waitFor({ state: "visible", timeout: 5000 });
     await page
-      .getByTestId("switch_type_expense")
+      .getByTestId(TransactionsTestIds.SwitchType('expense'))
       .locator("xpath=ancestor::label")
       .click({ timeout: 3000, force: true });
     await page.waitForLoadState("networkidle");
     await page.keyboard.press("Escape");
 
     // Apply account filter for accountA
-    await page.getByTestId("btn_filter_accounts").click();
-    await page.getByTestId("popover_filter_accounts").locator(`[data-account-name="${accountAName}"] input`).check();
+    await page.getByTestId(TransactionsTestIds.BtnFilter('accounts')).click();
+    await page.getByTestId(TransactionsTestIds.PopoverFilter('accounts')).locator(`[data-account-name="${accountAName}"] input`).check();
     await page.waitForLoadState("networkidle");
 
     await expect(page.getByText(expenseADesc)).toBeVisible({ timeout: 8000 });
@@ -472,20 +473,20 @@ test.describe("Transaction Filters", () => {
     await expect(page.getByText(targetDesc)).toBeVisible();
 
     // Apply a text search that hides the transaction
-    const searchInput = page.getByTestId("input_text_search");
+    const searchInput = page.getByTestId(TransactionsTestIds.InputTextSearch);
     await searchInput.fill("xxxxxxxxxnotfound");
     await page.waitForLoadState("networkidle");
     await expect(page.getByText(targetDesc)).not.toBeVisible({ timeout: 8000 });
 
     // The clear filters button should now be visible
-    await expect(page.getByTestId("btn_clear_filters")).toBeVisible();
+    await expect(page.getByTestId(TransactionsTestIds.BtnClearFilters)).toBeVisible();
 
     // Clear filters
-    await page.getByTestId("btn_clear_filters").click();
+    await page.getByTestId(TransactionsTestIds.BtnClearFilters).click();
     await page.waitForLoadState("networkidle");
 
     // Transaction should be visible again and clear filters button gone
     await expect(page.getByText(targetDesc)).toBeVisible({ timeout: 8000 });
-    await expect(page.getByTestId("btn_clear_filters")).not.toBeVisible();
+    await expect(page.getByTestId(TransactionsTestIds.BtnClearFilters)).not.toBeVisible();
   });
 });

--- a/frontend/e2e/tests/import.spec.ts
+++ b/frontend/e2e/tests/import.spec.ts
@@ -8,6 +8,7 @@ import {
   apiCreateCategory,
   apiDeleteCategory,
 } from "../helpers/api";
+import { ImportTestIds } from '@/testIds'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -124,7 +125,7 @@ test.describe("Import transactions", () => {
     await importPage.uploadCSV(csv, testAccountName);
 
     // Row 0 should have action "duplicate" (detected server-side)
-    const actionSelect = importPage.reviewStep.getByTestId("select_import_action_0");
+    const actionSelect = importPage.reviewStep.getByTestId(ImportTestIds.RowSelectAction(0));
     await expect(actionSelect).toHaveValue("Duplicado", {
       timeout: 5000,
     });
@@ -182,7 +183,7 @@ test.describe("Import transactions", () => {
 
     // Category should be auto-selected in row 0 after drawer close
     // Wait for Mantine Select to reflect the new value after form.setValue + re-render
-    await expect(importPage.reviewStep.getByTestId(`select_category_0`))
+    await expect(importPage.reviewStep.getByTestId(ImportTestIds.RowSelectCategory(0)))
       .toHaveValue(newCategoryName, { timeout: 5000 });
 
     // Confirm import succeeds with the auto-selected category
@@ -215,7 +216,7 @@ test.describe("Import transactions", () => {
     await importPage.createCategoryInDrawer(newCategoryName, { emoji });
 
     // Category should be auto-selected with emoji prefix in the select
-    await expect(importPage.reviewStep.getByTestId(`select_category_0`))
+    await expect(importPage.reviewStep.getByTestId(ImportTestIds.RowSelectCategory(0)))
       .toHaveValue(`${emoji} ${newCategoryName}`, { timeout: 5000 });
   });
 

--- a/frontend/e2e/tests/recurrence.spec.ts
+++ b/frontend/e2e/tests/recurrence.spec.ts
@@ -8,6 +8,7 @@ import {
   apiCreateTransaction,
   apiDeleteTransaction,
 } from '../helpers/api'
+import { TransactionsTestIds } from '@/testIds'
 
 // ─── Suite ────────────────────────────────────────────────────────────────────
 
@@ -115,7 +116,7 @@ test.describe('Recurrence', () => {
     await page.getByLabel('Total de parcelas').fill('3')
 
     // Attempt to submit
-    await page.getByTestId('btn_save_transaction').click()
+    await page.getByTestId(TransactionsTestIds.BtnSave).click()
 
     // Assert validation error is visible
     await expect(page.getByText('Parcela atual nao pode ser maior que o total')).toBeVisible()

--- a/frontend/e2e/tests/transfer-transaction.spec.ts
+++ b/frontend/e2e/tests/transfer-transaction.spec.ts
@@ -7,6 +7,7 @@ import {
   apiDeleteTransaction,
   apiGetTransaction,
 } from '../helpers/api'
+import { TransactionsTestIds } from '@/testIds'
 
 test.describe('Transfer Transactions', () => {
   let transactionsPage: TransactionsPage
@@ -54,10 +55,10 @@ test.describe('Transfer Transactions', () => {
     await transactionsPage.openCreateForm()
     await transactionsPage.selectType('transfer')
 
-    await expect(page.getByTestId('select_account')).toBeVisible()
-    await expect(page.getByTestId('select_destination_account')).toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.SelectAccount)).toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.SelectDestinationAccount)).toBeVisible()
     // Category selector must NOT appear for transfers
-    await expect(page.getByTestId('select_category')).not.toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.SelectCategory)).not.toBeVisible()
   })
 
   test('editing the credit side of a same-user transfer opens the debit (origin) side', async ({ page }) => {
@@ -94,10 +95,10 @@ test.describe('Transfer Transactions', () => {
     await transactionsPage.waitForUpdateDrawer()
 
     await expect(
-      transactionsPage.updateDrawer.getByTestId('select_account'),
+      transactionsPage.updateDrawer.getByTestId(TransactionsTestIds.SelectAccount),
     ).toHaveValue(sourceAccountName)
     await expect(
-      transactionsPage.updateDrawer.getByTestId('select_destination_account'),
+      transactionsPage.updateDrawer.getByTestId(TransactionsTestIds.SelectDestinationAccount),
     ).toHaveValue(destAccountName)
 
     // Change a restricted-on-linked-tx field (amount). Without the fix, the

--- a/frontend/e2e/tests/update-transaction.spec.ts
+++ b/frontend/e2e/tests/update-transaction.spec.ts
@@ -8,6 +8,7 @@ import {
   apiCreateTransaction,
   apiDeleteTransaction,
 } from '../helpers/api'
+import { TransactionsTestIds } from '@/testIds'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -76,15 +77,15 @@ test.describe('Transaction Update', () => {
     await expect(page.getByRole('heading', { name: 'Editar transação' })).toBeVisible()
 
     // Description pre-populated
-    const descInput = transactionsPage.updateDrawer.getByTestId('input_description')
+    const descInput = transactionsPage.updateDrawer.getByTestId(TransactionsTestIds.InputDescription)
     await expect(descInput).toHaveValue(desc)
 
     // Amount pre-populated (150000 cents = R$ 1.500,00)
-    const amountInput = transactionsPage.updateDrawer.getByTestId('input_amount')
+    const amountInput = transactionsPage.updateDrawer.getByTestId(TransactionsTestIds.InputAmount)
     await expect(amountInput).toHaveValue('1.500,00')
 
     // Expense type selected (data-active is on the label element, not the inner span)
-    const segmented = transactionsPage.updateDrawer.getByTestId('segmented_transaction_type')
+    const segmented = transactionsPage.updateDrawer.getByTestId(TransactionsTestIds.SegmentedTransactionType)
     await expect(segmented.locator('[data-active]').first()).toContainText('Despesa')
   })
 
@@ -186,7 +187,7 @@ test.describe('Transaction Update', () => {
     expect(await transactionsPage.getSelectedCount()).toBe(2)
 
     // Clean up selection
-    await page.getByTestId('btn_clear_selection').click()
+    await page.getByTestId(TransactionsTestIds.BtnClearSelection).click()
   })
 
   // ── Test 5: Non-recurring hides propagation selector ──────────────────────
@@ -208,7 +209,7 @@ test.describe('Transaction Update', () => {
 
     await transactionsPage.clickTransactionRow(tx.id)
 
-    await expect(page.getByTestId('propagation_update_option_current')).not.toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.PropagationUpdateOption('current'))).not.toBeVisible()
   })
 
   // ── Test 6: Recurring shows propagation selector ───────────────────────────
@@ -231,9 +232,9 @@ test.describe('Transaction Update', () => {
 
     await transactionsPage.clickTransactionRow(tx.id)
 
-    await expect(page.getByTestId('propagation_update_option_current')).toBeVisible()
-    await expect(page.getByTestId('propagation_update_option_current_and_future')).toBeVisible()
-    await expect(page.getByTestId('propagation_update_option_all')).toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.PropagationUpdateOption('current'))).toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.PropagationUpdateOption('current_and_future'))).toBeVisible()
+    await expect(page.getByTestId(TransactionsTestIds.PropagationUpdateOption('all'))).toBeVisible()
   })
 
   // ── Test 7: Propagation "current" — only changes current installment ────────

--- a/frontend/e2e/tsconfig.json
+++ b/frontend/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
+    "paths": {
+      "@/*": ["../src/*"]
+    },
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/src/components/AccountAvatar.tsx
+++ b/frontend/src/components/AccountAvatar.tsx
@@ -2,6 +2,7 @@ import { Avatar, type MantineSize } from "@mantine/core"
 import { getInitials } from "@/utils/getInitials"
 import { DEFAULT_AVATAR_COLOR } from "@/components/accounts/ColorSwatchPicker"
 import { Transactions } from "@/types/transactions"
+import { CommonTestIds } from '@/testIds'
 
 interface AccountAvatarProps {
   account: Transactions.Account | null | undefined
@@ -9,7 +10,7 @@ interface AccountAvatarProps {
 }
 
 export function AccountAvatar({ account, size }: AccountAvatarProps) {
-  if (!account) return <Avatar size={size} radius="xl" data-testid="avatar_account_empty" />
+  if (!account) return <Avatar size={size} radius="xl" data-testid={CommonTestIds.AvatarAccountEmpty} />
 
   const isShared = !!account.user_connection
 
@@ -25,7 +26,7 @@ export function AccountAvatar({ account, size }: AccountAvatarProps) {
         radius="xl"
         color={partnerAvatarUrl ? undefined : "grape"}
         imageProps={{ referrerPolicy: "no-referrer" }}
-        data-testid="avatar_account"
+        data-testid={CommonTestIds.AvatarAccount}
       >
         {getInitials(partnerName)}
       </Avatar>
@@ -38,7 +39,7 @@ export function AccountAvatar({ account, size }: AccountAvatarProps) {
       radius="xl"
       color={undefined}
       styles={{ placeholder: { backgroundColor: account.avatar_background_color ?? DEFAULT_AVATAR_COLOR, color: "white" } }}
-      data-testid="avatar_account"
+      data-testid={CommonTestIds.AvatarAccount}
     >
       {getInitials(account.name)}
     </Avatar>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -9,6 +9,7 @@ import { InviteDrawer } from "@/components/InviteDrawer";
 import { PWAInstallBanner } from "@/components/PWAInstallBanner";
 import { UserAvatar } from "@/components/UserAvatar";
 import { renderDrawer } from "@/utils/renderDrawer";
+import { CommonTestIds } from '@/testIds'
 
 const navLinks: Array<{ label: string; icon: typeof IconReceipt2; to: string }> = [
   { label: "Transações", icon: IconReceipt2, to: "/transactions" },
@@ -99,7 +100,7 @@ export function AppLayout() {
             leftSection={<Icon size={18} />}
             rightSection={
               badge ? (
-                <Badge size="xs" circle color="red" data-testid={`nav_badge_${to.slice(1)}`}>
+                <Badge size="xs" circle color="red" data-testid={CommonTestIds.NavBadge(to.slice(1))}>
                   {badge}
                 </Badge>
               ) : undefined

--- a/frontend/src/components/InviteDrawer.tsx
+++ b/frontend/src/components/InviteDrawer.tsx
@@ -1,6 +1,7 @@
 import { Drawer, Stack, Text, TextInput, Button, CopyButton, Group } from '@mantine/core'
 import { IconCopy, IconCheck } from '@tabler/icons-react'
 import { useMe } from '@/hooks/useMe'
+import { CommonTestIds } from '@/testIds'
 import { useDrawerContext } from '@/utils/renderDrawer'
 
 export function InviteDrawer() {
@@ -19,7 +20,7 @@ export function InviteDrawer() {
       title="Criar Conexão"
       position="right"
       size="md"
-      data-testid="drawer_invite"
+      data-testid={CommonTestIds.DrawerInvite}
     >
       <Stack gap="lg">
         <Text size="sm" c="dimmed">

--- a/frontend/src/components/UserAvatar.tsx
+++ b/frontend/src/components/UserAvatar.tsx
@@ -1,5 +1,6 @@
 import { Avatar, type MantineSize } from "@mantine/core"
 import { getInitials } from "@/utils/getInitials"
+import { CommonTestIds } from '@/testIds'
 
 interface UserAvatarProps {
   name: string
@@ -16,7 +17,7 @@ export function UserAvatar({ name, avatarUrl, size, color = "blue" }: UserAvatar
       radius="xl"
       color={avatarUrl ? undefined : color}
       imageProps={{ referrerPolicy: "no-referrer" }}
-      data-testid="avatar_user"
+      data-testid={CommonTestIds.AvatarUser}
     >
       {getInitials(name)}
     </Avatar>

--- a/frontend/src/components/accounts/AccountCard.tsx
+++ b/frontend/src/components/accounts/AccountCard.tsx
@@ -3,6 +3,7 @@ import { IconPencil, IconTrash, IconRefresh } from '@tabler/icons-react'
 import { Transactions } from '@/types/transactions'
 import { formatBalance } from '@/utils/formatCents'
 import { AccountAvatar } from '@/components/AccountAvatar'
+import { AccountsTestIds } from '@/testIds'
 
 interface Props {
   account: Transactions.Account
@@ -14,7 +15,7 @@ export function AccountCard({ account, onEdit, onDelete }: Props) {
   const isShared = !!account.user_connection
 
   return (
-    <Card withBorder radius="md" p="md" data-account-name={account.name} data-testid="account_card">
+    <Card withBorder radius="md" p="md" data-account-name={account.name} data-testid={AccountsTestIds.Card}>
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <Stack gap={4}>
           <Group gap="sm">
@@ -35,7 +36,7 @@ export function AccountCard({ account, onEdit, onDelete }: Props) {
         {!isShared && (
           <Group gap="xs" wrap="nowrap">
             {account.is_active && (
-              <ActionIcon variant="subtle" color="gray" onClick={() => onEdit(account)} data-testid="btn_account_edit">
+              <ActionIcon variant="subtle" color="gray" onClick={() => onEdit(account)} data-testid={AccountsTestIds.BtnEdit}>
                 <IconPencil size={16} />
               </ActionIcon>
             )}
@@ -43,7 +44,7 @@ export function AccountCard({ account, onEdit, onDelete }: Props) {
               variant="subtle"
               color={account.is_active ? 'red' : 'teal'}
               onClick={() => onDelete(account)}
-              data-testid="btn_account_action"
+              data-testid={AccountsTestIds.BtnAction}
             >
               {account.is_active ? <IconTrash size={16} /> : <IconRefresh size={16} />}
             </ActionIcon>

--- a/frontend/src/components/accounts/AccountDrawer.tsx
+++ b/frontend/src/components/accounts/AccountDrawer.tsx
@@ -6,6 +6,7 @@ import { useUpdateAccount } from '@/hooks/useUpdateAccount'
 import { Transactions } from '@/types/transactions'
 import { AccountForm, AccountFormValues } from './AccountForm'
 import { DEFAULT_AVATAR_COLOR } from './ColorSwatchPicker'
+import { AccountsTestIds } from '@/testIds'
 
 interface Props {
   account?: Transactions.Account
@@ -50,7 +51,7 @@ export function AccountDrawer({ account }: Props) {
       title={account ? 'Editar Conta' : 'Nova Conta'}
       position="right"
       size="md"
-      data-testid="drawer_account"
+      data-testid={AccountsTestIds.Drawer}
     >
       <AccountForm
         initialValues={initialValues}

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -7,6 +7,7 @@ import { CurrencyInput } from '@/components/transactions/form/CurrencyInput'
 import { ColorSwatchPicker, DEFAULT_AVATAR_COLOR } from '@/components/accounts/ColorSwatchPicker'
 import { useResetFormOnChange } from '@/hooks/useResetFormOnChange'
 import { Transactions } from '@/types/transactions'
+import { AccountsTestIds } from '@/testIds'
 
 const schema = z.object({
   name: z.string().min(1, 'Nome é obrigatório'),
@@ -63,7 +64,7 @@ export function AccountForm({ initialValues, onSubmit, isPending, error }: Props
   const avatarColor = useWatch({ control, name: 'avatar_background_color' })
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} noValidate data-testid="account_form">
+    <form onSubmit={handleSubmit(onSubmit)} noValidate data-testid={AccountsTestIds.Form}>
       <Stack gap="md">
         {error && (
           <Alert color="red" title="Erro" variant="light">
@@ -76,7 +77,7 @@ export function AccountForm({ initialValues, onSubmit, isPending, error }: Props
           required
           {...register('name')}
           error={errors.name?.message}
-          data-testid="input_account_name"
+          data-testid={AccountsTestIds.InputName}
         />
 
         <Textarea
@@ -92,7 +93,7 @@ export function AccountForm({ initialValues, onSubmit, isPending, error }: Props
           value={initialBalance}
           onChange={(val) => setValue('initial_balance', val)}
           error={errors.initial_balance?.message}
-          data-testid="input_initial_balance"
+          data-testid={AccountsTestIds.InputInitialBalance}
         />
 
         <ColorSwatchPicker
@@ -102,7 +103,7 @@ export function AccountForm({ initialValues, onSubmit, isPending, error }: Props
         />
 
         <Group justify="flex-end" mt="sm">
-          <Button type="submit" loading={isPending} data-testid="btn_account_save">
+          <Button type="submit" loading={isPending} data-testid={AccountsTestIds.BtnSave}>
             Salvar
           </Button>
         </Group>

--- a/frontend/src/components/accounts/ColorSwatchPicker.tsx
+++ b/frontend/src/components/accounts/ColorSwatchPicker.tsx
@@ -1,4 +1,5 @@
 import { ColorSwatch, SimpleGrid, Text, Stack } from "@mantine/core"
+import { AccountsTestIds } from '@/testIds'
 
 export const DEFAULT_AVATAR_COLOR = "#457b9d"
 
@@ -25,7 +26,7 @@ interface ColorSwatchPickerProps {
 
 export function ColorSwatchPicker({ value, onChange, label }: ColorSwatchPickerProps) {
   return (
-    <Stack gap="xs" data-testid="color_swatch_picker">
+    <Stack gap="xs" data-testid={AccountsTestIds.ColorSwatchPicker}>
       {label && <Text size="sm" fw={600}>{label}</Text>}
       <SimpleGrid cols={4} spacing={8}>
         {PRESET_COLORS.map((color) => (
@@ -36,7 +37,7 @@ export function ColorSwatchPicker({ value, onChange, label }: ColorSwatchPickerP
             radius="xl"
             onClick={() => onChange(color)}
             aria-label={`Selecionar cor ${color}`}
-            data-testid={`swatch_color_${color.replace('#', '')}`}
+            data-testid={AccountsTestIds.SwatchColor(color.replace('#', ''))}
             data-selected={value === color ? "true" : undefined}
             style={{
               cursor: "pointer",

--- a/frontend/src/components/categories/CategoryCard.tsx
+++ b/frontend/src/components/categories/CategoryCard.tsx
@@ -4,6 +4,7 @@ import { useDisclosure } from '@mantine/hooks'
 import { IconChevronDown, IconChevronRight, IconPlus, IconTrash } from '@tabler/icons-react'
 import { Transactions } from '@/types/transactions'
 import { InlineNewCategory } from './InlineNewCategory'
+import { CategoriesTestIds } from '@/testIds'
 
 const EMOJI_OPTIONS = [
   '🏠','🚗','🍔','🛒','💊','✈️','🎬','👕','📚','💡',
@@ -124,7 +125,7 @@ export function CategoryCard({
         )}
 
         {/* emoji button */}
-        <ActionIcon variant="subtle" color="gray" size="md" onClick={handleOpenEmoji} title="Mudar emoji" data-testid={`btn_emoji_${category.id}`}>
+        <ActionIcon variant="subtle" color="gray" size="md" onClick={handleOpenEmoji} title="Mudar emoji" data-testid={CategoriesTestIds.BtnEmoji(category.id)}>
           {category.emoji ? (
             <Text size="md" lh={1}>{category.emoji}</Text>
           ) : (
@@ -144,10 +145,10 @@ export function CategoryCard({
             error={nameError}
             style={{ minWidth: 140 }}
             rightSection={nameSaving ? <Loader size={14} /> : null}
-            data-testid="input_category_name"
+            data-testid={CategoriesTestIds.InputName}
           />
         ) : (
-          <UnstyledButton onClick={startEdit} data-testid="btn_category_name">
+          <UnstyledButton onClick={startEdit} data-testid={CategoriesTestIds.BtnName}>
             <Text fw={depth === 0 ? 600 : 400} size="md" style={{ cursor: 'text' }}>
               {category.name}
             </Text>
@@ -155,7 +156,7 @@ export function CategoryCard({
         )}
 
         {/* delete */}
-        <ActionIcon variant="subtle" color="red" size="md" onClick={() => onDelete(category)} data-testid="btn_category_delete">
+        <ActionIcon variant="subtle" color="red" size="md" onClick={() => onDelete(category)} data-testid={CategoriesTestIds.BtnDelete}>
           <IconTrash size={18} />
         </ActionIcon>
 
@@ -167,7 +168,7 @@ export function CategoryCard({
             size="md"
             onClick={handleAddChild}
             title="Adicionar subcategoria"
-            data-testid="btn_add_subcategory"
+            data-testid={CategoriesTestIds.BtnAddSubcategory}
           >
             <IconPlus size={18} />
           </ActionIcon>
@@ -204,7 +205,7 @@ export function CategoryCard({
       )}
 
       {/* emoji picker drawer */}
-      <Drawer opened={emojiOpen} onClose={handleCloseEmojiDrawer} title="Escolher emoji" position="right" size="sm" data-testid={`drawer_emoji_picker_${category.id}`}>
+      <Drawer opened={emojiOpen} onClose={handleCloseEmojiDrawer} title="Escolher emoji" position="right" size="sm" data-testid={CategoriesTestIds.DrawerEmojiPicker(category.id)}>
         <Stack gap="md">
           <ScrollArea>
             <SimpleGrid cols={7} spacing="xs">
@@ -212,7 +213,7 @@ export function CategoryCard({
                 <UnstyledButton
                   key={e}
                   onClick={() => handleEmojiSelect(e)}
-                  data-testid={`emoji_${e}`}
+                  data-testid={CategoriesTestIds.EmojiOption(e)}
                   style={{
                     fontSize: 24,
                     textAlign: 'center',

--- a/frontend/src/components/categories/DeleteCategoryModal.tsx
+++ b/frontend/src/components/categories/DeleteCategoryModal.tsx
@@ -4,6 +4,7 @@ import { useCategories, useDeleteCategory } from '@/hooks/useCategories'
 import { useDrawerContext } from '@/utils/renderDrawer'
 import { flattenCategories } from '@/utils/flattenCategories'
 import { Transactions } from '@/types/transactions'
+import { CategoriesTestIds } from '@/testIds'
 
 type Props = {
   category: Transactions.Category
@@ -53,7 +54,7 @@ export function DeleteCategoryModal({ category, allCategories }: Props) {
                 replaceWithId: replaceWithId ? Number(replaceWithId) : undefined,
               })
             }
-            data-testid="btn_confirm_delete_category"
+            data-testid={CategoriesTestIds.BtnConfirmDelete}
           >
             Excluir
           </Button>

--- a/frontend/src/components/categories/InlineNewCategory.tsx
+++ b/frontend/src/components/categories/InlineNewCategory.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react'
 import { ActionIcon, Box, Group, Loader, Text, TextInput } from '@mantine/core'
 import { useAutofocusRef } from '@/hooks/useAutofocusRef'
+import { CategoriesTestIds } from '@/testIds'
 
 interface Props {
   depth: number
@@ -53,7 +54,7 @@ export function InlineNewCategory({ depth, onSave, onCancel }: Props) {
         size="sm"
         style={{ minWidth: 160 }}
         rightSection={saving ? <Loader size={14} /> : null}
-        data-testid="input_new_category_name"
+        data-testid={CategoriesTestIds.InputNewName}
       />
     </Group>
   )

--- a/frontend/src/components/charges/AcceptChargeDrawer.tsx
+++ b/frontend/src/components/charges/AcceptChargeDrawer.tsx
@@ -19,6 +19,7 @@ import { parseApiError, mapTagsToFieldErrors } from "@/utils/apiErrors";
 import { QueryKeys } from "@/utils/queryKeys";
 import { formatBalance } from "@/utils/formatCents";
 import { Charges } from "@/types/charges";
+import { ChargesTestIds } from '@/testIds'
 
 const acceptChargeSchema = z.object({
   account_id: z.number("Selecione uma conta"),
@@ -123,7 +124,7 @@ export function AcceptChargeDrawer({ charge, partnerName }: AcceptChargeDrawerPr
       title="Aceitar Cobrança"
       position="right"
       size="md"
-      data-testid="drawer_accept_charge"
+      data-testid={ChargesTestIds.DrawerAccept}
     >
       <form onSubmit={form.handleSubmit(handleSubmit)} noValidate>
         <Stack gap="md">
@@ -171,7 +172,7 @@ export function AcceptChargeDrawer({ charge, partnerName }: AcceptChargeDrawerPr
                 onChange={(val) => field.onChange(val != null ? Number(val) : undefined)}
                 error={fieldState.error?.message}
                 required
-                data-testid="select_accept_account"
+                data-testid={ChargesTestIds.SelectAcceptAccount}
               />
             )}
           />
@@ -212,7 +213,7 @@ export function AcceptChargeDrawer({ charge, partnerName }: AcceptChargeDrawerPr
             loading={mutation.isPending}
             disabled={mutation.isPending}
             fullWidth
-            data-testid="btn_submit_accept_charge"
+            data-testid={ChargesTestIds.BtnSubmitAccept}
           >
             Confirmar aceitacao
           </Button>

--- a/frontend/src/components/charges/ChargeCard.tsx
+++ b/frontend/src/components/charges/ChargeCard.tsx
@@ -3,6 +3,7 @@ import { Charges } from '@/types/charges'
 import { formatBalance } from '@/utils/formatCents'
 import { ChargeStatusBadge } from './ChargeStatusBadge'
 import classes from './ChargeCard.module.css'
+import { ChargesTestIds } from '@/testIds'
 
 interface Props {
   charge: Charges.Charge
@@ -27,7 +28,7 @@ export function ChargeCard({ charge, currentUserId, partnerName, balanceAmount, 
       radius="md"
       p="md"
       className={classes.card}
-      data-testid={`charge_card_${charge.id}`}
+      data-testid={ChargesTestIds.Card(charge.id)}
     >
       <Group justify="space-between" align="flex-start">
         <Stack gap={2}>
@@ -52,17 +53,17 @@ export function ChargeCard({ charge, currentUserId, partnerName, balanceAmount, 
         </Text>
         <Group gap="xs">
           {isReceived && isPending && onAccept && (
-            <Button size="xs" color="teal" onClick={onAccept} data-testid="btn_accept_charge">
+            <Button size="xs" color="teal" onClick={onAccept} data-testid={ChargesTestIds.BtnAccept}>
               Aceitar
             </Button>
           )}
           {isReceived && isPending && onReject && (
-            <Button size="xs" color="red" variant="light" onClick={onReject} data-testid="btn_reject_charge">
+            <Button size="xs" color="red" variant="light" onClick={onReject} data-testid={ChargesTestIds.BtnReject}>
               Recusar
             </Button>
           )}
           {!isReceived && isPending && onCancel && (
-            <Button size="xs" color="red" variant="light" onClick={onCancel} data-testid="btn_cancel_charge">
+            <Button size="xs" color="red" variant="light" onClick={onCancel} data-testid={ChargesTestIds.BtnCancel}>
               Cancelar
             </Button>
           )}

--- a/frontend/src/components/charges/ConfirmChargeActionDrawer.tsx
+++ b/frontend/src/components/charges/ConfirmChargeActionDrawer.tsx
@@ -1,5 +1,6 @@
 import { Button, Group, Modal, Stack, Text } from '@mantine/core'
 import { useDrawerContext } from '@/utils/renderDrawer'
+import { ChargesTestIds } from '@/testIds'
 
 export type ConfirmChargeAction = 'reject' | 'cancel'
 
@@ -27,7 +28,7 @@ export function ConfirmChargeActionDrawer({ action }: Props) {
       onClose={reject}
       title={title}
       size="sm"
-      data-testid={`modal_confirm_${action}_charge`}
+      data-testid={ChargesTestIds.ModalConfirm(action)}
     >
       <Stack gap="md">
         <Text size="sm">{message}</Text>
@@ -38,7 +39,7 @@ export function ConfirmChargeActionDrawer({ action }: Props) {
           <Button
             color="red"
             onClick={() => close()}
-            data-testid={`btn_confirm_${action}_charge`}
+            data-testid={ChargesTestIds.BtnConfirm(action)}
           >
             {confirmLabel}
           </Button>

--- a/frontend/src/components/charges/CreateChargeDrawer.tsx
+++ b/frontend/src/components/charges/CreateChargeDrawer.tsx
@@ -19,6 +19,7 @@ import { parseApiError, mapTagsToFieldErrors } from "@/utils/apiErrors";
 import { QueryKeys } from "@/utils/queryKeys";
 import { formatBalance } from "@/utils/formatCents";
 import { Charges } from "@/types/charges";
+import { ChargesTestIds } from '@/testIds'
 
 const createChargeSchema = z.object({
   connection_id: z.number("Selecione uma conexao"),
@@ -154,7 +155,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
       title="Criar Cobrança"
       position="right"
       size="md"
-      data-testid="drawer_create_charge"
+      data-testid={ChargesTestIds.DrawerCreate}
     >
       <form onSubmit={form.handleSubmit(handleSubmit)} noValidate>
         <Stack gap="md">
@@ -177,7 +178,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
                   onChange={(val) => field.onChange(val != null ? Number(val) : undefined)}
                   error={fieldState.error?.message}
                   required
-                  data-testid="select_connection"
+                  data-testid={ChargesTestIds.SelectConnection}
                 />
               )}
             />
@@ -195,7 +196,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
                 onChange={(val) => field.onChange(val != null ? Number(val) : undefined)}
                 error={fieldState.error?.message}
                 required
-                data-testid="select_my_account"
+                data-testid={ChargesTestIds.SelectMyAccount}
               />
             )}
           />
@@ -247,8 +248,8 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
                 required
               >
                 <Stack gap="xs" mt="xs">
-                  <Radio value="charger" label="Cobrador (estou cobrando)" data-testid="radio_role_charger" />
-                  <Radio value="payer" label="Pagador (estou pagando)" data-testid="radio_role_payer" />
+                  <Radio value="charger" label="Cobrador (estou cobrando)" data-testid={ChargesTestIds.RadioRole('charger')} />
+                  <Radio value="payer" label="Pagador (estou pagando)" data-testid={ChargesTestIds.RadioRole('payer')} />
                 </Stack>
               </Radio.Group>
             )}
@@ -271,7 +272,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
                 decimalSeparator=","
                 prefix="R$ "
                 error={fieldState.error?.message}
-                data-testid="input_charge_amount"
+                data-testid={ChargesTestIds.InputAmount}
               />
             )}
           />
@@ -282,7 +283,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
             minRows={2}
             {...form.register("description")}
             error={form.formState.errors.description?.message}
-            data-testid="input_charge_description"
+            data-testid={ChargesTestIds.InputDescription}
           />
 
           {watchedConnectionId && (
@@ -304,7 +305,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
             loading={mutation.isPending}
             disabled={mutation.isPending}
             fullWidth
-            data-testid="btn_submit_create_charge"
+            data-testid={ChargesTestIds.BtnSubmitCreate}
           >
             Criar Cobrança
           </Button>

--- a/frontend/src/components/transactions/BulkDivisionDrawer.tsx
+++ b/frontend/src/components/transactions/BulkDivisionDrawer.tsx
@@ -7,6 +7,7 @@ import { Transactions } from "@/types/transactions";
 import { useMe } from "@/hooks/useMe";
 import { useAccounts } from "@/hooks/useAccounts";
 import { SplitSettingsFields } from "./form/SplitSettingsFields";
+import { TransactionsTestIds } from "@/testIds";
 
 // ─── Schema ──────────────────────────────────────────────────────────────────
 // Percentage-only shape. No `amount` field in the form state, by design (D-02).
@@ -64,7 +65,7 @@ export function BulkDivisionDrawer() {
         onClose={reject}
         position="bottom"
         title="Alterar divisão"
-        data-testid="drawer_bulk_division"
+        data-testid={TransactionsTestIds.DrawerBulkDivision}
         styles={drawerStyles}
       >
         <Text c="dimmed">Carregando...</Text>
@@ -157,7 +158,7 @@ function BulkDivisionDrawerForm({
       onClose={reject}
       position="bottom"
       title="Alterar divisão"
-      data-testid="drawer_bulk_division"
+      data-testid={TransactionsTestIds.DrawerBulkDivision}
       styles={drawerStyles}
     >
       {!hasConnectedAccounts ? (
@@ -173,7 +174,7 @@ function BulkDivisionDrawerForm({
                 color={isSumValid ? "green" : "red"}
                 variant="light"
                 size="lg"
-                data-testid="badge_bulk_division_sum"
+                data-testid={TransactionsTestIds.BadgeBulkDivisionSum}
               >
                 {`Total: ${sum}% / 100%`}
               </Badge>
@@ -181,7 +182,7 @@ function BulkDivisionDrawerForm({
                 type="submit"
                 disabled={!isSumValid}
                 style={{ alignSelf: "flex-start" }}
-                data-testid="btn_apply_bulk_division"
+                data-testid={TransactionsTestIds.BtnApplyBulkDivision}
               >
                 Aplicar
               </Button>

--- a/frontend/src/components/transactions/BulkProgressDrawer.tsx
+++ b/frontend/src/components/transactions/BulkProgressDrawer.tsx
@@ -10,6 +10,7 @@ import {
 import { IconCheck, IconX } from "@tabler/icons-react";
 import { useDrawerContext } from "@/utils/renderDrawer";
 import { useSequentialProgress } from "@/hooks/useSequentialProgress";
+import { TransactionsTestIds } from "@/testIds";
 
 export interface BulkProgressItem {
   id: number;
@@ -37,7 +38,7 @@ export function BulkProgressDrawer({
   successMessage,
   onInvalidate,
   onSuccess,
-  testIdPrefix = "bulk_progress",
+  testIdPrefix = TransactionsTestIds.BulkProgressDrawer,
 }: BulkProgressDrawerProps) {
   const { opened, close } = useDrawerContext<void>();
   const { state, progress, currentLabel, errorInfo } = useSequentialProgress({
@@ -79,18 +80,18 @@ export function BulkProgressDrawer({
             value={progress}
             animated={isProcessing}
             color={state === "error" ? "red" : "blue"}
-            data-testid="bulk_progress_bar"
+            data-testid={TransactionsTestIds.BulkProgressBar}
           />
         )}
 
         {isProcessing && (
-          <Text size="sm" c="dimmed" ta="center" data-testid="bulk_current_label">
+          <Text size="sm" c="dimmed" ta="center" data-testid={TransactionsTestIds.BulkCurrentLabel}>
             {currentLabel}
           </Text>
         )}
 
         {state === "success" && (
-          <Stack gap="sm" align="center" data-testid="bulk_success">
+          <Stack gap="sm" align="center" data-testid={TransactionsTestIds.BulkSuccess}>
             <Group justify="center" gap="xs">
               <ThemeIcon color="teal" radius="xl" size="lg">
                 <IconCheck size={18} />
@@ -99,14 +100,14 @@ export function BulkProgressDrawer({
                 {successMessage(items.length)}
               </Text>
             </Group>
-            <Button variant="default" onClick={() => close()} data-testid="btn_bulk_done">
+            <Button variant="default" onClick={() => close()} data-testid={TransactionsTestIds.BtnBulkDone}>
               Fechar
             </Button>
           </Stack>
         )}
 
         {state === "error" && errorInfo && (
-          <Stack gap="xs" data-testid="bulk_error">
+          <Stack gap="xs" data-testid={TransactionsTestIds.BulkError}>
             <Group gap="xs">
               <ThemeIcon color="red" radius="xl" size="md">
                 <IconX size={14} />
@@ -130,7 +131,7 @@ export function BulkProgressDrawer({
                 ))}
               </>
             )}
-            <Button variant="default" onClick={() => close()} mt="xs" data-testid="btn_bulk_close_error">
+            <Button variant="default" onClick={() => close()} mt="xs" data-testid={TransactionsTestIds.BtnBulkCloseError}>
               Fechar
             </Button>
           </Stack>

--- a/frontend/src/components/transactions/ClearFiltersButton.tsx
+++ b/frontend/src/components/transactions/ClearFiltersButton.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon, Button } from '@mantine/core'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { IconX } from '@tabler/icons-react'
+import { TransactionsTestIds } from '@/testIds'
 
 interface ClearFiltersButtonProps {
   variant?: 'icon' | 'button'
@@ -47,7 +48,7 @@ export function ClearFiltersButton({ variant = 'button' }: ClearFiltersButtonPro
         color="red"
         onClick={clearFilters}
         aria-label="Limpar filtros"
-        data-testid="btn_clear_filters"
+        data-testid={TransactionsTestIds.BtnClearFilters}
       >
         <IconX size={18} />
       </ActionIcon>
@@ -61,7 +62,7 @@ export function ClearFiltersButton({ variant = 'button' }: ClearFiltersButtonPro
       color="red"
       leftSection={<IconX size={12} />}
       onClick={clearFilters}
-      data-testid="btn_clear_filters"
+      data-testid={TransactionsTestIds.BtnClearFilters}
     >
       Limpar filtros
     </Button>

--- a/frontend/src/components/transactions/CreateTransactionDrawer.tsx
+++ b/frontend/src/components/transactions/CreateTransactionDrawer.tsx
@@ -17,6 +17,7 @@ import { useDrawerContext } from "@/utils/renderDrawer";
 import { transactionFormSchema, TransactionFormValues } from "./form/transactionFormSchema";
 import { TransactionForm } from "./form/TransactionForm";
 import { convertUtcToLocalKeepingValues } from "@/utils/parseDate";
+import { TransactionsTestIds } from '@/testIds'
 
 const TYPE_LABELS: Record<Transactions.TransactionType, string> = {
   expense: "Nova Despesa",
@@ -116,7 +117,7 @@ export function CreateTransactionDrawer() {
       title={TYPE_LABELS[transactionType]}
       position="right"
       size="md"
-      data-testid="drawer_create_transaction"
+      data-testid={TransactionsTestIds.DrawerCreate}
     >
       <FormProvider {...methods}>
         <TransactionForm

--- a/frontend/src/components/transactions/FiltersDrawer.tsx
+++ b/frontend/src/components/transactions/FiltersDrawer.tsx
@@ -1,6 +1,7 @@
 import { Drawer } from '@mantine/core'
 import { useDrawerContext } from '@/utils/renderDrawer'
 import { TransactionFilters } from '@/components/transactions/TransactionFilters'
+import { TransactionsTestIds } from '@/testIds'
 
 export function FiltersDrawer() {
   const { opened, reject } = useDrawerContext<void>()
@@ -12,7 +13,7 @@ export function FiltersDrawer() {
       position="bottom"
       title="Filtros"
       size="auto"
-      data-testid="drawer_transaction_filters"
+      data-testid={TransactionsTestIds.DrawerFilters}
       styles={{
         content: {
           borderRadius: 'var(--mantine-radius-lg) var(--mantine-radius-lg) 0 0',

--- a/frontend/src/components/transactions/PropagationSettingsDrawer.tsx
+++ b/frontend/src/components/transactions/PropagationSettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import { Button, Drawer, Radio, Stack, Text } from '@mantine/core'
 import { useState } from 'react'
 import { useDrawerContext } from '@/utils/renderDrawer'
+import { TransactionsTestIds } from '@/testIds'
 
 export type PropagationSetting = 'current' | 'current_and_future' | 'all'
 
@@ -56,7 +57,7 @@ export function PropagationSettingsDrawer({ actionLabel = 'excluir' }: Propagati
         body: { paddingBottom: 'var(--mantine-spacing-xl)' },
       }}
     >
-      <Stack gap="md" data-testid="propagation_drawer_body">
+      <Stack gap="md" data-testid={TransactionsTestIds.PropagationDrawerBody}>
         <Text size="sm" c="dimmed">
           {copy.body}
         </Text>
@@ -68,7 +69,7 @@ export function PropagationSettingsDrawer({ actionLabel = 'excluir' }: Propagati
                 value={opt.value}
                 label={opt.label}
                 description={opt.description}
-                data-testid={`propagation_option_${opt.value}`}
+                data-testid={TransactionsTestIds.PropagationOption(opt.value)}
               />
             ))}
           </Stack>

--- a/frontend/src/components/transactions/SelectCategoryDrawer.tsx
+++ b/frontend/src/components/transactions/SelectCategoryDrawer.tsx
@@ -2,6 +2,7 @@ import { Drawer, Group, Stack, Text, UnstyledButton } from '@mantine/core'
 import { useCategories } from '@/hooks/useCategories'
 import { Transactions } from '@/types/transactions'
 import { useDrawerContext } from '@/utils/renderDrawer'
+import { TransactionsTestIds } from '@/testIds'
 
 function CategoryRow({
   category,
@@ -23,7 +24,7 @@ function CategoryRow({
           borderRadius: 'var(--mantine-radius-sm)',
           width: '100%',
         }}
-        data-testid={`category_option_${category.id}`}
+        data-testid={TransactionsTestIds.CategoryOption(category.id)}
       >
         <Group gap="xs">
           {category.emoji && <Text>{category.emoji}</Text>}
@@ -49,7 +50,7 @@ export function SelectCategoryDrawer() {
       title="Selecionar categoria"
       position="right"
       size="md"
-      data-testid="drawer_select_category"
+      data-testid={TransactionsTestIds.DrawerSelectCategory}
     >
       <Stack gap={4}>
         {categories.length === 0 ? (

--- a/frontend/src/components/transactions/SelectDateDrawer.tsx
+++ b/frontend/src/components/transactions/SelectDateDrawer.tsx
@@ -2,6 +2,7 @@ import { Button, Drawer, Stack } from '@mantine/core'
 import { DateInput } from '@mantine/dates'
 import { useState } from 'react'
 import { useDrawerContext } from '@/utils/renderDrawer'
+import { TransactionsTestIds } from '@/testIds'
 
 export function SelectDateDrawer() {
   const { opened, close, reject } = useDrawerContext<Date>()
@@ -13,7 +14,7 @@ export function SelectDateDrawer() {
       onClose={reject}
       position="bottom"
       title="Alterar data"
-      data-testid="drawer_select_date"
+      data-testid={TransactionsTestIds.DrawerSelectDate}
       styles={{
         content: {
           borderRadius: 'var(--mantine-radius-lg) var(--mantine-radius-lg) 0 0',
@@ -30,13 +31,13 @@ export function SelectDateDrawer() {
           label="Nova data"
           placeholder="Selecione uma data"
           valueFormat="DD/MM/YYYY"
-          data-testid="input_bulk_date"
+          data-testid={TransactionsTestIds.InputBulkDate}
         />
         <Button
           onClick={() => date && close(date)}
           disabled={!date}
           style={{ alignSelf: 'flex-start' }}
-          data-testid="btn_apply_date"
+          data-testid={TransactionsTestIds.BtnApplyDate}
         >
           Aplicar
         </Button>

--- a/frontend/src/components/transactions/SelectionActionBar.tsx
+++ b/frontend/src/components/transactions/SelectionActionBar.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon, Button, Group, Menu, Text } from '@mantine/core'
 import { IconCalendar, IconCategory, IconChevronDown, IconShare, IconTrash, IconX } from '@tabler/icons-react'
 import classes from './SelectionActionBar.module.css'
+import { TransactionsTestIds } from '@/testIds'
 
 interface SelectionActionBarProps {
   count: number
@@ -14,20 +15,20 @@ interface SelectionActionBarProps {
 
 export function SelectionActionBar({ count, onClearSelection, onCategoryChange, onDateChange, onDivisaoChange, connectedAccountsCount, onDelete }: SelectionActionBarProps) {
   return (
-    <div className={classes.bar} data-testid="selection_action_bar">
+    <div className={classes.bar} data-testid={TransactionsTestIds.SelectionActionBar}>
       <ActionIcon
         className={classes.closeButton}
         variant="default"
         radius="xl"
         size="md"
         onClick={onClearSelection}
-        data-testid="btn_clear_selection"
+        data-testid={TransactionsTestIds.BtnClearSelection}
         aria-label="Limpar seleção"
       >
         <IconX size={14} />
       </ActionIcon>
       <Group justify="space-between" align="center">
-        <Text size="sm" fw={700} data-testid="selection_count">
+        <Text size="sm" fw={700} data-testid={TransactionsTestIds.SelectionCount}>
           {count}
         </Text>
         <Menu shadow="md" width={200}>
@@ -36,7 +37,7 @@ export function SelectionActionBar({ count, onClearSelection, onCategoryChange, 
               size="sm"
               variant="default"
               rightSection={<IconChevronDown size={14} />}
-              data-testid="btn_bulk_actions_menu"
+              data-testid={TransactionsTestIds.BtnBulkActionsMenu}
             >
               Ações
             </Button>
@@ -45,14 +46,14 @@ export function SelectionActionBar({ count, onClearSelection, onCategoryChange, 
             <Menu.Item
               leftSection={<IconCategory size={14} />}
               onClick={onCategoryChange}
-              data-testid="btn_bulk_category"
+              data-testid={TransactionsTestIds.BtnBulkCategory}
             >
               Alterar categoria
             </Menu.Item>
             <Menu.Item
               leftSection={<IconCalendar size={14} />}
               onClick={onDateChange}
-              data-testid="btn_bulk_date"
+              data-testid={TransactionsTestIds.BtnBulkDate}
             >
               Alterar data
             </Menu.Item>
@@ -60,12 +61,12 @@ export function SelectionActionBar({ count, onClearSelection, onCategoryChange, 
               leftSection={<IconShare size={14} />}
               onClick={connectedAccountsCount === 0 ? undefined : onDivisaoChange}
               disabled={connectedAccountsCount === 0}
-              data-testid="btn_bulk_division"
+              data-testid={TransactionsTestIds.BtnBulkDivision}
             >
               Divisão
             </Menu.Item>
             {connectedAccountsCount === 0 && (
-              <Text size="xs" c="dimmed" px="sm" pb="xs" data-testid="hint_bulk_division_no_connection">
+              <Text size="xs" c="dimmed" px="sm" pb="xs" data-testid={TransactionsTestIds.HintBulkDivisionNoConnection}>
                 Conecte uma conta para usar esta ação.
               </Text>
             )}
@@ -73,7 +74,7 @@ export function SelectionActionBar({ count, onClearSelection, onCategoryChange, 
             <Menu.Item
               leftSection={<IconTrash size={14} color="var(--mantine-color-red-5)" />}
               onClick={onDelete}
-              data-testid="btn_bulk_delete"
+              data-testid={TransactionsTestIds.BtnBulkDelete}
             >
               Excluir
             </Menu.Item>

--- a/frontend/src/components/transactions/TransactionRow.tsx
+++ b/frontend/src/components/transactions/TransactionRow.tsx
@@ -8,6 +8,7 @@ import { RecurrenceBadge } from "./RecurrenceBadge";
 import classes from "./TransactionRow.module.css";
 import { FocusField } from "./form/TransactionForm";
 import { MouseEventHandler } from "react";
+import { TransactionsTestIds } from "@/testIds";
 
 const MAX_TAGS = 3;
 
@@ -49,13 +50,13 @@ function AccountCell({
 
   if (tx.type === "transfer") {
     return (
-      <Group gap={4} wrap="nowrap" data-testid="transfer_avatar_group">
+      <Group gap={4} wrap="nowrap" data-testid={TransactionsTestIds.TransferAvatarGroup}>
         <Tooltip label={fromAccount?.name ?? "\u2014"} withArrow position="top">
           <span>
             <AccountAvatar account={fromAccount} size={28} />
           </span>
         </Tooltip>
-        <IconArrowRight size={12} style={{ opacity: 0.5 }} data-testid="icon_transfer_arrow" />
+        <IconArrowRight size={12} style={{ opacity: 0.5 }} data-testid={TransactionsTestIds.IconTransferArrow} />
         <Tooltip label={toAccount?.name ?? "\u2014"} withArrow position="top">
           <span>
             <AccountAvatar account={toAccount} size={28} />
@@ -175,7 +176,7 @@ export function TransactionRow({
             onChange={() => onSelect?.(tx.id)}
             onClick={(e) => e.stopPropagation()}
             size="sm"
-            data-testid={`checkbox_${tx.id}`}
+            data-testid={TransactionsTestIds.Checkbox(tx.id)}
           />
         )}
       </div>

--- a/frontend/src/components/transactions/UpdatePropagationSelector.tsx
+++ b/frontend/src/components/transactions/UpdatePropagationSelector.tsx
@@ -1,4 +1,5 @@
 import { Radio, Stack, Text } from '@mantine/core'
+import { TransactionsTestIds } from '@/testIds'
 
 export type PropagationValue = 'current' | 'current_and_future' | 'all'
 
@@ -25,7 +26,7 @@ export function UpdatePropagationSelector({ value, onChange }: Props) {
               value={opt.value}
               label={opt.label}
               description={opt.description}
-              data-testid={`propagation_update_option_${opt.value}`}
+              data-testid={TransactionsTestIds.PropagationUpdateOption(opt.value)}
             />
           ))}
         </Stack>

--- a/frontend/src/components/transactions/UpdateTransactionDrawer.tsx
+++ b/frontend/src/components/transactions/UpdateTransactionDrawer.tsx
@@ -14,6 +14,7 @@ import { updateTransactionFormSchema, UpdateTransactionFormValues, TransactionFo
 import { TransactionForm, FocusField } from "./form/TransactionForm";
 import { UpdatePropagationSelector } from "./UpdatePropagationSelector";
 import { convertUtcToLocalKeepingValues } from "@/utils/parseDate";
+import { TransactionsTestIds } from '@/testIds'
 
 interface Props {
   transaction: Transactions.Transaction;
@@ -107,7 +108,7 @@ export function UpdateTransactionDrawer({ transaction, focusField }: Props) {
       title="Editar transação"
       position="right"
       size="md"
-      data-testid="drawer_update_transaction"
+      data-testid={TransactionsTestIds.DrawerUpdate}
     >
       <FormProvider {...methods}>
         <TransactionForm

--- a/frontend/src/components/transactions/filters/AccountFilter.tsx
+++ b/frontend/src/components/transactions/filters/AccountFilter.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useState } from 'react'
 import { useAccounts } from '@/hooks/useAccounts'
 import { Transactions } from '@/types/transactions'
+import { TransactionsTestIds } from '@/testIds'
 
 interface AccountFilterProps {
   inline?: boolean
@@ -30,7 +31,7 @@ function AccountGroup({
           label={acc.name}
           checked={selected.includes(acc.id)}
           onChange={() => toggle(acc.id)}
-          data-testid={`checkbox_filter_account_${acc.id}`}
+          data-testid={TransactionsTestIds.CheckboxFilterAccount(acc.id)}
           data-account-name={acc.name}
         />
       ))}
@@ -101,13 +102,13 @@ export function AccountFilter({ inline }: AccountFilterProps) {
             variant="default"
             leftSection={<IconBuildingBank size={16} />}
             onClick={() => setOpened((o) => !o)}
-            data-testid="btn_filter_accounts"
+            data-testid={TransactionsTestIds.BtnFilter('accounts')}
           >
             Contas
           </Button>
         </Indicator>
       </Popover.Target>
-      <Popover.Dropdown data-testid="popover_filter_accounts">
+      <Popover.Dropdown data-testid={TransactionsTestIds.PopoverFilter('accounts')}>
         <Stack gap="xs" maw={280}>
           <AccountOptions accounts={accounts} selected={selected} toggle={toggle} />
         </Stack>

--- a/frontend/src/components/transactions/filters/AdvancedFilter.tsx
+++ b/frontend/src/components/transactions/filters/AdvancedFilter.tsx
@@ -3,6 +3,7 @@ import { IconAdjustments } from "@tabler/icons-react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useState } from "react";
 import { Transactions } from "@/types/transactions";
+import { TransactionsTestIds } from "@/testIds";
 
 const TYPE_OPTIONS: { value: Transactions.TransactionType; label: string }[] = [
   { value: "expense", label: "Apenas despesas" },
@@ -29,7 +30,7 @@ function TypeOptions({
           label={opt.label}
           checked={selected.includes(opt.value)}
           onChange={() => toggle(opt.value)}
-          data-testid={`switch_type_${opt.value}`}
+          data-testid={TransactionsTestIds.SwitchType(opt.value)}
         />
       ))}
     </>
@@ -83,7 +84,7 @@ export function AdvancedFilter({ inline }: AdvancedFilterProps) {
       onChange={setOpened}
       position="bottom-start"
       shadow="md"
-      data-testid="advanced_filters_popover"
+      data-testid={TransactionsTestIds.AdvancedFiltersPopover}
     >
       <Popover.Target>
         <Indicator label={advancedCount} size={16} disabled={!advancedCount}>
@@ -91,7 +92,7 @@ export function AdvancedFilter({ inline }: AdvancedFilterProps) {
             variant="default"
             leftSection={<IconAdjustments size={16} />}
             onClick={() => setOpened((o) => !o)}
-            data-testid="open_advanced_filters"
+            data-testid={TransactionsTestIds.BtnOpenAdvancedFilters}
           >
             Filtros avançados
           </Button>
@@ -104,7 +105,7 @@ export function AdvancedFilter({ inline }: AdvancedFilterProps) {
             label="Ocultar acertos"
             checked={hideSettlements}
             onChange={toggleHideSettlements}
-            data-testid="switch_hide_settlements"
+            data-testid={TransactionsTestIds.SwitchHideSettlements}
           />
         </Stack>
       </Popover.Dropdown>

--- a/frontend/src/components/transactions/filters/CategoryFilter.tsx
+++ b/frontend/src/components/transactions/filters/CategoryFilter.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { Transactions } from '@/types/transactions'
 import { useCategories } from '@/hooks/useCategories'
 import classes from './CategoryFilter.module.css'
+import { TransactionsTestIds } from '@/testIds'
 
 interface CategoryNodeProps {
   category: Transactions.Category
@@ -38,7 +39,7 @@ function CategoryNode({ category, selected, onToggle }: CategoryNodeProps) {
           }
           checked={selected.includes(category.id)}
           onChange={() => onToggle(category.id)}
-          data-testid={`checkbox_filter_category_${category.id}`}
+          data-testid={TransactionsTestIds.CheckboxFilterCategory(category.id)}
           data-category-name={category.name}
         />
       </Group>
@@ -56,7 +57,7 @@ function CategoryNode({ category, selected, onToggle }: CategoryNodeProps) {
                 }
                 checked={selected.includes(child.id)}
                 onChange={() => onToggle(child.id)}
-                data-testid={`checkbox_filter_category_${child.id}`}
+                data-testid={TransactionsTestIds.CheckboxFilterCategory(child.id)}
                 data-category-name={child.name}
               />
             ))}
@@ -124,13 +125,13 @@ export function CategoryFilter({ inline }: CategoryFilterProps) {
             variant="default"
             leftSection={<IconCategory size={16} />}
             onClick={() => setOpened((o) => !o)}
-            data-testid="btn_filter_categories"
+            data-testid={TransactionsTestIds.BtnFilter('categories')}
           >
             Categorias
           </Button>
         </Indicator>
       </Popover.Target>
-      <Popover.Dropdown data-testid="popover_filter_categories">
+      <Popover.Dropdown data-testid={TransactionsTestIds.PopoverFilter('categories')}>
         <Stack gap="xs" maw={280} className={classes.list}>
           <CategoryOptions categories={categories} selected={selected} toggle={toggle} />
         </Stack>

--- a/frontend/src/components/transactions/filters/GroupBySelector.tsx
+++ b/frontend/src/components/transactions/filters/GroupBySelector.tsx
@@ -1,6 +1,7 @@
 import { SegmentedControl, Stack, Text } from '@mantine/core'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { Transactions } from '@/types/transactions'
+import { TransactionsTestIds } from '@/testIds'
 
 const OPTIONS = [
   { value: 'date', label: 'Data' },
@@ -22,7 +23,7 @@ export function GroupBySelector() {
   return (
     <Stack gap={4}>
       <Text size="sm" c="dimmed">Agrupar por</Text>
-      <SegmentedControl value={groupBy} onChange={onChange} data={OPTIONS} size="sm" data-testid="segmented_group_by" />
+      <SegmentedControl value={groupBy} onChange={onChange} data={OPTIONS} size="sm" data-testid={TransactionsTestIds.SegmentedGroupBy} />
     </Stack>
   )
 }

--- a/frontend/src/components/transactions/filters/TagFilter.tsx
+++ b/frontend/src/components/transactions/filters/TagFilter.tsx
@@ -3,6 +3,7 @@ import { IconTag } from '@tabler/icons-react'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useState } from 'react'
 import { useTags } from '@/hooks/useTags'
+import { TransactionsTestIds } from '@/testIds'
 
 interface TagFilterProps {
   inline?: boolean
@@ -24,7 +25,7 @@ function TagOptions({ tags, selected, toggle }: {
           variant={selected.includes(tag.id) ? 'filled' : 'outline'}
           style={{ cursor: 'pointer' }}
           onClick={() => toggle(tag.id)}
-          data-testid={`badge_filter_tag_${tag.id}`}
+          data-testid={TransactionsTestIds.BadgeFilterTag(tag.id)}
           data-tag-name={tag.name}
         >
           {tag.name}
@@ -67,13 +68,13 @@ export function TagFilter({ inline }: TagFilterProps) {
             variant="default"
             leftSection={<IconTag size={16} />}
             onClick={() => setOpened((o) => !o)}
-            data-testid="btn_filter_tags"
+            data-testid={TransactionsTestIds.BtnFilter('tags')}
           >
             Tags
           </Button>
         </Indicator>
       </Popover.Target>
-      <Popover.Dropdown data-testid="popover_filter_tags">
+      <Popover.Dropdown data-testid={TransactionsTestIds.PopoverFilter('tags')}>
         <TagOptions tags={tags} selected={selected} toggle={toggle} />
       </Popover.Dropdown>
     </Popover>

--- a/frontend/src/components/transactions/filters/TextSearch.tsx
+++ b/frontend/src/components/transactions/filters/TextSearch.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { IconSearch } from '@tabler/icons-react'
 import { useSearch } from '@tanstack/react-router'
 import { useSyncTransactionsSearchQuery } from '@/hooks/useSyncTransactionsSearchQuery'
+import { TransactionsTestIds } from '@/testIds'
 
 interface TextSearchProps {
   style?: React.CSSProperties
@@ -21,7 +22,7 @@ export function TextSearch({ style }: TextSearchProps) {
       value={value}
       onChange={(e) => setValue(e.currentTarget.value)}
       style={{ minWidth: 200, ...style }}
-      data-testid="input_text_search"
+      data-testid={TransactionsTestIds.InputTextSearch}
     />
   )
 }

--- a/frontend/src/components/transactions/form/DescriptionAutocomplete.tsx
+++ b/frontend/src/components/transactions/form/DescriptionAutocomplete.tsx
@@ -2,6 +2,7 @@ import { Autocomplete } from "@mantine/core";
 import { useTransactionSuggestions } from "@/hooks/useTransactionSuggestions";
 import { Transactions } from "@/types/transactions";
 import { forwardRef } from "react";
+import { TransactionsTestIds } from "@/testIds";
 
 interface Props {
   value: string;
@@ -45,7 +46,7 @@ export const DescriptionAutocomplete = forwardRef<HTMLInputElement, Props>(funct
       onOptionSubmit={handleOptionSubmit}
       data={options}
       error={error}
-      data-testid="input_description"
+      data-testid={TransactionsTestIds.InputDescription}
       defaultDropdownOpened={false}
     />
   );

--- a/frontend/src/components/transactions/form/SplitSettingsFields.tsx
+++ b/frontend/src/components/transactions/form/SplitSettingsFields.tsx
@@ -23,6 +23,7 @@ import { Transactions } from "@/types/transactions";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useMe } from "@/hooks/useMe";
 import { getInitials } from "@/utils/getInitials";
+import { TransactionsTestIds } from "@/testIds";
 
 function formatCurrency(cents: number): string {
   return (cents / 100).toLocaleString("pt-BR", {
@@ -110,7 +111,7 @@ function SplitRowControls({
             onChange={(val) => setPercentage(Math.min(100, Math.max(1, Number(val))))}
             style={{ width: 90 }}
             size="sm"
-            data-testid="input_split_percentage"
+            data-testid={TransactionsTestIds.InputSplitPercentage}
           />
           {totalAmount > 0 && (
             <Text size="sm" c="dimmed">
@@ -125,7 +126,7 @@ function SplitRowControls({
             value={fieldValue}
             onChange={(v) => setValue(amountFieldName, v)}
             error={error}
-            data-testid="input_split_amount"
+            data-testid={TransactionsTestIds.InputSplitAmount}
           />
         </Box>
       )}
@@ -366,7 +367,7 @@ export function SplitSettingsFields({
             c="dimmed"
             onClick={() => append({ connection_id: 0, amount: 0 })}
             style={{ alignSelf: "flex-start" }}
-            data-testid="btn_add_split_row"
+            data-testid={TransactionsTestIds.BtnAddSplitRow}
           >
             + Adicionar divisão
           </Anchor>

--- a/frontend/src/components/transactions/form/TransactionForm.tsx
+++ b/frontend/src/components/transactions/form/TransactionForm.tsx
@@ -25,6 +25,7 @@ import { DescriptionAutocomplete } from "./DescriptionAutocomplete";
 import { RecurrenceFields } from "./RecurrenceFields";
 import { SplitSettingsFields } from "./SplitSettingsFields";
 import { TransactionFormValues } from "./transactionFormSchema";
+import { TransactionsTestIds } from "@/testIds";
 
 export type { TransactionFormValues };
 
@@ -189,7 +190,7 @@ export const TransactionForm = ({
                 if (val === "transfer") setValue("split_settings", []);
               }}
               fullWidth
-              data-testid="segmented_transaction_type"
+              data-testid={TransactionsTestIds.SegmentedTransactionType}
             />
           )}
         />
@@ -222,7 +223,7 @@ export const TransactionForm = ({
                 value={field.value}
                 onChange={field.onChange}
                 error={errors.amount?.message}
-                data-testid="input_amount"
+                data-testid={TransactionsTestIds.InputAmount}
               />
             )}
           />
@@ -259,7 +260,7 @@ export const TransactionForm = ({
                   onBlur={makeSelectBlurHandler(accountOptions, (val) => field.onChange(val))}
                   error={errors.account_id?.message}
                   searchable
-                  data-testid="select_account"
+                  data-testid={TransactionsTestIds.SelectAccount}
                 />
               )}
             />
@@ -277,7 +278,7 @@ export const TransactionForm = ({
                   onBlur={makeSelectBlurHandler(destinationAccountOptions, (val) => field.onChange(val))}
                   error={errors.destination_account_id?.message}
                   searchable
-                  data-testid="select_destination_account"
+                  data-testid={TransactionsTestIds.SelectDestinationAccount}
                 />
               )}
             />
@@ -299,7 +300,7 @@ export const TransactionForm = ({
                     error={errors.category_id?.message}
                     searchable
                     clearable
-                    data-testid="select_category"
+                    data-testid={TransactionsTestIds.SelectCategory}
                   />
                 )}
               />
@@ -317,7 +318,7 @@ export const TransactionForm = ({
                     onBlur={makeSelectBlurHandler(accountOptions, (val) => field.onChange(val))}
                     error={errors.account_id?.message}
                     searchable
-                    data-testid="select_account"
+                    data-testid={TransactionsTestIds.SelectAccount}
                   />
                 )}
               />
@@ -383,7 +384,7 @@ export const TransactionForm = ({
               Salvar e criar outra
             </Button>
           )}
-          <Button type="submit" loading={isSubmitting || isPending} data-testid="btn_save_transaction">
+          <Button type="submit" loading={isSubmitting || isPending} data-testid={TransactionsTestIds.BtnSave}>
             Salvar
           </Button>
         </Group>

--- a/frontend/src/components/transactions/import/CreateCategoryDrawer.tsx
+++ b/frontend/src/components/transactions/import/CreateCategoryDrawer.tsx
@@ -6,6 +6,7 @@ import { useCategories, useCreateCategory, useUpdateCategory } from '@/hooks/use
 import { CategoryCard } from '@/components/categories/CategoryCard'
 import { InlineNewCategory } from '@/components/categories/InlineNewCategory'
 import { Transactions } from '@/types/transactions'
+import { ImportTestIds } from '@/testIds'
 
 type PendingParentId = number | 'root' | null
 
@@ -43,14 +44,14 @@ export function CreateCategoryDrawer() {
   }
 
   return (
-    <Drawer opened={opened} onClose={reject} title="Categorias" position="right" size="md" data-testid="drawer_create_category">
+    <Drawer opened={opened} onClose={reject} title="Categorias" position="right" size="md" data-testid={ImportTestIds.DrawerCreateCategory}>
       <Stack gap="sm">
         <Button
           leftSection={<IconPlus size={16} />}
           onClick={() => setPendingParentId('root')}
           size="xs"
           variant="light"
-          data-testid="btn_new_category_in_drawer"
+          data-testid={ImportTestIds.BtnNewCategoryInDrawer}
         >
           Nova Categoria
         </Button>
@@ -86,7 +87,7 @@ export function CreateCategoryDrawer() {
         <Button
           onClick={() => close(lastCreatedRef.current ?? undefined)}
           mt="md"
-          data-testid="btn_close_create_category_drawer"
+          data-testid={ImportTestIds.BtnCloseCreateCategoryDrawer}
         >
           Fechar
         </Button>

--- a/frontend/src/components/transactions/import/ImportCSVBulkToolbar.tsx
+++ b/frontend/src/components/transactions/import/ImportCSVBulkToolbar.tsx
@@ -18,6 +18,7 @@ import { useSplitSummary } from "@/hooks/import/useSplitSummary";
 import { SplitSettingsFields } from "../form/SplitSettingsFields";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useDisclosure } from "@mantine/hooks";
+import { ImportTestIds } from "@/testIds";
 
 const ACTION_OPTIONS = [
   { value: "import", label: "Importar" },
@@ -177,7 +178,7 @@ export function ImportCSVBulkToolbar({
           color="red"
           leftSection={<IconTrash size={14} />}
           onClick={onRemove}
-          data-testid="btn_bulk_remove"
+          data-testid={ImportTestIds.BtnBulkRemove}
         >
           Remover
         </Button>
@@ -221,7 +222,7 @@ export function ImportCSVBulkToolbar({
             size="xs"
             data={ACTION_OPTIONS}
             withCheckIcon={false}
-            data-testid="select_bulk_action"
+            data-testid={ImportTestIds.SelectBulkAction}
             onChange={(val) => {
               if (val) {
                 localForm.reset({ action_type: "import_action", import_action: val as Transactions.ImportRowAction });
@@ -248,7 +249,7 @@ export function ImportCSVBulkToolbar({
             size="xs"
             data={TYPE_OPTIONS}
             withCheckIcon={false}
-            data-testid="select_bulk_action"
+            data-testid={ImportTestIds.SelectBulkAction}
             onChange={(val) => {
               if (val) {
                 localForm.reset({ action_type: "type", type: val as Transactions.TransactionType });
@@ -308,7 +309,7 @@ export function ImportCSVBulkToolbar({
           leftSection={<IconHammer size={14} />}
           onClick={applySelectedAction}
           disabled={applyDisabled}
-          data-testid="btn_bulk_apply"
+          data-testid={ImportTestIds.BtnBulkApply}
         >
           Aplicar
         </Button>

--- a/frontend/src/components/transactions/import/ImportConfirmButton.tsx
+++ b/frontend/src/components/transactions/import/ImportConfirmButton.tsx
@@ -1,5 +1,6 @@
 import { Button, Group } from '@mantine/core'
 import { IconPlayerPause, IconPlayerPlay } from '@tabler/icons-react'
+import { ImportTestIds } from '@/testIds'
 
 interface Props {
   importing: boolean
@@ -18,7 +19,7 @@ export function ImportConfirmButton({ importing, paused, toImportCount, onPause,
           color="orange"
           leftSection={<IconPlayerPause size={16} />}
           onClick={onPause}
-          data-testid="btn_pause_import"
+          data-testid={ImportTestIds.BtnPause}
         >
           Pausar
         </Button>
@@ -29,7 +30,7 @@ export function ImportConfirmButton({ importing, paused, toImportCount, onPause,
           leftSection={<IconPlayerPlay size={16} />}
           onClick={onConfirm}
           disabled={toImportCount === 0}
-          data-testid={paused ? 'btn_resume_import' : 'btn_confirm_import'}
+          data-testid={paused ? ImportTestIds.BtnResume : ImportTestIds.BtnConfirm}
         >
           {paused ? 'Retomar importação' : `Confirmar importação (${toImportCount})`}
         </Button>

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -17,6 +17,7 @@ import { useSplitSummary } from "@/hooks/import/useSplitSummary";
 import { renderDrawer } from "@/utils/renderDrawer";
 import { CreateCategoryDrawer } from "./CreateCategoryDrawer";
 import { AccountDrawer } from "@/components/accounts/AccountDrawer";
+import { ImportTestIds } from '@/testIds'
 
 const TRANSACTION_TYPE_OPTIONS = [
   { value: "expense", label: "Despesa" },
@@ -152,7 +153,7 @@ export const ImportReviewRow = memo(
     };
 
     return (
-      <Table.Tr ref={ref} className={rowClass()} data-row-index={rowIndex} data-testid={`import_row_${rowIndex}`}>
+      <Table.Tr ref={ref} className={rowClass()} data-row-index={rowIndex} data-testid={ImportTestIds.Row(rowIndex)}>
         {/* Checkbox */}
         <Table.Td style={{ cursor: "pointer" }}>
           <Checkbox
@@ -161,7 +162,7 @@ export const ImportReviewRow = memo(
             onClick={(e) => onToggleSelect(rowIndex, e.shiftKey)}
             disabled={disabled}
             size="xs"
-            data-testid={`checkbox_import_row_${rowIndex}`}
+            data-testid={ImportTestIds.RowCheckbox(rowIndex)}
           />
         </Table.Td>
 
@@ -169,7 +170,7 @@ export const ImportReviewRow = memo(
         <Table.Td>
           <Box
             className={classes.statusIcon}
-            data-testid={`import_status_${rowIndex}`}
+            data-testid={ImportTestIds.RowStatus(rowIndex)}
             data-status={importStatus}
           >
             {statusCell()}
@@ -269,7 +270,7 @@ export const ImportReviewRow = memo(
                     clearable
                     placeholder="Selecionar..."
                     withCheckIcon={false}
-                    data-testid={`select_category_${rowIndex}`}
+                    data-testid={ImportTestIds.RowSelectCategory(rowIndex)}
                     style={{ flex: 1 }}
                   />
                 )}
@@ -287,7 +288,7 @@ export const ImportReviewRow = memo(
                 }}
                 disabled={disabled || isSkipped}
                 aria-label="Criar categoria"
-                data-testid={`btn_create_category_row_${rowIndex}`}
+                data-testid={ImportTestIds.RowBtnCreateCategory(rowIndex)}
               >
                 <IconPlus size={14} />
               </ActionIcon>
@@ -384,7 +385,7 @@ export const ImportReviewRow = memo(
                 onChange={field.onChange}
                 disabled={disabled}
                 withCheckIcon={false}
-                data-testid={`select_import_action_${rowIndex}`}
+                data-testid={ImportTestIds.RowSelectAction(rowIndex)}
               />
             )}
           />

--- a/frontend/src/components/transactions/import/UploadStep.tsx
+++ b/frontend/src/components/transactions/import/UploadStep.tsx
@@ -23,6 +23,7 @@ import { Transactions } from '@/types/transactions'
 import { parseApiError } from '@/utils/apiErrors'
 import { renderDrawer } from '@/utils/renderDrawer'
 import { CSV_COLUMNS } from './importPayload'
+import { ImportTestIds } from '@/testIds'
 
 type Props = {
   onParsed: (rows: Transactions.ParsedImportRow[], accountId: number) => void
@@ -78,7 +79,7 @@ export function UploadStep({ onParsed, onBack }: Props) {
   }
 
   return (
-    <Stack gap="md" maw={{ lg: 1280 }} data-testid="import_upload_step">
+    <Stack gap="md" maw={{ lg: 1280 }} data-testid={ImportTestIds.UploadStep}>
       <Group gap="xs">
         <Button variant="subtle" leftSection={<IconArrowLeft size={16} />} onClick={onBack} size="sm">
           Voltar
@@ -94,7 +95,7 @@ export function UploadStep({ onParsed, onBack }: Props) {
           data={ownAccountOptions}
           value={accountId ? String(accountId) : null}
           onChange={(val) => setAccountId(val ? Number(val) : null)}
-          data-testid="select_import_account"
+          data-testid={ImportTestIds.SelectAccount}
         />
         <ActionIcon
           variant="subtle"
@@ -107,7 +108,7 @@ export function UploadStep({ onParsed, onBack }: Props) {
               .catch(() => {})
           }}
           aria-label="Criar conta"
-          data-testid="btn_create_account_header"
+          data-testid={ImportTestIds.BtnCreateAccountHeader}
           mb={2}
         >
           <IconPlus size={16} />
@@ -122,7 +123,7 @@ export function UploadStep({ onParsed, onBack }: Props) {
           ]}
           value={decimalSeparator}
           onChange={(val) => setDecimalSeparator((val as Transactions.DecimalSeparatorValue | null) ?? 'comma')}
-          data-testid="select_decimal_separator"
+          data-testid={ImportTestIds.SelectDecimalSeparator}
         />
         <Select
           label="Regra de definição do tipo"
@@ -135,7 +136,7 @@ export function UploadStep({ onParsed, onBack }: Props) {
           onChange={(val) =>
             setTypeDefinitionRule((val as Transactions.TypeDefinitionRule | null) ?? 'positive_as_income')
           }
-          data-testid="select_decimal_separator"
+          data-testid={ImportTestIds.SelectDecimalSeparator}
         />
       </Flex>
 
@@ -147,7 +148,7 @@ export function UploadStep({ onParsed, onBack }: Props) {
         leftSection={<IconFileTypeCsv size={16} />}
         value={file}
         onChange={setFile}
-        data-testid="input_csv_file"
+        data-testid={ImportTestIds.InputCsvFile}
       />
 
       {errorMessage && (
@@ -161,7 +162,7 @@ export function UploadStep({ onParsed, onBack }: Props) {
         loading={mutation.isPending}
         leftSection={mutation.isPending ? <Loader size="xs" /> : undefined}
         disabled={!file || !accountId}
-        data-testid="btn_process_csv"
+        data-testid={ImportTestIds.BtnProcessCSV}
       >
         Processar arquivo
       </Button>

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -7,6 +7,7 @@ import { AccountDrawer } from '@/components/accounts/AccountDrawer'
 import { AccountSection } from '@/components/accounts/AccountSection'
 import { renderDrawer } from '@/utils/renderDrawer'
 import { Transactions } from '@/types/transactions'
+import { AccountsTestIds } from '@/testIds'
 
 export function AccountsPage() {
   const { query, invalidate } = useAccounts()
@@ -37,7 +38,7 @@ export function AccountsPage() {
     <Stack gap="md">
       <Group justify="space-between" align="center">
         <Text fw={700} size="xl">Contas</Text>
-        <Button leftSection={<IconPlus size={16} />} onClick={handleAdd} data-testid="btn_new_account">
+        <Button leftSection={<IconPlus size={16} />} onClick={handleAdd} data-testid={AccountsTestIds.BtnNew}>
           Nova Conta
         </Button>
       </Group>
@@ -55,7 +56,7 @@ export function AccountsPage() {
             accounts={activeOwnQuery.data ?? []}
             onEdit={handleEdit}
             onAction={(a) => deactivateMutation.mutate(a.id)}
-            testId="section_active"
+            testId={AccountsTestIds.SectionActive}
           />
           <AccountSection
             label="Contas compartilhadas"
@@ -68,7 +69,7 @@ export function AccountsPage() {
             accounts={inactiveQuery.data ?? []}
             onEdit={handleEdit}
             onAction={(a) => activateMutation.mutate(a.id)}
-            testId="section_inactive"
+            testId={AccountsTestIds.SectionInactive}
           />
           {!hasAccounts && (
             <Text c="dimmed" ta="center" py="md">Nenhuma conta cadastrada</Text>

--- a/frontend/src/pages/CategoriesPage.tsx
+++ b/frontend/src/pages/CategoriesPage.tsx
@@ -7,6 +7,7 @@ import { DeleteCategoryModal } from '@/components/categories/DeleteCategoryModal
 import { InlineNewCategory } from '@/components/categories/InlineNewCategory'
 import { renderDrawer } from '@/utils/renderDrawer'
 import { Transactions } from '@/types/transactions'
+import { CategoriesTestIds } from '@/testIds'
 
 // pendingParentId:
 //   null        → no inline input
@@ -62,7 +63,7 @@ export function CategoriesPage() {
             leftSection={<IconPlus size={16} />}
             onClick={() => setPendingParentId('root')}
             size="sm"
-            data-testid="btn_new_category"
+            data-testid={CategoriesTestIds.BtnNew}
           >
             Nova Categoria
           </Button>
@@ -78,7 +79,7 @@ export function CategoriesPage() {
       ) : categories.length === 0 && pendingParentId === null ? (
         <Stack align="center" py="xl" gap="sm">
           <Text c="dimmed">Nenhuma categoria cadastrada</Text>
-          <Button leftSection={<IconPlus size={16} />} onClick={() => setPendingParentId('root')} data-testid="btn_create_first_category">
+          <Button leftSection={<IconPlus size={16} />} onClick={() => setPendingParentId('root')} data-testid={CategoriesTestIds.BtnCreateFirst}>
             Criar primeira categoria
           </Button>
         </Stack>

--- a/frontend/src/pages/ChargesPage.tsx
+++ b/frontend/src/pages/ChargesPage.tsx
@@ -17,6 +17,7 @@ import { ConfirmChargeActionDrawer, type ConfirmChargeAction } from "@/component
 import { PeriodNavigator } from "@/components/transactions/PeriodNavigator";
 import { CreateChargeDrawer } from "@/components/charges/CreateChargeDrawer";
 import { AcceptChargeDrawer } from "@/components/charges/AcceptChargeDrawer";
+import { ChargesTestIds } from '@/testIds'
 
 export function ChargesPage() {
   const search = useSearch({ from: "/_authenticated/charges" });
@@ -117,7 +118,7 @@ export function ChargesPage() {
             onClick={() =>
               void renderDrawer(() => <CreateChargeDrawer periodMonth={search.month} periodYear={search.year} />)
             }
-            data-testid="btn_new_charge"
+            data-testid={ChargesTestIds.BtnNew}
           >
             Nova Cobrança
           </Button>
@@ -129,7 +130,7 @@ export function ChargesPage() {
             onClick={() =>
               void renderDrawer(() => <CreateChargeDrawer periodMonth={search.month} periodYear={search.year} />)
             }
-            data-testid="btn_new_charge"
+            data-testid={ChargesTestIds.BtnNew}
           >
             <IconPlus size={18} />
           </ActionIcon>
@@ -138,8 +139,8 @@ export function ChargesPage() {
 
       <Tabs defaultValue="received">
         <Tabs.List>
-          <Tabs.Tab value="received" data-testid="tab_charges_received">Recebidas</Tabs.Tab>
-          <Tabs.Tab value="sent" data-testid="tab_charges_sent">Enviadas</Tabs.Tab>
+          <Tabs.Tab value="received" data-testid={ChargesTestIds.Tab('received')}>Recebidas</Tabs.Tab>
+          <Tabs.Tab value="sent" data-testid={ChargesTestIds.Tab('sent')}>Enviadas</Tabs.Tab>
         </Tabs.List>
 
         <Tabs.Panel value="received" pt="md">

--- a/frontend/src/pages/ImportTransactionsPage.tsx
+++ b/frontend/src/pages/ImportTransactionsPage.tsx
@@ -31,6 +31,7 @@ import {
   importFormSchema,
   type ImportFormValues,
 } from '@/components/transactions/form/importFormSchema'
+import { ImportTestIds } from '@/testIds'
 
 export function ImportTransactionsPage() {
   const navigate = useNavigate()
@@ -285,7 +286,7 @@ export function ImportTransactionsPage() {
             onBack={() => void navigate({ to: '/transactions' })}
           />
         ) : allImportedSuccess ? (
-          <Stack align="center" justify="center" gap="xs" py="xl" data-testid="finished_import_successfully_step">
+          <Stack align="center" justify="center" gap="xs" py="xl" data-testid={ImportTestIds.FinishedStep}>
             <IconCircleCheck size={64} color="var(--mantine-color-green-6)" />
             <Text fw={500} fz="lg">
               Importação concluída com sucesso!
@@ -295,7 +296,7 @@ export function ImportTransactionsPage() {
             </Text>
           </Stack>
         ) : (
-          <Stack gap="md" data-testid="import_review_step">
+          <Stack gap="md" data-testid={ImportTestIds.ReviewStep}>
             <Group justify="space-between" align="center" wrap="nowrap">
               <Group gap="xs">
                 <Button

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -26,6 +26,7 @@ import { SelectDateDrawer } from '@/components/transactions/SelectDateDrawer'
 import { TextSearch } from '@/components/transactions/filters/TextSearch'
 import { Transactions } from '@/types/transactions'
 import { splitPercentagesToCents } from '@/utils/splitMath'
+import { TransactionsTestIds } from '@/testIds'
 
 export function TransactionsPage() {
   const search = useSearch({ from: '/_authenticated/transactions' })
@@ -165,7 +166,7 @@ export function TransactionsPage() {
           successMessage={(n) => n === 1 ? '1 transação excluída com sucesso' : `${n} transações excluídas com sucesso`}
           onInvalidate={invalidateTransactions}
           onSuccess={clearSelection}
-          testIdPrefix="bulk_delete"
+          testIdPrefix={TransactionsTestIds.BulkDeleteDrawer}
         />
       ))
     } catch {
@@ -211,7 +212,7 @@ export function TransactionsPage() {
           successMessage={(n) => n === 1 ? '1 transação atualizada com sucesso' : `${n} transações atualizadas com sucesso`}
           onInvalidate={invalidateTransactions}
           onSuccess={clearSelection}
-          testIdPrefix="bulk_category"
+          testIdPrefix={TransactionsTestIds.BulkCategoryDrawer}
         />
       ))
     } catch {
@@ -262,7 +263,7 @@ export function TransactionsPage() {
           successMessage={(n) => n === 1 ? '1 transação atualizada com sucesso' : `${n} transações atualizadas com sucesso`}
           onInvalidate={invalidateTransactions}
           onSuccess={clearSelection}
-          testIdPrefix="bulk_date"
+          testIdPrefix={TransactionsTestIds.BulkDateDrawer}
         />
       ))
     } catch {
@@ -320,7 +321,7 @@ export function TransactionsPage() {
           }
           onInvalidate={invalidateTransactions}
           onSuccess={clearSelection}
-          testIdPrefix="bulk_division"
+          testIdPrefix={TransactionsTestIds.BulkDivisionProgressDrawer}
         />
       ))
     } catch {
@@ -352,14 +353,14 @@ export function TransactionsPage() {
                   size="lg"
                   variant="filled"
                   onClick={() => void renderDrawer(() => <CreateTransactionDrawer />)}
-                  data-testid="btn_new_transaction"
+                  data-testid={TransactionsTestIds.BtnNew}
                   aria-label="Nova Transação"
                 >
                   <IconPlus size={18} />
                 </ActionIcon>
                 <Menu shadow="md" width={200}>
                   <Menu.Target>
-                    <ActionIcon size="lg" variant="default" aria-label="Mais opções" data-testid="btn_more_options">
+                    <ActionIcon size="lg" variant="default" aria-label="Mais opções" data-testid={TransactionsTestIds.BtnMoreOptions}>
                       <IconDots size={18} />
                     </ActionIcon>
                   </Menu.Target>
@@ -367,7 +368,7 @@ export function TransactionsPage() {
                     <Menu.Item
                       leftSection={<IconTableImport size={14} />}
                       onClick={() => void navigate({ to: '/transactions/import' })}
-                      data-testid="menu_item_import_transactions"
+                      data-testid={TransactionsTestIds.MenuItemImportTransactions}
                     >
                       Importar transações
                     </Menu.Item>
@@ -431,12 +432,12 @@ export function TransactionsPage() {
           <Group justify="space-between" align="center">
             <PeriodNavigator month={search.month} year={search.year} onPeriodChange={(m, y) => routeNavigate({ search: { ...search, month: m, year: y } })} />
             <Group gap="xs">
-              <Button leftSection={<IconPlus size={16} />} onClick={() => void renderDrawer(() => <CreateTransactionDrawer />)} data-testid="btn_new_transaction">
+              <Button leftSection={<IconPlus size={16} />} onClick={() => void renderDrawer(() => <CreateTransactionDrawer />)} data-testid={TransactionsTestIds.BtnNew}>
                 Nova Transação
               </Button>
               <Menu shadow="md" width={200}>
                 <Menu.Target>
-                  <ActionIcon variant="default" aria-label="Mais opções" data-testid="btn_more_options">
+                  <ActionIcon variant="default" aria-label="Mais opções" data-testid={TransactionsTestIds.BtnMoreOptions}>
                     <IconDots size={16} />
                   </ActionIcon>
                 </Menu.Target>
@@ -444,7 +445,7 @@ export function TransactionsPage() {
                   <Menu.Item
                     leftSection={<IconTableImport size={14} />}
                     onClick={() => void navigate({ to: '/transactions/import' })}
-                    data-testid="menu_item_import_transactions"
+                    data-testid={TransactionsTestIds.MenuItemImportTransactions}
                   >
                     Importar transações
                   </Menu.Item>

--- a/frontend/src/testIds/accounts.ts
+++ b/frontend/src/testIds/accounts.ts
@@ -1,0 +1,16 @@
+export const AccountsTestIds = {
+  Card: 'account_card',
+  Form: 'account_form',
+  BtnNew: 'btn_new_account',
+  BtnEdit: 'btn_account_edit',
+  BtnAction: 'btn_account_action',
+  BtnSave: 'btn_account_save',
+  InputName: 'input_account_name',
+  InputInitialBalance: 'input_initial_balance',
+  Drawer: 'drawer_account',
+  SectionActive: 'section_active',
+  SectionInactive: 'section_inactive',
+  ColorSwatchPicker: 'color_swatch_picker',
+  /** Hex with leading `#` stripped, e.g. `swatch_color_e63946`. */
+  SwatchColor: (hexWithoutHash: string) => `swatch_color_${hexWithoutHash}` as const,
+} as const

--- a/frontend/src/testIds/categories.ts
+++ b/frontend/src/testIds/categories.ts
@@ -1,0 +1,14 @@
+export const CategoriesTestIds = {
+  BtnNew: 'btn_new_category',
+  BtnCreateFirst: 'btn_create_first_category',
+  BtnName: 'btn_category_name',
+  BtnDelete: 'btn_category_delete',
+  BtnAddSubcategory: 'btn_add_subcategory',
+  BtnConfirmDelete: 'btn_confirm_delete_category',
+  InputName: 'input_category_name',
+  InputNewName: 'input_new_category_name',
+  BtnEmoji: (categoryId: number | string) => `btn_emoji_${categoryId}` as const,
+  DrawerEmojiPicker: (categoryId: number | string) =>
+    `drawer_emoji_picker_${categoryId}` as const,
+  EmojiOption: (emoji: string) => `emoji_${emoji}` as const,
+} as const

--- a/frontend/src/testIds/charges.ts
+++ b/frontend/src/testIds/charges.ts
@@ -1,0 +1,24 @@
+export type ChargeAction = 'reject' | 'cancel'
+export type ChargeRole = 'charger' | 'payer'
+export type ChargesTab = 'received' | 'sent'
+
+export const ChargesTestIds = {
+  ModalConfirm: (action: ChargeAction) => `modal_confirm_${action}_charge` as const,
+  BtnConfirm: (action: ChargeAction) => `btn_confirm_${action}_charge` as const,
+  BtnNew: 'btn_new_charge',
+  DrawerCreate: 'drawer_create_charge',
+  DrawerAccept: 'drawer_accept_charge',
+  Tab: (tab: ChargesTab) => `tab_charges_${tab}` as const,
+  Card: (chargeId: number | string) => `charge_card_${chargeId}` as const,
+  BtnAccept: 'btn_accept_charge',
+  BtnReject: 'btn_reject_charge',
+  BtnCancel: 'btn_cancel_charge',
+  SelectConnection: 'select_connection',
+  SelectMyAccount: 'select_my_account',
+  RadioRole: (role: ChargeRole) => `radio_role_${role}` as const,
+  InputAmount: 'input_charge_amount',
+  InputDescription: 'input_charge_description',
+  BtnSubmitCreate: 'btn_submit_create_charge',
+  SelectAcceptAccount: 'select_accept_account',
+  BtnSubmitAccept: 'btn_submit_accept_charge',
+} as const

--- a/frontend/src/testIds/common.ts
+++ b/frontend/src/testIds/common.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared testids used across pages (AppLayout, cross-cutting drawers, etc.).
+ *
+ * Rules (mirror the registry-wide convention):
+ * - Static keys are plain strings; parametric keys are factory functions that
+ *   return a string literal union.
+ * - Values live in snake_case to match the existing `data-testid` output;
+ *   keys are PascalCase (following the QueryKeys convention).
+ * - Import in both src/ and e2e/ via `@/testIds`.
+ */
+export const CommonTestIds = {
+  DrawerInvite: 'drawer_invite',
+  AvatarUser: 'avatar_user',
+  AvatarAccount: 'avatar_account',
+  AvatarAccountEmpty: 'avatar_account_empty',
+  /**
+   * NavLink badge, keyed by the route's path without the leading slash
+   * (e.g. `nav_badge_charges` for `/charges`).
+   */
+  NavBadge: (route: string) => `nav_badge_${route}` as const,
+} as const

--- a/frontend/src/testIds/import.ts
+++ b/frontend/src/testIds/import.ts
@@ -1,0 +1,37 @@
+export const ImportTestIds = {
+  // Steps
+  UploadStep: 'import_upload_step',
+  ReviewStep: 'import_review_step',
+  FinishedStep: 'finished_import_successfully_step',
+
+  // Upload-step controls
+  BtnProcessCSV: 'btn_process_csv',
+  SelectAccount: 'select_import_account',
+  SelectDecimalSeparator: 'select_decimal_separator',
+  InputCsvFile: 'input_csv_file',
+  BtnCreateAccountHeader: 'btn_create_account_header',
+
+  // Review-step controls
+  BtnConfirm: 'btn_confirm_import',
+  BtnPause: 'btn_pause_import',
+  BtnResume: 'btn_resume_import',
+
+  // Row-scoped (parametric)
+  Row: (rowIndex: number) => `import_row_${rowIndex}` as const,
+  RowStatus: (rowIndex: number) => `import_status_${rowIndex}` as const,
+  RowSelectCategory: (rowIndex: number) => `select_category_${rowIndex}` as const,
+  RowSelectAction: (rowIndex: number) => `select_import_action_${rowIndex}` as const,
+  RowCheckbox: (rowIndex: number) => `checkbox_import_row_${rowIndex}` as const,
+  RowBtnCreateCategory: (rowIndex: number) =>
+    `btn_create_category_row_${rowIndex}` as const,
+
+  // Bulk toolbar
+  BtnBulkRemove: 'btn_bulk_remove',
+  BtnBulkApply: 'btn_bulk_apply',
+  SelectBulkAction: 'select_bulk_action',
+
+  // Category-creation drawer (mounted from the import flow)
+  DrawerCreateCategory: 'drawer_create_category',
+  BtnNewCategoryInDrawer: 'btn_new_category_in_drawer',
+  BtnCloseCreateCategoryDrawer: 'btn_close_create_category_drawer',
+} as const

--- a/frontend/src/testIds/index.ts
+++ b/frontend/src/testIds/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Central registry of `data-testid` values. Both components (src/) and e2e
+ * tests (e2e/) import from here, so the two sides can never drift.
+ *
+ * Conventions:
+ * - One file per domain (accounts, categories, charges, transactions, import),
+ *   plus `common.ts` for cross-cutting layout/invite ids.
+ * - Static ids are `PascalCase: 'snake_case'`. Parametric ids are factory
+ *   functions that return a `snake_case_${param}` literal type via `as const`.
+ * - When adding a new testid: add it here first, then reference it from the
+ *   component and the test in the same PR.
+ */
+export { CommonTestIds } from './common'
+export { AccountsTestIds } from './accounts'
+export { CategoriesTestIds } from './categories'
+export { ChargesTestIds, type ChargeAction } from './charges'
+export {
+  TransactionsTestIds,
+  type TransactionType,
+  type PropagationOption,
+} from './transactions'
+export { ImportTestIds } from './import'

--- a/frontend/src/testIds/transactions.ts
+++ b/frontend/src/testIds/transactions.ts
@@ -1,0 +1,97 @@
+export type TransactionType = 'expense' | 'income' | 'transfer'
+export type PropagationOption = 'current' | 'current_and_future' | 'all'
+export type TransactionFilterKind = 'accounts' | 'categories' | 'tags'
+
+export const TransactionsTestIds = {
+  // Page-level
+  BtnNew: 'btn_new_transaction',
+  BtnSave: 'btn_save_transaction',
+  BtnMoreOptions: 'btn_more_options',
+  MenuItemImportTransactions: 'menu_item_import_transactions',
+  Checkbox: (txId: number | string) => `checkbox_${txId}` as const,
+
+  // Drawers (create / update)
+  DrawerCreate: 'drawer_create_transaction',
+  DrawerUpdate: 'drawer_update_transaction',
+
+  // Form fields
+  InputAmount: 'input_amount',
+  InputDescription: 'input_description',
+  SelectAccount: 'select_account',
+  SelectDestinationAccount: 'select_destination_account',
+  SelectCategory: 'select_category',
+  SegmentedTransactionType: 'segmented_transaction_type',
+
+  // Split
+  InputSplitAmount: 'input_split_amount',
+  InputSplitPercentage: 'input_split_percentage',
+  BtnAddSplitRow: 'btn_add_split_row',
+
+  // Transfer row avatar pair
+  TransferAvatarGroup: 'transfer_avatar_group',
+  IconTransferArrow: 'icon_transfer_arrow',
+
+  // Filters (top-level)
+  InputTextSearch: 'input_text_search',
+  SegmentedGroupBy: 'segmented_group_by',
+  AdvancedFiltersPopover: 'advanced_filters_popover',
+  BtnOpenAdvancedFilters: 'open_advanced_filters',
+  SwitchType: (type: TransactionType) => `switch_type_${type}` as const,
+  SwitchHideSettlements: 'switch_hide_settlements',
+  BtnClearFilters: 'btn_clear_filters',
+  DrawerFilters: 'drawer_transaction_filters',
+
+  // Per-kind filter Popover triggers + dropdowns
+  BtnFilter: (kind: TransactionFilterKind) => `btn_filter_${kind}` as const,
+  PopoverFilter: (kind: TransactionFilterKind) => `popover_filter_${kind}` as const,
+
+  // Filter entries (scoped inside the Popover)
+  CheckboxFilterAccount: (accountId: number | string) =>
+    `checkbox_filter_account_${accountId}` as const,
+  CheckboxFilterCategory: (categoryId: number | string) =>
+    `checkbox_filter_category_${categoryId}` as const,
+  BadgeFilterTag: (tagId: number | string) => `badge_filter_tag_${tagId}` as const,
+
+  // Selection & bulk menu
+  SelectionActionBar: 'selection_action_bar',
+  SelectionCount: 'selection_count',
+  BtnClearSelection: 'btn_clear_selection',
+  BtnBulkActionsMenu: 'btn_bulk_actions_menu',
+  BtnBulkCategory: 'btn_bulk_category',
+  BtnBulkDate: 'btn_bulk_date',
+  BtnBulkDivision: 'btn_bulk_division',
+  BtnBulkDelete: 'btn_bulk_delete',
+  HintBulkDivisionNoConnection: 'hint_bulk_division_no_connection',
+
+  // Bulk progress drawer (root testid; overridden per flow via testIdPrefix)
+  BulkProgressDrawer: 'bulk_progress',
+  BulkDeleteDrawer: 'bulk_delete',
+  BulkCategoryDrawer: 'bulk_category',
+  BulkDateDrawer: 'bulk_date',
+  BulkDivisionProgressDrawer: 'bulk_division',
+  BulkProgressBar: 'bulk_progress_bar',
+  BulkCurrentLabel: 'bulk_current_label',
+  BulkSuccess: 'bulk_success',
+  BulkError: 'bulk_error',
+  BtnBulkDone: 'btn_bulk_done',
+  BtnBulkCloseError: 'btn_bulk_close_error',
+
+  // Bulk division drawer
+  DrawerBulkDivision: 'drawer_bulk_division',
+  BadgeBulkDivisionSum: 'badge_bulk_division_sum',
+  BtnApplyBulkDivision: 'btn_apply_bulk_division',
+
+  // Select category / date drawers
+  DrawerSelectCategory: 'drawer_select_category',
+  DrawerSelectDate: 'drawer_select_date',
+  InputBulkDate: 'input_bulk_date',
+  BtnApplyDate: 'btn_apply_date',
+  CategoryOption: (categoryId: number | string) =>
+    `category_option_${categoryId}` as const,
+
+  // Propagation
+  PropagationDrawerBody: 'propagation_drawer_body',
+  PropagationOption: (opt: PropagationOption) => `propagation_option_${opt}` as const,
+  PropagationUpdateOption: (opt: PropagationOption) =>
+    `propagation_update_option_${opt}` as const,
+} as const

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "files": [],
-  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./e2e/tsconfig.json" }
+  ],
   "compilerOptions": {
     "types": ["node"]
   }


### PR DESCRIPTION
Phase 8 of the CLAUDE.md migration plan — TestIds registry. Branches directly off the updated migration main.

## Summary

Introduces `src/testIds/` — a domain-split registry of every `data-testid` used by the app. Both components (src/) and e2e tests (e2e/) import from it via the shared `@/testIds` alias, so the two sides can no longer drift. The risk this closes surfaced during Phase 7: a test silently outliving a component-side testid rename. With this PR, TypeScript catches the mismatch at build time.

## Registry shape

```ts
// src/testIds/accounts.ts
export const AccountsTestIds = {
  Card: 'account_card',
  Form: 'account_form',
  BtnNew: 'btn_new_account',
  BtnSave: 'btn_account_save',
  InputName: 'input_account_name',
  // ...
} as const

// src/testIds/transactions.ts
export const TransactionsTestIds = {
  Checkbox: (txId: number | string) => `checkbox_${txId}` as const,
  SwitchType: (type: TransactionType) => `switch_type_${type}` as const,
  PropagationOption: (opt: PropagationOption) => `propagation_option_${opt}` as const,
  // ...
} as const
```

Static keys are `PascalCase` constants holding `snake_case` literals; parametric keys are factory functions that return a `snake_case_${param}` literal type via `as const`. Mirrors the `QueryKeys` pattern already used elsewhere in the codebase.

Files:

```
src/testIds/common.ts         — CommonTestIds (layout / invite)
src/testIds/accounts.ts       — AccountsTestIds
src/testIds/categories.ts     — CategoriesTestIds
src/testIds/charges.ts        — ChargesTestIds + ChargeAction type
src/testIds/transactions.ts   — TransactionsTestIds + TransactionType + PropagationOption
src/testIds/import.ts         — ImportTestIds
src/testIds/index.ts          — barrel re-export
```

## E2E config

- **`e2e/tsconfig.json` (new)** — extends `tsconfig.app.json` and adds `paths: { '@/*': ['../src/*'] }` so specs and page-objects can resolve `@/testIds`. Disables `noUnusedLocals` / `noUnusedParameters` in e2e to avoid surfacing unrelated pre-existing test-file hygiene issues in this PR.
- **`tsconfig.json`** — references the new e2e project so `tsc -b` now typechecks specs alongside the app.

Playwright ≥ 1.39 respects `paths` from the closest tsconfig automatically, so no `playwright.config.ts` changes are needed.

## Migration (mechanical)

Applied in two scripted passes (scripts live under `/tmp` and are discarded after the commit):

- **src/** — 82 `data-testid="…"` / `data-testid={`…`}` literals across 33 component/page files replaced with registry references.
- **e2e/** — 160+ `getByTestId('…')` / `getByTestId(`…`)` calls across 15 page-object + spec files rewritten to use the same registry.
- The one attribute-prefix selector in `ImportPage.ts` (`[data-testid^='btn_emoji_']`, needed because the category id isn't known at call time) now derives its prefix from `CategoriesTestIds.BtnEmoji('')` — the coupling to the factory is explicit instead of a string duplicate.

## Verification

- `npx tsc -b` — clean (now also covers e2e).
- `npm run build` — passes.
- `npm run lint` — 1 error + 1 warning, both pre-existing (`usePWAInstall.ts:31`, `CreateChargeDrawer.tsx:96`); unchanged.
- Audit: `grep -rnE 'data-testid="[^"]+"|getByTestId\\((['\"` + "`" + `])' src/ e2e/` returns only the four references inside `src/testIds/` files themselves (the definition) and the documented attribute-prefix selector.

## Conflicts with Phase 7

PR #98 (Phase 7) touches most of the same e2e page-objects. Mergeable in either order, but the second-to-merge will need a rebase:

- If **Phase 7 merges first**: rebase Phase 8 onto it and re-run the scripts to migrate the new Phase 7 testids (`drawer_create_transaction`, `avatar_user`, `swatch_color_*`, etc.) into the registry; a few extra static entries will need to be added to the registry files.
- If **Phase 8 merges first**: rebase Phase 7 onto it and convert its new string literals to registry references (same scripts, pointed at the Phase 7 diff).

Recommend merging **#98 (Phase 7) first** since it adds more testids and Phase 8's registry naturally absorbs them.

## Test plan

- [ ] `npm run e2e:docker-up && npm run e2e:ci && npm run e2e:docker-down` — full suite; all specs should pass unchanged because the resolved string values are identical to before (the registry is a compile-time indirection).
- [ ] Open the dev server and smoke-test a create-transaction, edit-transaction, filter, and CSV-import flow to confirm no runtime regressions from the mass data-testid rewrite.

https://claude.ai/code/session_01DhJPxh3PD6YVmruL2WVbcS