### PR TITLE
feat: allow expenses/income on shared accounts

### DIFF
--- a/backend/internal/domain/transaction.go
+++ b/backend/internal/domain/transaction.go
@@ -109,17 +109,18 @@ func (t *Transaction) SetType(newType TransactionType) {
 }
 
 type TransactionCreateRequest struct {
-	TransactionType      TransactionType     `json:"transaction_type"`
-	AccountID            int                 `json:"account_id"`
-	CategoryID           int                 `json:"category_id,omitempty"`
-	Amount               int64               `json:"amount"`
-	Date                 time.Time           `json:"date"`
-	Description          string              `json:"description"`
-	DestinationAccountID *int                `json:"destination_account_id,omitempty"`
-	Tags                 []Tag               `json:"tags,omitempty"`
-	RecurrenceSettings   *RecurrenceSettings `json:"recurrence_settings,omitempty"`
-	SplitSettings        []SplitSettings     `json:"split_settings,omitempty"`
-	ChargeID             *int                `json:"charge_id,omitempty"`
+	TransactionType          TransactionType     `json:"transaction_type"`
+	AccountID                int                 `json:"account_id"`
+	CategoryID               int                 `json:"category_id,omitempty"`
+	Amount                   int64               `json:"amount"`
+	Date                     time.Time           `json:"date"`
+	Description              string              `json:"description"`
+	DestinationAccountID     *int                `json:"destination_account_id,omitempty"`
+	Tags                     []Tag               `json:"tags,omitempty"`
+	RecurrenceSettings       *RecurrenceSettings `json:"recurrence_settings,omitempty"`
+	SplitSettings            []SplitSettings     `json:"split_settings,omitempty"`
+	ChargeID                 *int                `json:"charge_id,omitempty"`
+	SharedAccountConnection  *UserConnection     `json:"-"`
 }
 
 type TransactionUpdateRequest struct {

--- a/backend/internal/service/transaction_create.go
+++ b/backend/internal/service/transaction_create.go
@@ -23,9 +23,20 @@ func (s *transactionService) Create(ctx context.Context, userID int, transaction
 	}
 	defer s.dbTransaction.Rollback(ctx)
 
-	_, err = s.services.Account.GetByID(ctx, userID, transaction.AccountID)
+	account, err := s.services.Account.GetByID(ctx, userID, transaction.AccountID)
 	if err != nil {
 		return 0, err
+	}
+
+	if account.UserConnection != nil {
+		if transaction.TransactionType == domain.TransactionTypeTransfer {
+			return 0, pkgErrors.ErrTransferNotAllowedOnSharedAccount
+		}
+		if len(transaction.SplitSettings) > 0 {
+			return 0, pkgErrors.ErrSplitSettingsNotAllowedOnSharedAccount
+		}
+		account.UserConnection.SwapIfNeeded(userID)
+		transaction.SharedAccountConnection = account.UserConnection
 	}
 
 	if transaction.CategoryID > 0 {
@@ -236,7 +247,7 @@ func (s *transactionService) createTransactions(ctx context.Context, userID int,
 			firstID = t.ID
 		}
 
-		if req.TransactionType != domain.TransactionTypeTransfer && len(req.SplitSettings) > 0 {
+		if req.SharedAccountConnection == nil && req.TransactionType != domain.TransactionTypeTransfer && len(req.SplitSettings) > 0 {
 			if err := s.createSettlementsForSplit(ctx, userID, t, req.TransactionType, req.SplitSettings); err != nil {
 				return 0, err
 			}
@@ -333,6 +344,36 @@ func (s *transactionService) injectLinkedTransactions(
 	recurrenceSettings *domain.RecurrenceSettings) error {
 
 	hasRecurrence := recurrenceSettings != nil
+
+	// Shared account: create a single inverted linked tx on the partner's account
+	if req.SharedAccountConnection != nil {
+		conn := req.SharedAccountConnection
+		linkedTx := domain.Transaction{
+			ID:                      0,
+			InstallmentNumber:       transaction.InstallmentNumber,
+			Date:                    transaction.Date,
+			Description:             transaction.Description,
+			UserID:                  conn.ToUserID,
+			OriginalUserID:          &userID,
+			Type:                    lo.Ternary(transaction.Type == domain.TransactionTypeExpense, domain.TransactionTypeIncome, domain.TransactionTypeExpense),
+			OperationType:           transaction.OperationType.Invert(),
+			AccountID:               conn.ToAccountID,
+			CategoryID:              nil,
+			Amount:                  transaction.Amount,
+			Tags:                    nil,
+			ChargeID:                transaction.ChargeID,
+			TransactionRecurrenceID: transaction.TransactionRecurrenceID,
+		}
+		if hasRecurrence {
+			r, err := s.createRecurrence(ctx, conn.ToUserID, *recurrenceSettings)
+			if err != nil {
+				return err
+			}
+			linkedTx.TransactionRecurrenceID = &r.ID
+		}
+		transaction.LinkedTransactions = append(transaction.LinkedTransactions, linkedTx)
+		return nil
+	}
 
 	var connectionIDs []int
 

--- a/backend/internal/service/transaction_create_test.go
+++ b/backend/internal/service/transaction_create_test.go
@@ -1465,6 +1465,169 @@ func now() time.Time {
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 }
 
+func (suite *TransactionCreateWithDBTestSuite) TestCreateExpenseOnSharedAccount() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, user1)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	amount := int64(1000)
+	d := now()
+
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		TransactionType: domain.TransactionTypeExpense,
+		AccountID:       conn.FromAccountID,
+		CategoryID:      category.ID,
+		Amount:          amount,
+		Date:            d,
+		Description:     "shared account expense",
+	})
+	suite.Require().NoError(err)
+
+	// user1: 1 expense (debit) on conn.FromAccountID
+	txsUser1, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user1.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(txsUser1, 1)
+	suite.Assert().Equal(conn.FromAccountID, txsUser1[0].AccountID)
+	suite.Assert().Equal(domain.TransactionTypeExpense, txsUser1[0].Type)
+	suite.Assert().Equal(domain.OperationTypeDebit, txsUser1[0].OperationType)
+	suite.Assert().Equal(amount, txsUser1[0].Amount)
+	suite.Assert().Len(txsUser1[0].LinkedTransactions, 1)
+
+	// Linked tx: user2 gets income (credit) on conn.ToAccountID
+	lt := txsUser1[0].LinkedTransactions[0]
+	suite.Assert().Equal(conn.ToAccountID, lt.AccountID)
+	suite.Assert().Equal(user2.ID, lt.UserID)
+	suite.Assert().Equal(domain.TransactionTypeIncome, lt.Type)
+	suite.Assert().Equal(domain.OperationTypeCredit, lt.OperationType)
+	suite.Assert().Equal(amount, lt.Amount)
+	suite.Assert().Equal(user1.ID, lo.FromPtr(lt.OriginalUserID))
+
+	// user2: 1 income (credit) on conn.ToAccountID
+	txsUser2, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user2.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(txsUser2, 1)
+	suite.Assert().Equal(conn.ToAccountID, txsUser2[0].AccountID)
+	suite.Assert().Equal(domain.TransactionTypeIncome, txsUser2[0].Type)
+	suite.Assert().Equal(domain.OperationTypeCredit, txsUser2[0].OperationType)
+
+	// No settlements
+	settlements, err := suite.Repos.Settlement.Search(ctx, domain.SettlementFilter{
+		SourceTransactionIDs: []int{txsUser1[0].ID},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Empty(settlements, "shared account expenses should not create settlements")
+}
+
+func (suite *TransactionCreateWithDBTestSuite) TestCreateIncomeOnSharedAccount() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, user1)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	amount := int64(2000)
+	d := now()
+
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		TransactionType: domain.TransactionTypeIncome,
+		AccountID:       conn.FromAccountID,
+		CategoryID:      category.ID,
+		Amount:          amount,
+		Date:            d,
+		Description:     "shared account income",
+	})
+	suite.Require().NoError(err)
+
+	// user1: 1 income (credit) on conn.FromAccountID
+	txsUser1, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user1.ID,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Len(txsUser1, 1)
+	suite.Assert().Equal(domain.TransactionTypeIncome, txsUser1[0].Type)
+	suite.Assert().Equal(domain.OperationTypeCredit, txsUser1[0].OperationType)
+
+	// Linked tx: user2 gets expense (debit) on conn.ToAccountID
+	suite.Assert().Len(txsUser1[0].LinkedTransactions, 1)
+	lt := txsUser1[0].LinkedTransactions[0]
+	suite.Assert().Equal(conn.ToAccountID, lt.AccountID)
+	suite.Assert().Equal(user2.ID, lt.UserID)
+	suite.Assert().Equal(domain.TransactionTypeExpense, lt.Type)
+	suite.Assert().Equal(domain.OperationTypeDebit, lt.OperationType)
+	suite.Assert().Equal(amount, lt.Amount)
+}
+
+func (suite *TransactionCreateWithDBTestSuite) TestCreateExpenseOnSharedAccount_RejectsSplitSettings() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		TransactionType: domain.TransactionTypeExpense,
+		AccountID:       conn.FromAccountID,
+		Amount:          1000,
+		Date:            now(),
+		Description:     "should fail",
+		SplitSettings: []domain.SplitSettings{
+			{ConnectionID: conn.ID, Percentage: lo.ToPtr(50)},
+		},
+	})
+	suite.Assert().Error(err)
+	suite.Assert().ErrorIs(err, pkgErrors.ErrSplitSettingsNotAllowedOnSharedAccount)
+}
+
+func (suite *TransactionCreateWithDBTestSuite) TestCreateTransferOnSharedAccount_Rejected() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	account, err := suite.createTestAccount(ctx, user1)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		TransactionType:      domain.TransactionTypeTransfer,
+		AccountID:            conn.FromAccountID,
+		DestinationAccountID: lo.ToPtr(account.ID),
+		Amount:               1000,
+		Date:                 now(),
+		Description:          "should fail",
+	})
+	suite.Assert().Error(err)
+	suite.Assert().ErrorIs(err, pkgErrors.ErrTransferNotAllowedOnSharedAccount)
+}
+
 func TestTransactionCreateWithDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -52,6 +52,8 @@ const (
 	ErrorTagSplitSettingPercentageMustBeBetween1And100          ErrorTag = "TRANSACTION.SPLIT_SETTING_PERCENTAGE_MUST_BE_BETWEEN_1_AND_100"
 	ErrorTagSplitSettingAmountMustBeGreaterThanZero             ErrorTag = "TRANSACTION.SPLIT_SETTING_AMOUNT_MUST_BE_GREATER_THAN_ZERO"
 	ErrorTagSplitSettingInvalidDestinationAccountID             ErrorTag = "TRANSACTION.SPLIT_SETTING_INVALID_DESTINATION_ACCOUNT_ID"
+	ErrorTagSplitSettingsNotAllowedOnSharedAccount              ErrorTag = "TRANSACTION.SPLIT_SETTINGS_NOT_ALLOWED_ON_SHARED_ACCOUNT"
+	ErrorTagTransferNotAllowedOnSharedAccount                   ErrorTag = "TRANSACTION.TRANSFER_NOT_ALLOWED_ON_SHARED_ACCOUNT"
 	ErrorTagInvalidPeriod                                       ErrorTag = "TRANSACTION.INVALID_PERIOD"
 	ErrorTagInvalidPropagationSettings                          ErrorTag = "TRANSACTION.INVALID_PROPAGATION_SETTINGS"
 	ErrorTagParentTransactionBelongsToAnotherUser               ErrorTag = "TRANSACTION.PARENT_TRANSACTION_BELONGS_TO_ANOTHER_USER"
@@ -73,7 +75,9 @@ const (
 
 var (
 	ErrMissingDestinationAccount          = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagMissingDestinationAccount)}, "missing destination account")
-	ErrSplitSettingsNotAllowedForTransfer = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSplitSettingsNotAllowedForTransfer)}, "split settings are not allowed for transfer transactions")
+	ErrSplitSettingsNotAllowedForTransfer      = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSplitSettingsNotAllowedForTransfer)}, "split settings are not allowed for transfer transactions")
+	ErrSplitSettingsNotAllowedOnSharedAccount  = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSplitSettingsNotAllowedOnSharedAccount)}, "split settings are not allowed on shared accounts")
+	ErrTransferNotAllowedOnSharedAccount       = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagTransferNotAllowedOnSharedAccount)}, "transfers are not allowed on shared accounts")
 	ErrAmountMustBeGreaterThanZero        = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagAmountMustBeGreaterThanZero)}, "amount must be greater than zero")
 	ErrDateIsRequired                     = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagDateIsRequired)}, "date is required")
 	ErrDescriptionIsRequired              = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagDescriptionIsRequired)}, "description is required")

--- a/frontend/e2e/helpers/createUserAndPartner.ts
+++ b/frontend/e2e/helpers/createUserAndPartner.ts
@@ -1,0 +1,112 @@
+/**
+ * Creates two fresh users with an accepted connection between them.
+ * Each test gets isolated users to avoid cross-test interference.
+ *
+ * Returns auth tokens, user IDs, account IDs, and connection details
+ * for both the primary user and their partner.
+ */
+
+import { getAuthTokenForUser, apiFetchAs } from "./api";
+
+export interface UserAndPartnerResult {
+  /** Auth token for the primary user */
+  userToken: string;
+  /** Primary user's ID */
+  userId: number;
+  /** Primary user's personal account ID */
+  userAccountId: number;
+  /** Primary user's shared account ID (from the connection) */
+  userConnAccountId: number;
+
+  /** Auth token for the partner user */
+  partnerToken: string;
+  /** Partner user's ID */
+  partnerId: number;
+  /** Partner user's personal account ID */
+  partnerAccountId: number;
+  /** Partner user's shared account ID (from the connection) */
+  partnerConnAccountId: number;
+
+  /** The connection ID between both users */
+  connectionId: number;
+}
+
+export async function createUserAndPartner(
+  prefix = "e2e-shared",
+): Promise<UserAndPartnerResult> {
+  const uid = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const userEmail = `${uid}-user@financeapp.local`;
+  const partnerEmail = `${uid}-partner@financeapp.local`;
+
+  // 1. Auth both users (test-login auto-creates them)
+  const userToken = await getAuthTokenForUser(userEmail);
+  const partnerToken = await getAuthTokenForUser(partnerEmail);
+
+  // 2. Create personal accounts for both
+  const userAccountRes = await apiFetchAs(userToken, "/api/accounts", {
+    method: "POST",
+    body: JSON.stringify({ name: `Conta ${uid}`, initial_balance: 0 }),
+  });
+  const userAccount = (await userAccountRes.json()) as { id: number };
+
+  const partnerAccountRes = await apiFetchAs(partnerToken, "/api/accounts", {
+    method: "POST",
+    body: JSON.stringify({ name: `Partner ${uid}`, initial_balance: 0 }),
+  });
+  const partnerAccount = (await partnerAccountRes.json()) as { id: number };
+
+  // 3. Get partner user ID
+  const meRes = await apiFetchAs(partnerToken, "/api/auth/me");
+  const partnerUser = (await meRes.json()) as { id: number };
+
+  // 4. Get user ID
+  const userMeRes = await apiFetchAs(userToken, "/api/auth/me");
+  const user = (await userMeRes.json()) as { id: number };
+
+  // 5. Create connection (user → partner) and accept
+  const connRes = await apiFetchAs(userToken, "/api/user-connections", {
+    method: "POST",
+    body: JSON.stringify({
+      to_user_id: partnerUser.id,
+      from_default_split_percentage: 50,
+    }),
+  });
+  const connection = (await connRes.json()) as { id: number };
+
+  await apiFetchAs(partnerToken, `/api/user-connections/${connection.id}/accepted`, {
+    method: "PATCH",
+  });
+
+  // 6. Find connection accounts for both sides
+  const userAccountsRes = await apiFetchAs(userToken, "/api/accounts");
+  const userAccounts = (await userAccountsRes.json()) as Array<{
+    id: number;
+    user_connection?: { id: number };
+  }>;
+  const userConnAccount = userAccounts.find((a) => a.user_connection?.id === connection.id);
+  if (!userConnAccount) {
+    throw new Error("Could not find user's connection account");
+  }
+
+  const partnerAccountsRes = await apiFetchAs(partnerToken, "/api/accounts");
+  const partnerAccounts = (await partnerAccountsRes.json()) as Array<{
+    id: number;
+    user_connection?: { id: number };
+  }>;
+  const partnerConnAccount = partnerAccounts.find((a) => a.user_connection?.id === connection.id);
+  if (!partnerConnAccount) {
+    throw new Error("Could not find partner's connection account");
+  }
+
+  return {
+    userToken,
+    userId: user.id,
+    userAccountId: userAccount.id,
+    userConnAccountId: userConnAccount.id,
+    partnerToken,
+    partnerId: partnerUser.id,
+    partnerAccountId: partnerAccount.id,
+    partnerConnAccountId: partnerConnAccount.id,
+    connectionId: connection.id,
+  };
+}

--- a/frontend/e2e/tests/shared-account-expenses.spec.ts
+++ b/frontend/e2e/tests/shared-account-expenses.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from "@playwright/test";
+import { TransactionsPage } from "../pages/TransactionsPage";
+import { TransactionsTestIds } from "@/testIds";
+import { createUserAndPartner, type UserAndPartnerResult } from "../helpers/createUserAndPartner";
+import {
+  apiFetchAs,
+  apiListTransactions,
+  openAuthedPage,
+} from "../helpers/api";
+
+const now = new Date();
+const MONTH = now.getMonth() + 1;
+const YEAR = now.getFullYear();
+
+test.describe("Shared account expenses", () => {
+  let setup: UserAndPartnerResult;
+  let categoryId: number;
+  let sharedAccountName: string;
+
+  test.beforeAll(async () => {
+    setup = await createUserAndPartner("e2e-shared-acct");
+
+    // Create a category for the primary user
+    const catRes = await apiFetchAs(setup.userToken, "/api/categories", {
+      method: "POST",
+      body: JSON.stringify({ name: `Cat ${Date.now()}` }),
+    });
+    const cat = (await catRes.json()) as { id: number };
+    categoryId = cat.id;
+
+    // Get the shared account name for UI selection
+    const accountsRes = await apiFetchAs(setup.userToken, "/api/accounts");
+    const accounts = (await accountsRes.json()) as Array<{
+      id: number;
+      name: string;
+      user_connection?: { id: number };
+    }>;
+    const sharedAccount = accounts.find((a) => a.id === setup.userConnAccountId);
+    if (!sharedAccount) throw new Error("Shared account not found");
+    sharedAccountName = sharedAccount.name;
+  });
+
+  test("create expense on shared account creates inverted tx for partner", async ({
+    browser,
+  }) => {
+    const page = await openAuthedPage(browser, setup.userToken);
+    const txPage = new TransactionsPage(page);
+    await txPage.gotoMonth(MONTH, YEAR);
+
+    await txPage.openCreateForm();
+    await txPage.fillDescription("Shared expense test");
+    await txPage.fillAmount(5000);
+    await txPage.selectAccount(sharedAccountName);
+
+    // Split settings should NOT be visible when shared account is selected
+    await expect(
+      page.getByTestId(TransactionsTestIds.BtnAddSplitRow),
+    ).not.toBeVisible();
+
+    await txPage.submitForm();
+
+    // Verify user1 sees the expense
+    const userTxs = await apiListTransactions(MONTH, YEAR, {
+      token: setup.userToken,
+    });
+    const userExpense = userTxs.find(
+      (t) => t.description === "Shared expense test",
+    );
+    expect(userExpense).toBeDefined();
+    expect(userExpense!.type).toBe("expense");
+    expect(userExpense!.operation_type).toBe("debit");
+    expect(userExpense!.account_id).toBe(setup.userConnAccountId);
+
+    // Verify partner sees the inverted income
+    const partnerTxs = await apiListTransactions(MONTH, YEAR, {
+      token: setup.partnerToken,
+    });
+    const partnerIncome = partnerTxs.find(
+      (t) => t.description === "Shared expense test",
+    );
+    expect(partnerIncome).toBeDefined();
+    expect(partnerIncome!.type).toBe("income");
+    expect(partnerIncome!.operation_type).toBe("credit");
+    expect(partnerIncome!.account_id).toBe(setup.partnerConnAccountId);
+
+    await page.close();
+  });
+
+  test("create income on shared account creates inverted tx for partner", async ({
+    browser,
+  }) => {
+    const page = await openAuthedPage(browser, setup.userToken);
+    const txPage = new TransactionsPage(page);
+    await txPage.gotoMonth(MONTH, YEAR);
+
+    await txPage.openCreateForm();
+    await txPage.selectType("income");
+    await txPage.fillDescription("Shared income test");
+    await txPage.fillAmount(3000);
+    await txPage.selectAccount(sharedAccountName);
+
+    await txPage.submitForm();
+
+    // Verify user1 sees the income
+    const userTxs = await apiListTransactions(MONTH, YEAR, {
+      token: setup.userToken,
+    });
+    const userIncome = userTxs.find(
+      (t) => t.description === "Shared income test",
+    );
+    expect(userIncome).toBeDefined();
+    expect(userIncome!.type).toBe("income");
+    expect(userIncome!.operation_type).toBe("credit");
+
+    // Verify partner sees the inverted expense
+    const partnerTxs = await apiListTransactions(MONTH, YEAR, {
+      token: setup.partnerToken,
+    });
+    const partnerExpense = partnerTxs.find(
+      (t) => t.description === "Shared income test",
+    );
+    expect(partnerExpense).toBeDefined();
+    expect(partnerExpense!.type).toBe("expense");
+    expect(partnerExpense!.operation_type).toBe("debit");
+
+    await page.close();
+  });
+
+  test("shared accounts not visible in transfer source selector", async ({
+    browser,
+  }) => {
+    const page = await openAuthedPage(browser, setup.userToken);
+    const txPage = new TransactionsPage(page);
+    await txPage.gotoMonth(MONTH, YEAR);
+
+    await txPage.openCreateForm();
+    await txPage.selectType("transfer");
+
+    // Open the source account dropdown and verify shared account is not listed
+    const sourceInput = page.getByTestId(TransactionsTestIds.SelectAccount);
+    await sourceInput.click();
+    await expect(
+      page.getByRole("option", { name: sharedAccountName }),
+    ).not.toBeVisible();
+
+    await page.close();
+  });
+});

--- a/frontend/src/components/transactions/form/TransactionForm.tsx
+++ b/frontend/src/components/transactions/form/TransactionForm.tsx
@@ -18,6 +18,7 @@ import {
 } from "@mantine/core";
 import { DatePickerInput } from "@mantine/dates";
 import { useAccounts } from "@/hooks/useAccounts";
+import { useGroupedAccountOptions } from "@/hooks/useGroupedAccountOptions";
 import { useFlattenCategories } from "@/hooks/useCategories";
 import { useTags } from "@/hooks/useTags";
 import { Transactions } from "@/types/transactions";
@@ -75,7 +76,10 @@ export const TransactionForm = ({
 
   const transactionType = useWatch({ control, name: "transaction_type" });
   const recurrenceEnabled = useWatch({ control, name: "recurrenceEnabled" });
+  const accountId = useWatch({ control, name: "account_id" });
   const isTransfer = transactionType === "transfer";
+  const selectedAccount = accounts.find((a) => a.id === accountId);
+  const isSharedAccount = !!selectedAccount?.user_connection;
 
   const generalError = submitError ?? (errors as Record<string, { message?: string }>)["_general"]?.message;
 
@@ -97,44 +101,13 @@ export const TransactionForm = ({
     setValue("split_settings", []);
   }
 
-  const accountOptions = accounts
+  // Transfer source: personal accounts only (flat list)
+  const personalAccountOptions = accounts
     .filter((a) => !a.user_connection)
     .map((a) => ({ value: String(a.id), label: a.name }));
 
-  const destinationAccountOptions: ComboboxItemGroup<ComboboxItem>[] = accounts.reduce<
-    ComboboxItemGroup<ComboboxItem>[]
-  >(
-    (acc, a) => {
-      const item = { label: a.name, value: String(a.id) };
-      if (a.user_connection) {
-        return [
-          acc[0],
-          {
-            ...acc[1],
-            items: [...acc[1].items, item],
-          },
-        ];
-      }
-
-      return [
-        {
-          ...acc[0],
-          items: [...acc[0].items, item],
-        },
-        acc[1],
-      ];
-    },
-    [
-      {
-        group: "Minhas contas",
-        items: [],
-      },
-      {
-        group: "Contas Compartilhadas",
-        items: [],
-      },
-    ],
-  );
+  // Expense/income + transfer destination: grouped personal + shared
+  const groupedAccountOptions = useGroupedAccountOptions(accounts);
 
   const categoryOptions = categories.map((c) => ({
     value: String(c.id),
@@ -255,10 +228,10 @@ export const TransactionForm = ({
                   ref={field.ref}
                   label="Conta"
                   required
-                  data={accountOptions}
+                  data={personalAccountOptions}
                   value={field.value ? String(field.value) : null}
                   onChange={(val) => field.onChange(val ? Number(val) : null)}
-                  onBlur={makeSelectBlurHandler(accountOptions, (val) => field.onChange(val))}
+                  onBlur={makeSelectBlurHandler(personalAccountOptions, (val) => field.onChange(val))}
                   error={errors.account_id?.message}
                   searchable
                   data-testid={TransactionsTestIds.SelectAccount}
@@ -273,10 +246,10 @@ export const TransactionForm = ({
                   ref={field.ref}
                   label="Conta de destino"
                   required
-                  data={destinationAccountOptions}
+                  data={groupedAccountOptions}
                   value={field.value ? String(field.value) : null}
                   onChange={(val) => field.onChange(val ? Number(val) : null)}
-                  onBlur={makeSelectBlurHandler(destinationAccountOptions, (val) => field.onChange(val))}
+                  onBlur={makeSelectBlurHandler(groupedAccountOptions, (val) => field.onChange(val))}
                   error={errors.destination_account_id?.message}
                   searchable
                   data-testid={TransactionsTestIds.SelectDestinationAccount}
@@ -313,10 +286,17 @@ export const TransactionForm = ({
                     ref={field.ref}
                     label="Conta"
                     required
-                    data={accountOptions}
+                    data={groupedAccountOptions}
                     value={field.value ? String(field.value) : null}
-                    onChange={(val) => field.onChange(val ? Number(val) : null)}
-                    onBlur={makeSelectBlurHandler(accountOptions, (val) => field.onChange(val))}
+                    onChange={(val) => {
+                      field.onChange(val ? Number(val) : null);
+                      // Clear split settings when selecting a shared account
+                      const acct = accounts.find((a) => a.id === Number(val));
+                      if (acct?.user_connection) {
+                        setValue("split_settings", []);
+                      }
+                    }}
+                    onBlur={makeSelectBlurHandler(groupedAccountOptions, (val) => field.onChange(val))}
                     error={errors.account_id?.message}
                     searchable
                     data-testid={TransactionsTestIds.SelectAccount}
@@ -325,7 +305,7 @@ export const TransactionForm = ({
               />
             </SimpleGrid>
 
-            <SplitSettingsFields />
+            {!isSharedAccount && <SplitSettingsFields />}
           </>
         )}
 

--- a/frontend/src/hooks/useGroupedAccountOptions.ts
+++ b/frontend/src/hooks/useGroupedAccountOptions.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+import type { ComboboxItemGroup, ComboboxItem } from "@mantine/core";
+import type { Transactions } from "@/types/transactions";
+
+export function useGroupedAccountOptions(accounts: Transactions.Account[]): ComboboxItemGroup<ComboboxItem>[] {
+  return useMemo(
+    () =>
+      accounts.reduce<ComboboxItemGroup<ComboboxItem>[]>(
+        (acc, a) => {
+          const item = { label: a.name, value: String(a.id) };
+          if (a.user_connection) {
+            acc[1] = { ...acc[1], items: [...acc[1].items, item] };
+          } else {
+            acc[0] = { ...acc[0], items: [...acc[0].items, item] };
+          }
+          return acc;
+        },
+        [
+          { group: "Minhas contas", items: [] },
+          { group: "Contas Compartilhadas", items: [] },
+        ],
+      ),
+    [accounts],
+  );
+}


### PR DESCRIPTION
## Summary

- Allow users to create expenses/income directly on shared (connection) accounts
- When a shared account is selected, an inverted linked transaction is created on the partner's side (expense→income, income→expense)
- Split settings are hidden and rejected for shared accounts
- Transfers remain restricted to personal accounts as source

## Changes

**Backend**: shared account detection via `UserConnection`, validation (reject split+transfer), inverted linked tx creation, skip settlement

**Frontend**: `useGroupedAccountOptions` hook for account dropdown grouping, show shared accounts in expense/income selector, hide split settings when shared account selected

**E2E**: `createUserAndPartner` helper for isolated user pairs, 3 tests covering expense/income on shared accounts and transfer restriction

## Test plan

- [ ] Backend integration tests pass (expense, income, reject split, reject transfer on shared accounts)
- [ ] Frontend: create expense on shared account → split settings hidden, form submits
- [ ] E2E: expense on shared account creates inverted income for partner
- [ ] E2E: income on shared account creates inverted expense for partner
- [ ] E2E: shared accounts not visible in transfer source selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)