### PR TITLE
feat(e2e): import installment test + fix recurrenceEnabled bug

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -265,6 +265,25 @@ Rules:
 - Naming convention (already in use): `btn_<action>`, `input_<field>`, `drawer_<name>`, `section_<name>`, `row_<entity>`, `checkbox_<purpose>`. Stay consistent.
 - When adding a new UI element, add a stable `data-testid` in the same commit. No test may rely on class names, tag shapes, or attribute probes as a workaround.
 
+### Declaring testid constants (`src/testIds/`)
+
+All `data-testid` values are centralised in `src/testIds/` and re-exported from `src/testIds/index.ts`. Never use magic strings — always reference the constant.
+
+All ids — static or parametric — are declared as `as const` objects:
+  ```ts
+  // src/testIds/recurrence.ts
+  export const RecurrenceTestIds = {
+    // static id
+    TypeSelect: 'select_recurrence_type',
+    CurrentInstallmentInput: 'input_recurrence_current_installment',
+    // parametric id (factory function)
+    RowBtnRecurrencePopover: (rowIndex: number) => `btn_recurrence_popover_${rowIndex}` as const,
+  } as const
+  ```
+- Group ids by domain, one file per domain (e.g. `recurrence.ts`, `import.ts`).
+- Static ids: plain string value. Parametric ids: arrow function returning `'...' as const` so the return type is a string literal, not `string`.
+- Add the export to `index.ts` before referencing the id anywhere.
+
 When a testid is missing, the fix is to add it to the component, not to invent a fragile selector in the test.
 
 ## Known divergences (migrate when touching)

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -232,6 +232,14 @@ export async function apiGetTransaction(id: number): Promise<Transactions.Transa
   return transactions
 }
 
+export async function apiListTransactions(
+  month: number,
+  year: number,
+): Promise<Transactions.Transaction[]> {
+  const res = await apiFetch(`/api/transactions?month=${month}&year=${year}`)
+  return res.json()
+}
+
 export async function apiUpdateTransaction(
   id: number,
   payload: Partial<Transactions.CreateTransactionPayload>,

--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -1,5 +1,5 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-import { AccountsTestIds, CategoriesTestIds, ImportTestIds, TransactionsTestIds } from '@/testIds'
+import { AccountsTestIds, CategoriesTestIds, ImportTestIds, RecurrenceTestIds, TransactionsTestIds } from '@/testIds'
 export class ImportPage {
   readonly page: Page;
   readonly uploadStep: Locator;
@@ -229,5 +229,45 @@ export class ImportPage {
   async getRowActionLabel(rowIndex: number): Promise<string> {
     const select = this.reviewStep.getByTestId(ImportTestIds.RowSelectAction(rowIndex));
     return select.locator("input").inputValue();
+  }
+
+  /**
+   * Open the recurrence popover for a row and configure installment settings.
+   * Closes the popover by clicking outside so `onClose` fires and syncs values
+   * back to the parent form (including setting `recurrenceEnabled = true`).
+   */
+  async setRowInstallments(
+    rowIndex: number,
+    opts: { type: "monthly" | "weekly" | "daily" | "yearly"; current: number; total: number },
+  ) {
+    const btn = this.reviewStep.getByTestId(ImportTestIds.RowBtnRecurrencePopover(rowIndex));
+    await btn.click();
+
+    const dropdown = this.page.getByTestId(ImportTestIds.RecurrencePopoverDropdown(rowIndex));
+    await expect(dropdown).toBeVisible({ timeout: 5000 });
+
+    // Select frequency type
+    const typeSelect = dropdown.getByTestId(RecurrenceTestIds.TypeSelect);
+    await typeSelect.click();
+    const typeLabels: Record<string, string> = {
+      monthly: "Mensal",
+      weekly: "Semanal",
+      daily: "Diário",
+      yearly: "Anual",
+    };
+    await this.page.getByRole("option", { name: typeLabels[opts.type] }).click();
+
+    // Fill current installment
+    const currentInput = dropdown.getByTestId(RecurrenceTestIds.CurrentInstallmentInput);
+    await currentInput.fill(String(opts.current));
+
+    // Fill total installments
+    const totalInput = dropdown.getByTestId(RecurrenceTestIds.TotalInstallmentsInput);
+    await totalInput.fill(String(opts.total));
+
+    // Dismiss the popover with Escape so onClose fires and syncs values to the parent form.
+    // Using keyboard is more reliable than position-based clicks inside a trapFocus popover.
+    await this.page.keyboard.press('Escape');
+    await expect(dropdown).not.toBeVisible({ timeout: 5000 });
   }
 }

--- a/frontend/e2e/tests/import-installment.spec.ts
+++ b/frontend/e2e/tests/import-installment.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import { ImportPage } from "../pages/ImportPage";
+import {
+  apiCreateAccount,
+  apiDeleteAccount,
+  apiCreateCategory,
+  apiDeleteCategory,
+  apiListTransactions,
+} from "../helpers/api";
+
+/**
+ * Import Installment E2E Tests
+ *
+ * Validates that installment settings (parcelamento) configured in the import
+ * review step are persisted correctly in the created transaction.
+ *
+ * Flow:
+ *   1. Upload a CSV with a single expense row.
+ *   2. Configure installments via the recurrence popover (e.g. 1/3 monthly).
+ *   3. Confirm import.
+ *   4. Fetch the created transaction via the API and assert that
+ *      `transaction_recurrence` reflects the configured settings.
+ */
+
+const CSV_HEADER = "Data;Descrição;Valor";
+
+function buildCsvContent(rows: string[][]): string {
+  return [CSV_HEADER, ...rows.map((r) => r.join(";"))].join("\n");
+}
+
+test.describe("Import with installment settings", () => {
+  let importPage: ImportPage;
+  let testAccountId: number;
+  let testAccountName: string;
+  let testCategoryId: number;
+  let testCategoryName: string;
+
+  test.beforeAll(async () => {
+    testAccountName = `Conta Parcela Import ${Date.now()}`;
+    const account = await apiCreateAccount({
+      name: testAccountName,
+      initial_balance: 0,
+    });
+    testAccountId = account.id;
+
+    testCategoryName = `Cat Parcela Import ${Date.now()}`;
+    const category = await apiCreateCategory({ name: testCategoryName });
+    testCategoryId = category.id;
+  });
+
+  test.afterAll(async () => {
+    await apiDeleteCategory(testCategoryId).catch(() => undefined);
+    await apiDeleteAccount(testAccountId).catch(() => undefined);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    importPage = new ImportPage(page);
+    await importPage.goto();
+  });
+
+  test("installment settings are saved: transaction has correct recurrence after import", async () => {
+    const description = `Parcelado Import ${Date.now()}`;
+    // Use a fixed date so we know which month/year to query
+    const csv = buildCsvContent([["15/03/2026", description, "-300,00"]]);
+
+    await importPage.uploadCSV(csv, testAccountName);
+
+    // Set category (required for expenses)
+    await importPage.setRowCategory(0, testCategoryName);
+
+    // Configure 1/3 monthly installments
+    await importPage.setRowInstallments(0, { type: "monthly", current: 1, total: 3 });
+
+    // Confirm import
+    await importPage.confirmImport();
+
+    // Fetch transactions for March 2026 and find the imported one
+    const transactions = await apiListTransactions(3, 2026);
+    const tx = transactions.find((t) => t.description === description);
+
+    expect(tx, "transaction should exist after import").toBeDefined();
+    expect(tx!.transaction_recurrence_id, "should have a recurrence id").not.toBeNull();
+    expect(tx!.transaction_recurrence_id, "should have a recurrence id").not.toBeUndefined();
+    expect(tx!.installment_number).toBe(1);
+    expect(tx!.transaction_recurrence?.type).toBe("monthly");
+    expect(tx!.transaction_recurrence?.installments).toBe(3);
+  });
+});

--- a/frontend/src/components/transactions/form/RecurrenceFields.tsx
+++ b/frontend/src/components/transactions/form/RecurrenceFields.tsx
@@ -1,6 +1,7 @@
 import { Select, NumberInput, Stack, Group, Text } from "@mantine/core";
 import { Controller, useFormContext, type FieldValues } from "react-hook-form";
 import { getFieldErrorMessage } from "@/utils/getFieldErrorMessage";
+import { RecurrenceTestIds } from "@/testIds";
 
 interface RecurrenceFieldsProps {
   /**
@@ -55,6 +56,7 @@ export function RecurrenceFields({
             error={fieldError("recurrenceType")}
             comboboxProps={{ withinPortal: comboboxWithinPortal }}
             clearable
+            data-testid={RecurrenceTestIds.TypeSelect}
           />
         )}
       />
@@ -69,6 +71,7 @@ export function RecurrenceFields({
             render={({ field }) => (
               <NumberInput
                 aria-label="Parcela atual"
+                data-testid={RecurrenceTestIds.CurrentInstallmentInput}
                 min={1}
                 w={64}
                 hideControls
@@ -86,6 +89,7 @@ export function RecurrenceFields({
             render={({ field }) => (
               <NumberInput
                 aria-label="Total de parcelas"
+                data-testid={RecurrenceTestIds.TotalInstallmentsInput}
                 min={1}
                 w={64}
                 hideControls

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -436,6 +436,11 @@ function RecurrencePopover({ namePrefix, summary, hasRecurrence, disabled }: Rec
   function handleClose() {
     const values = localForm.getValues();
     const rowPath = namePrefix.slice(0, -1);
+    // Sync recurrenceEnabled so buildPayload includes the settings in the import payload.
+    parentForm.setValue(
+      `${rowPath}.recurrenceEnabled` as `rows.${number}.recurrenceEnabled`,
+      values.recurrenceType != null,
+    );
     parentForm.setValue(
       `${rowPath}.recurrenceType` as `rows.${number}.recurrenceType`,
       values.recurrenceType,
@@ -450,15 +455,23 @@ function RecurrencePopover({ namePrefix, summary, hasRecurrence, disabled }: Rec
     );
   }
 
+  const rowIdx = namePrefix.match(/rows\.(\d+)\./)?.[1] ?? '0';
+
   return (
     <FormProvider {...localForm}>
       <Popover trapFocus withinPortal onOpen={handleOpen} onClose={handleClose}>
         <Popover.Target>
-          <Button size="xs" variant={hasRecurrence ? "light" : "default"} disabled={disabled} fullWidth>
+          <Button
+            size="xs"
+            variant={hasRecurrence ? "light" : "default"}
+            disabled={disabled}
+            fullWidth
+            data-testid={ImportTestIds.RowBtnRecurrencePopover(Number(rowIdx))}
+          >
             {summary}
           </Button>
         </Popover.Target>
-        <Popover.Dropdown>
+        <Popover.Dropdown data-testid={ImportTestIds.RecurrencePopoverDropdown(Number(rowIdx))}>
           <Stack gap="xs" w={300}>
             <RecurrenceFields namePrefix="" comboboxWithinPortal={false} />
           </Stack>

--- a/frontend/src/testIds/import.ts
+++ b/frontend/src/testIds/import.ts
@@ -30,6 +30,12 @@ export const ImportTestIds = {
   BtnBulkApply: 'btn_bulk_apply',
   SelectBulkAction: 'select_bulk_action',
 
+  // Recurrence popover (per-row)
+  RowBtnRecurrencePopover: (rowIndex: number) =>
+    `btn_recurrence_popover_${rowIndex}` as const,
+  RecurrencePopoverDropdown: (rowIndex: number) =>
+    `recurrence_popover_dropdown_${rowIndex}` as const,
+
   // Category-creation drawer (mounted from the import flow)
   DrawerCreateCategory: 'drawer_create_category',
   BtnNewCategoryInDrawer: 'btn_new_category_in_drawer',

--- a/frontend/src/testIds/index.ts
+++ b/frontend/src/testIds/index.ts
@@ -5,8 +5,13 @@
  * Conventions:
  * - One file per domain (accounts, categories, charges, transactions, import),
  *   plus `common.ts` for cross-cutting layout/invite ids.
- * - Static ids are `PascalCase: 'snake_case'`. Parametric ids are factory
- *   functions that return a `snake_case_${param}` literal type via `as const`.
+ * - All ids (static and parametric) are declared as `as const` objects:
+ *     export const XxxTestIds = {
+ *       StaticId: 'snake_case_value',
+ *       ParametricId: (n: number) => `snake_case_${n}` as const,
+ *     } as const
+ * - Static ids are plain string values. Parametric ids are arrow functions
+ *   returning `'...' as const` so the return type is a string literal.
  * - When adding a new testid: add it here first, then reference it from the
  *   component and the test in the same PR.
  */
@@ -20,3 +25,4 @@ export {
   type PropagationOption,
 } from './transactions'
 export { ImportTestIds } from './import'
+export { RecurrenceTestIds } from './recurrence'

--- a/frontend/src/testIds/recurrence.ts
+++ b/frontend/src/testIds/recurrence.ts
@@ -1,0 +1,12 @@
+/**
+ * Testids for RecurrenceFields — a shared component used in both the
+ * transaction form and the import review row popover.
+ *
+ * Parametric (per-row) ids stay as factory functions in the domain-specific
+ * testid files (e.g. ImportTestIds).
+ */
+export const RecurrenceTestIds = {
+  TypeSelect: 'select_recurrence_type',
+  CurrentInstallmentInput: 'input_recurrence_current_installment',
+  TotalInstallmentsInput: 'input_recurrence_total_installments',
+} as const


### PR DESCRIPTION
## Summary

- **Bug fix**: `RecurrencePopover.handleClose` nunca setava `recurrenceEnabled = true` ao fechar o popover do import, fazendo com que `buildPayload` ignorasse o `recurrence_settings` configurado manualmente (o payload só inclui recorrência quando `recurrenceEnabled && recurrenceType && ...`).
- **Testids**: adicionados `data-testid` nos inputs de `RecurrenceFields` e no botão/dropdown do `RecurrencePopover`; novo `RecurrenceTestIds` como `as const` em `src/testIds/recurrence.ts`.
- **Novo teste e2e** (`import-installment.spec.ts`): valida o fluxo completo — upload CSV → configura 1/3 mensal no popover de parcelamento → confirma import → verifica via API que a transação criada tem `transaction_recurrence` com `type=monthly`, `installments=3` e `installment_number=1`.
- **Convenção documentada**: `CLAUDE.md` e `src/testIds/index.ts` atualizados com a regra de usar `as const` para testids (estáticos como string, paramétricos como arrow function).

## Test plan

- [ ] Rodar `npm run test:e2e -- --grep "import installment"` e confirmar que o novo teste passa
- [ ] Confirmar que os demais testes de import continuam passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)