### PR TITLE
e2e: form field helpers + testid-only Select/SegmentedControl options

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -286,6 +286,35 @@ All ids — static or parametric — are declared as `as const` objects:
 
 When a testid is missing, the fix is to add it to the component, not to invent a fragile selector in the test.
 
+### Form fields: use `e2e/helpers/formFields.ts` (mandatory)
+
+**Every interaction with a form field in an e2e test must go through a helper from `frontend/e2e/helpers/formFields.ts`.** Do not call `.fill()`, `.click()`, `.check()`, `.setChecked()`, `.setInputFiles()`, or `press(digit)` loops directly on a form field locator — that's how Mantine quirks (the `CurrencyInput` keydown handler, combobox option portals, SegmentedControl item targeting) leak back into Page Objects and tests start failing intermittently.
+
+Helpers in v1 — pick the one that matches the field:
+
+| Field kind | Helper |
+|---|---|
+| Text input | `fillText` / `clearText` |
+| Textarea | `fillTextarea` |
+| `NumberInput` | `fillNumber` |
+| `CurrencyInput` (cents) | `fillCurrencyCents` / `clearAndFillCurrencyCents` |
+| `DateInput` | `fillDateInput` |
+| Mantine `Select` | `selectOption(root, triggerTestId, optionTestId)` |
+| `TagsInput` | `fillTagsInput` |
+| `Radio` | `pickRadio` |
+| `Checkbox` | `setCheckbox` |
+| `Switch` | `setSwitch` |
+| `SegmentedControl` | `pickSegmented(root, segmentedTestId, optionTestId)` |
+| `FileInput` | `setFileInput` |
+
+Rules:
+- **Always pass an option testid**, never a label, to `selectOption` and `pickSegmented`. Both helpers refuse label fallbacks. If a Mantine `Select` doesn't have a `renderOption` testid yet, add one in the same PR (factory under `src/testIds/`, then `renderOption={({ option }) => <span data-testid={...}>{option.label}</span>}` on the `Select`). Same pattern for `SegmentedControl`: render each item's `label` as JSX with a per-option testid.
+- **Always scope `root` to a drawer/form locator** when the form lives inside one (e.g. `formDrawer`, `updateDrawer`, `createDrawer`). Defaulting to `page` lets stale duplicates match silently.
+- **Page Object methods that fill a form field must call a helper** — they shouldn't reimplement the keydown loop, the click+option dance, or hardcoded label maps. If you find yourself writing one of those in a Page Object, the helper is missing or the testid is missing; fix the source rather than work around it in the test.
+- **Specs themselves should also call helpers** when they need to touch a field that the Page Object doesn't expose — don't reach into `page.getByLabel(...)` / `getByRole('option', ...)`.
+
+Add a new helper (or extend an existing one) when a new form-field kind first appears in a real test. Don't ship a one-off interaction inline.
+
 ## Known divergences (migrate when touching)
 
 These exist in the codebase and agents should **not** copy them. When touching a file listed here, prefer migrating it toward the conventions above within the scope of the task.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -288,32 +288,42 @@ When a testid is missing, the fix is to add it to the component, not to invent a
 
 ### Form fields: use `e2e/helpers/formFields.ts` (mandatory)
 
-**Every interaction with a form field in an e2e test must go through a helper from `frontend/e2e/helpers/formFields.ts`.** Do not call `.fill()`, `.click()`, `.check()`, `.setChecked()`, `.setInputFiles()`, or `press(digit)` loops directly on a form field locator — that's how Mantine quirks (the `CurrencyInput` keydown handler, combobox option portals, SegmentedControl item targeting) leak back into Page Objects and tests start failing intermittently.
+**Every interaction with a form field in an e2e test must go through a field class from `frontend/e2e/helpers/formFields.ts`.** Do not call `.fill()`, `.click()`, `.check()`, `.setChecked()`, `.setInputFiles()`, or `press(digit)` loops directly on a form field locator — that's how Mantine quirks (the `CurrencyInput` keydown handler, combobox option portals, SegmentedControl item targeting) leak back into Page Objects and tests start failing intermittently.
 
-Helpers in v1 — pick the one that matches the field:
+The module exposes one class per field kind. Each class is constructed with `(root: Page | Locator, testid: string)` and exposes only the methods that make sense for that kind, so the type system stops you from calling `.fillCents()` on a text input or `.pick()` on a checkbox.
 
-| Field kind | Helper |
-|---|---|
-| Text input | `fillText` / `clearText` |
-| Textarea | `fillTextarea` |
-| `NumberInput` | `fillNumber` |
-| `CurrencyInput` (cents) | `fillCurrencyCents` / `clearAndFillCurrencyCents` |
-| `DateInput` | `fillDateInput` |
-| Mantine `Select` | `selectOption(root, triggerTestId, optionTestId)` |
-| `TagsInput` | `fillTagsInput` |
-| `Radio` | `pickRadio` |
-| `Checkbox` | `setCheckbox` |
-| `Switch` | `setSwitch` |
-| `SegmentedControl` | `pickSegmented(root, segmentedTestId, optionTestId)` |
-| `FileInput` | `setFileInput` |
+| Field kind | Class | Methods |
+|---|---|---|
+| Text input | `TextField` | `fill(value)`, `clear()` |
+| Textarea | `TextareaField` | `fill(value)` |
+| `NumberInput` | `NumberField` | `fill(value)` |
+| `CurrencyInput` (cents) | `CurrencyField` | `fillCents(cents)`, `clearAndFillCents(cents)` |
+| `DateInput` | `DateField` | `fill(formattedDate)` |
+| Mantine `Select` | `SelectField` | `pick(optionTestId, { search? })` |
+| `TagsInput` | `TagsField` | `add(values)` |
+| `Radio` | `RadioField` | `pick()` |
+| `Checkbox` | `CheckboxField` | `set(checked)` |
+| `Switch` | `SwitchField` | `set(on)` |
+| `SegmentedControl` | `SegmentedField` | `pick(optionTestId)` |
+| `FileInput` | `FileField` | `set(content)` |
+
+Call shape:
+
+```ts
+await new CurrencyField(this.formDrawer, TransactionsTestIds.InputAmount).fillCents(5000)
+await new SelectField(this.formDrawer, TransactionsTestIds.SelectAccount)
+  .pick(TransactionsTestIds.OptionAccount(accountId))
+await new SegmentedField(this.formDrawer, TransactionsTestIds.SegmentedTransactionType)
+  .pick(TransactionsTestIds.SegmentTransactionType('expense'))
+```
 
 Rules:
-- **Always pass an option testid**, never a label, to `selectOption` and `pickSegmented`. Both helpers refuse label fallbacks. If a Mantine `Select` doesn't have a `renderOption` testid yet, add one in the same PR (factory under `src/testIds/`, then `renderOption={({ option }) => <span data-testid={...}>{option.label}</span>}` on the `Select`). Same pattern for `SegmentedControl`: render each item's `label` as JSX with a per-option testid.
+- **Always pass an option testid**, never a label, to `SelectField.pick` and `SegmentedField.pick`. Both refuse label fallbacks. If a Mantine `Select` doesn't have a `renderOption` testid yet, add one in the same PR (factory under `src/testIds/`, then `renderOption={({ option }) => <span data-testid={...}>{option.label}</span>}` on the `Select`). Same pattern for `SegmentedControl`: render each item's `label` as JSX with a per-option testid.
 - **Always scope `root` to a drawer/form locator** when the form lives inside one (e.g. `formDrawer`, `updateDrawer`, `createDrawer`). Defaulting to `page` lets stale duplicates match silently.
-- **Page Object methods that fill a form field must call a helper** — they shouldn't reimplement the keydown loop, the click+option dance, or hardcoded label maps. If you find yourself writing one of those in a Page Object, the helper is missing or the testid is missing; fix the source rather than work around it in the test.
-- **Specs themselves should also call helpers** when they need to touch a field that the Page Object doesn't expose — don't reach into `page.getByLabel(...)` / `getByRole('option', ...)`.
+- **Page Object methods that fill a form field must instantiate a field class** — they shouldn't reimplement the keydown loop, the click+option dance, or hardcoded label maps. If you find yourself writing one of those in a Page Object, the class is missing or the testid is missing; fix the source rather than work around it in the test.
+- **Specs themselves should also use the classes** when they need to touch a field that the Page Object doesn't expose — don't reach into `page.getByLabel(...)` / `getByRole('option', ...)`.
 
-Add a new helper (or extend an existing one) when a new form-field kind first appears in a real test. Don't ship a one-off interaction inline.
+Add a new field class (or extend an existing one) when a new form-field kind first appears in a real test. Don't ship a one-off interaction inline.
 
 ## Known divergences (migrate when touching)
 

--- a/frontend/e2e/helpers/formFields.ts
+++ b/frontend/e2e/helpers/formFields.ts
@@ -76,7 +76,15 @@ export class CurrencyField extends FieldBase {
   async clearAndFillCents(cents: number): Promise<void> {
     const input = this.locator()
     await input.click()
-    await input.press('Control+a')
+    // CurrencyInput's keydown handler treats each Backspace as `floor(value/10)`,
+    // so we need one Backspace per digit currently displayed to drain the value
+    // to 0 — Control+a + digit doesn't reliably trigger the "all selected"
+    // branch because React re-renders reset the selection between presses.
+    const display = await input.inputValue()
+    const digitCount = display.replace(/\D/g, '').length
+    for (let i = 0; i < digitCount; i++) {
+      await input.press('Backspace')
+    }
     for (const digit of String(cents)) {
       await input.press(digit)
     }

--- a/frontend/e2e/helpers/formFields.ts
+++ b/frontend/e2e/helpers/formFields.ts
@@ -1,97 +1,106 @@
 /**
- * Form-field interaction helpers for Playwright e2e tests.
+ * Form-field interaction helpers for Playwright e2e tests — one class per
+ * field kind. Each class wraps a `(root, testid)` pair and exposes only the
+ * methods that make sense for that kind, so the type system stops you from
+ * calling `.pickCents()` on a text input or `.pick()` on a checkbox.
  *
- * Encapsulate the Mantine-specific quirks (CurrencyInput keydown loop,
- * combobox option portals, SegmentedControl item targeting) so Page Objects
- * stay short and tests don't drift back to fragile `getByRole('option')` /
- * `getByText(label)` patterns.
+ * Classes encapsulate the Mantine-specific quirks (CurrencyInput keydown
+ * digit-loop, combobox option portals, SegmentedControl item targeting) so
+ * Page Objects stay short and tests don't drift back to fragile
+ * `getByRole('option')` / `getByText(label)` patterns.
  *
  * Conventions:
- * - All helpers take `root: Page | Locator` first to scope inside drawers/forms.
- * - Helpers that resolve portalled content (Select dropdown options) extract
- *   the `Page` from `root` internally.
- * - Selects and Segmented controls take an option `testid` — never a label —
- *   per `frontend/CLAUDE.md` selectors policy.
+ * - Constructor: `(root: Page | Locator, testid: string)`. Always scope `root`
+ *   to a drawer/form locator when the field lives inside one — defaulting to
+ *   `page` lets stale duplicates match silently.
+ * - Selects and SegmentedControls require an option testid (no label
+ *   fallback), per the testid-only selector policy in `frontend/CLAUDE.md`.
+ * - Classes that resolve portalled content (Select dropdowns) extract `Page`
+ *   from `root` internally.
  */
 
 import { type Page, type Locator } from '@playwright/test'
 
 export type FieldRoot = Page | Locator
 
-function resolvePage(root: FieldRoot): Page {
-  return 'page' in root ? root.page() : root
+abstract class FieldBase {
+  constructor(
+    protected readonly root: FieldRoot,
+    protected readonly testid: string,
+  ) {}
+
+  protected locator(): Locator {
+    return this.root.getByTestId(this.testid)
+  }
+
+  protected page(): Page {
+    return 'page' in this.root ? this.root.page() : this.root
+  }
 }
 
 // ─── Plain text / textarea / number ───────────────────────────────────────────
 
-export async function fillText(root: FieldRoot, testid: string, value: string): Promise<void> {
-  await root.getByTestId(testid).fill(value)
+export class TextField extends FieldBase {
+  async fill(value: string): Promise<void> {
+    await this.locator().fill(value)
+  }
+
+  async clear(): Promise<void> {
+    await this.locator().fill('')
+  }
 }
 
-export async function clearText(root: FieldRoot, testid: string): Promise<void> {
-  await root.getByTestId(testid).fill('')
+export class TextareaField extends FieldBase {
+  async fill(value: string): Promise<void> {
+    await this.locator().fill(value)
+  }
 }
 
-export async function fillTextarea(root: FieldRoot, testid: string, value: string): Promise<void> {
-  await root.getByTestId(testid).fill(value)
-}
-
-export async function fillNumber(
-  root: FieldRoot,
-  testid: string,
-  value: number | string,
-): Promise<void> {
-  await root.getByTestId(testid).fill(String(value))
+export class NumberField extends FieldBase {
+  async fill(value: number | string): Promise<void> {
+    await this.locator().fill(String(value))
+  }
 }
 
 // ─── CurrencyInput (custom keydown handler — only per-key presses work) ──────
 
-export async function fillCurrencyCents(
-  root: FieldRoot,
-  testid: string,
-  cents: number,
-): Promise<void> {
-  const input = root.getByTestId(testid)
-  await input.click()
-  for (const digit of String(cents)) {
-    await input.press(digit)
+export class CurrencyField extends FieldBase {
+  async fillCents(cents: number): Promise<void> {
+    const input = this.locator()
+    await input.click()
+    for (const digit of String(cents)) {
+      await input.press(digit)
+    }
   }
-}
 
-export async function clearAndFillCurrencyCents(
-  root: FieldRoot,
-  testid: string,
-  cents: number,
-): Promise<void> {
-  const input = root.getByTestId(testid)
-  await input.click()
-  await input.press('Control+a')
-  for (const digit of String(cents)) {
-    await input.press(digit)
+  async clearAndFillCents(cents: number): Promise<void> {
+    const input = this.locator()
+    await input.click()
+    await input.press('Control+a')
+    for (const digit of String(cents)) {
+      await input.press(digit)
+    }
   }
 }
 
 // ─── Date / Month picker ──────────────────────────────────────────────────────
 
 /**
- * Type a date directly into a Mantine `DateInput`.
- * Pass it in the format the input expects (component default is DD/MM/YYYY).
- * Tabs out to commit the value and close the popover.
+ * Wraps a Mantine `DateInput`. Pass the date in the format the input expects
+ * (component default is DD/MM/YYYY). Tabs out to commit and close the popover.
  */
-export async function fillDateInput(
-  root: FieldRoot,
-  testid: string,
-  formattedDate: string,
-): Promise<void> {
-  const input = root.getByTestId(testid)
-  await input.click()
-  await input.fill(formattedDate)
-  await input.press('Tab')
+export class DateField extends FieldBase {
+  async fill(formattedDate: string): Promise<void> {
+    const input = this.locator()
+    await input.click()
+    await input.fill(formattedDate)
+    await input.press('Tab')
+  }
 }
 
 // ─── Select (Mantine combobox) ────────────────────────────────────────────────
 
-interface SelectOptionParams {
+interface SelectPickOptions {
   /**
    * Optional text to type into the search-enabled combobox before clicking
    * the option. Use when the option list is virtualised or long; otherwise
@@ -101,80 +110,74 @@ interface SelectOptionParams {
 }
 
 /**
- * Pick an option from a Mantine `Select` by clicking its `optionTestId`.
- *
- * The component must instrument its option via `renderOption` with the
- * matching `data-testid`. Helpers do not fall back to `getByRole('option', { name })`
- * — that path is forbidden by the testid-only selector policy.
+ * Wraps a Mantine `Select`. The component must instrument its option via
+ * `renderOption` with the matching `data-testid` — this class does not fall
+ * back to `getByRole('option', { name })` (forbidden by the testid-only
+ * selector policy).
  */
-export async function selectOption(
-  root: FieldRoot,
-  triggerTestId: string,
-  optionTestId: string,
-  params: SelectOptionParams = {},
-): Promise<void> {
-  const trigger = root.getByTestId(triggerTestId)
-  await trigger.click()
-  if (params.search) {
-    await trigger.fill(params.search)
+export class SelectField extends FieldBase {
+  /** Click the trigger, then click the option whose testid matches. */
+  async pick(optionTestId: string, opts: SelectPickOptions = {}): Promise<void> {
+    const trigger = this.locator()
+    await trigger.click()
+    if (opts.search) {
+      await trigger.fill(opts.search)
+    }
+    // Mantine renders Select options in a portal attached to <body>, so resolve
+    // the option locator from the Page rather than from `root`.
+    await this.page().getByTestId(optionTestId).click()
   }
-  // Mantine renders Select options in a portal attached to <body>, so resolve
-  // the option locator from the Page rather than from `root`.
-  await resolvePage(root).getByTestId(optionTestId).click()
 }
 
 // ─── TagsInput (multi) ────────────────────────────────────────────────────────
 
 /**
- * Add multiple tags to a Mantine `TagsInput`. Presses `Enter` after each tag,
- * which both creates new tags and confirms suggestions.
+ * Wraps a Mantine `TagsInput`. Presses `Enter` after each tag, which both
+ * creates new tags and confirms suggestions.
  */
-export async function fillTagsInput(
-  root: FieldRoot,
-  testid: string,
-  values: string[],
-): Promise<void> {
-  const input = root.getByTestId(testid)
-  await input.click()
-  for (const tag of values) {
-    await input.fill(tag)
-    await input.press('Enter')
+export class TagsField extends FieldBase {
+  async add(values: string[]): Promise<void> {
+    const input = this.locator()
+    await input.click()
+    for (const tag of values) {
+      await input.fill(tag)
+      await input.press('Enter')
+    }
   }
 }
 
 // ─── Radio / Checkbox / Switch ────────────────────────────────────────────────
 
-export async function pickRadio(root: FieldRoot, testid: string): Promise<void> {
-  await root.getByTestId(testid).check()
+/** A single Mantine `Radio` already scoped to its own testid. */
+export class RadioField extends FieldBase {
+  async pick(): Promise<void> {
+    await this.locator().check()
+  }
 }
 
-export async function setCheckbox(
-  root: FieldRoot,
-  testid: string,
-  checked: boolean,
-): Promise<void> {
-  await root.getByTestId(testid).setChecked(checked)
+export class CheckboxField extends FieldBase {
+  async set(checked: boolean): Promise<void> {
+    await this.locator().setChecked(checked)
+  }
 }
 
-export async function setSwitch(root: FieldRoot, testid: string, on: boolean): Promise<void> {
-  await root.getByTestId(testid).setChecked(on)
+export class SwitchField extends FieldBase {
+  async set(on: boolean): Promise<void> {
+    await this.locator().setChecked(on)
+  }
 }
 
 // ─── SegmentedControl ─────────────────────────────────────────────────────────
 
 /**
- * Click an option inside a Mantine `SegmentedControl`.
- *
- * The component must render each item's `label` as JSX carrying the
- * `optionTestId`, e.g.
+ * Wraps a Mantine `SegmentedControl`. The component must render each item's
+ * `label` as JSX carrying the `optionTestId`, e.g.
  *   `{ value: 'expense', label: <span data-testid={...}>Despesa</span> }`.
  */
-export async function pickSegmented(
-  root: FieldRoot,
-  segmentedTestId: string,
-  optionTestId: string,
-): Promise<void> {
-  await root.getByTestId(segmentedTestId).getByTestId(optionTestId).click()
+export class SegmentedField extends FieldBase {
+  async pick(optionTestId: string): Promise<void> {
+    await this.locator().getByTestId(optionTestId).click()
+  }
 }
 
 // ─── FileInput ────────────────────────────────────────────────────────────────
@@ -187,10 +190,8 @@ export interface FilePayload {
 
 export type FileInputContent = string | string[] | FilePayload | FilePayload[]
 
-export async function setFileInput(
-  root: FieldRoot,
-  testid: string,
-  files: FileInputContent,
-): Promise<void> {
-  await root.getByTestId(testid).setInputFiles(files)
+export class FileField extends FieldBase {
+  async set(files: FileInputContent): Promise<void> {
+    await this.locator().setInputFiles(files)
+  }
 }

--- a/frontend/e2e/helpers/formFields.ts
+++ b/frontend/e2e/helpers/formFields.ts
@@ -1,0 +1,196 @@
+/**
+ * Form-field interaction helpers for Playwright e2e tests.
+ *
+ * Encapsulate the Mantine-specific quirks (CurrencyInput keydown loop,
+ * combobox option portals, SegmentedControl item targeting) so Page Objects
+ * stay short and tests don't drift back to fragile `getByRole('option')` /
+ * `getByText(label)` patterns.
+ *
+ * Conventions:
+ * - All helpers take `root: Page | Locator` first to scope inside drawers/forms.
+ * - Helpers that resolve portalled content (Select dropdown options) extract
+ *   the `Page` from `root` internally.
+ * - Selects and Segmented controls take an option `testid` — never a label —
+ *   per `frontend/CLAUDE.md` selectors policy.
+ */
+
+import { type Page, type Locator } from '@playwright/test'
+
+export type FieldRoot = Page | Locator
+
+function resolvePage(root: FieldRoot): Page {
+  return 'page' in root ? root.page() : root
+}
+
+// ─── Plain text / textarea / number ───────────────────────────────────────────
+
+export async function fillText(root: FieldRoot, testid: string, value: string): Promise<void> {
+  await root.getByTestId(testid).fill(value)
+}
+
+export async function clearText(root: FieldRoot, testid: string): Promise<void> {
+  await root.getByTestId(testid).fill('')
+}
+
+export async function fillTextarea(root: FieldRoot, testid: string, value: string): Promise<void> {
+  await root.getByTestId(testid).fill(value)
+}
+
+export async function fillNumber(
+  root: FieldRoot,
+  testid: string,
+  value: number | string,
+): Promise<void> {
+  await root.getByTestId(testid).fill(String(value))
+}
+
+// ─── CurrencyInput (custom keydown handler — only per-key presses work) ──────
+
+export async function fillCurrencyCents(
+  root: FieldRoot,
+  testid: string,
+  cents: number,
+): Promise<void> {
+  const input = root.getByTestId(testid)
+  await input.click()
+  for (const digit of String(cents)) {
+    await input.press(digit)
+  }
+}
+
+export async function clearAndFillCurrencyCents(
+  root: FieldRoot,
+  testid: string,
+  cents: number,
+): Promise<void> {
+  const input = root.getByTestId(testid)
+  await input.click()
+  await input.press('Control+a')
+  for (const digit of String(cents)) {
+    await input.press(digit)
+  }
+}
+
+// ─── Date / Month picker ──────────────────────────────────────────────────────
+
+/**
+ * Type a date directly into a Mantine `DateInput`.
+ * Pass it in the format the input expects (component default is DD/MM/YYYY).
+ * Tabs out to commit the value and close the popover.
+ */
+export async function fillDateInput(
+  root: FieldRoot,
+  testid: string,
+  formattedDate: string,
+): Promise<void> {
+  const input = root.getByTestId(testid)
+  await input.click()
+  await input.fill(formattedDate)
+  await input.press('Tab')
+}
+
+// ─── Select (Mantine combobox) ────────────────────────────────────────────────
+
+interface SelectOptionParams {
+  /**
+   * Optional text to type into the search-enabled combobox before clicking
+   * the option. Use when the option list is virtualised or long; otherwise
+   * leave undefined and the helper just clicks the testid.
+   */
+  search?: string
+}
+
+/**
+ * Pick an option from a Mantine `Select` by clicking its `optionTestId`.
+ *
+ * The component must instrument its option via `renderOption` with the
+ * matching `data-testid`. Helpers do not fall back to `getByRole('option', { name })`
+ * — that path is forbidden by the testid-only selector policy.
+ */
+export async function selectOption(
+  root: FieldRoot,
+  triggerTestId: string,
+  optionTestId: string,
+  params: SelectOptionParams = {},
+): Promise<void> {
+  const trigger = root.getByTestId(triggerTestId)
+  await trigger.click()
+  if (params.search) {
+    await trigger.fill(params.search)
+  }
+  // Mantine renders Select options in a portal attached to <body>, so resolve
+  // the option locator from the Page rather than from `root`.
+  await resolvePage(root).getByTestId(optionTestId).click()
+}
+
+// ─── TagsInput (multi) ────────────────────────────────────────────────────────
+
+/**
+ * Add multiple tags to a Mantine `TagsInput`. Presses `Enter` after each tag,
+ * which both creates new tags and confirms suggestions.
+ */
+export async function fillTagsInput(
+  root: FieldRoot,
+  testid: string,
+  values: string[],
+): Promise<void> {
+  const input = root.getByTestId(testid)
+  await input.click()
+  for (const tag of values) {
+    await input.fill(tag)
+    await input.press('Enter')
+  }
+}
+
+// ─── Radio / Checkbox / Switch ────────────────────────────────────────────────
+
+export async function pickRadio(root: FieldRoot, testid: string): Promise<void> {
+  await root.getByTestId(testid).check()
+}
+
+export async function setCheckbox(
+  root: FieldRoot,
+  testid: string,
+  checked: boolean,
+): Promise<void> {
+  await root.getByTestId(testid).setChecked(checked)
+}
+
+export async function setSwitch(root: FieldRoot, testid: string, on: boolean): Promise<void> {
+  await root.getByTestId(testid).setChecked(on)
+}
+
+// ─── SegmentedControl ─────────────────────────────────────────────────────────
+
+/**
+ * Click an option inside a Mantine `SegmentedControl`.
+ *
+ * The component must render each item's `label` as JSX carrying the
+ * `optionTestId`, e.g.
+ *   `{ value: 'expense', label: <span data-testid={...}>Despesa</span> }`.
+ */
+export async function pickSegmented(
+  root: FieldRoot,
+  segmentedTestId: string,
+  optionTestId: string,
+): Promise<void> {
+  await root.getByTestId(segmentedTestId).getByTestId(optionTestId).click()
+}
+
+// ─── FileInput ────────────────────────────────────────────────────────────────
+
+export interface FilePayload {
+  name: string
+  mimeType: string
+  buffer: Buffer
+}
+
+export type FileInputContent = string | string[] | FilePayload | FilePayload[]
+
+export async function setFileInput(
+  root: FieldRoot,
+  testid: string,
+  files: FileInputContent,
+): Promise<void> {
+  await root.getByTestId(testid).setInputFiles(files)
+}

--- a/frontend/e2e/pages/AccountsPage.ts
+++ b/frontend/e2e/pages/AccountsPage.ts
@@ -1,5 +1,6 @@
 import { type Page, type Locator, expect } from '@playwright/test'
 import { AccountsTestIds } from '@/testIds'
+import { fillCurrencyCents, fillText } from '../helpers/formFields'
 
 export class AccountsPage {
   readonly page: Page
@@ -22,13 +23,9 @@ export class AccountsPage {
 
   async fillForm(name: string, balanceCents = 0) {
     const form = this.page.getByTestId(AccountsTestIds.Form)
-    await form.getByTestId(AccountsTestIds.InputName).fill(name)
+    await fillText(form, AccountsTestIds.InputName, name)
     if (balanceCents !== 0) {
-      const balanceInput = form.getByTestId(AccountsTestIds.InputInitialBalance)
-      await balanceInput.click()
-      for (const digit of String(balanceCents)) {
-        await balanceInput.press(digit)
-      }
+      await fillCurrencyCents(form, AccountsTestIds.InputInitialBalance, balanceCents)
     }
   }
 

--- a/frontend/e2e/pages/AccountsPage.ts
+++ b/frontend/e2e/pages/AccountsPage.ts
@@ -1,6 +1,6 @@
 import { type Page, type Locator, expect } from '@playwright/test'
 import { AccountsTestIds } from '@/testIds'
-import { fillCurrencyCents, fillText } from '../helpers/formFields'
+import { CurrencyField, TextField } from '../helpers/formFields'
 
 export class AccountsPage {
   readonly page: Page
@@ -23,9 +23,9 @@ export class AccountsPage {
 
   async fillForm(name: string, balanceCents = 0) {
     const form = this.page.getByTestId(AccountsTestIds.Form)
-    await fillText(form, AccountsTestIds.InputName, name)
+    await new TextField(form, AccountsTestIds.InputName).fill(name)
     if (balanceCents !== 0) {
-      await fillCurrencyCents(form, AccountsTestIds.InputInitialBalance, balanceCents)
+      await new CurrencyField(form, AccountsTestIds.InputInitialBalance).fillCents(balanceCents)
     }
   }
 

--- a/frontend/e2e/pages/CategoriesPage.ts
+++ b/frontend/e2e/pages/CategoriesPage.ts
@@ -1,6 +1,6 @@
 import { type Page, type Locator, expect } from '@playwright/test'
 import { CategoriesTestIds } from '@/testIds'
-import { fillText } from '../helpers/formFields'
+import { TextField } from '../helpers/formFields'
 
 export class CategoriesPage {
   readonly page: Page
@@ -26,7 +26,7 @@ export class CategoriesPage {
 
     const input = this.page.getByTestId(CategoriesTestIds.InputNewName)
     await expect(input).toBeVisible()
-    await fillText(this.page, CategoriesTestIds.InputNewName, name)
+    await new TextField(this.page, CategoriesTestIds.InputNewName).fill(name)
     await input.press('Enter')
     await expect(this.page.getByText(name)).toBeVisible()
   }
@@ -36,7 +36,7 @@ export class CategoriesPage {
 
     const input = this.page.getByTestId(CategoriesTestIds.InputNewName)
     await expect(input).toBeVisible()
-    await fillText(this.page, CategoriesTestIds.InputNewName, childName)
+    await new TextField(this.page, CategoriesTestIds.InputNewName).fill(childName)
     await input.press('Enter')
     await expect(this.page.getByText(childName)).toBeVisible()
   }
@@ -46,7 +46,7 @@ export class CategoriesPage {
 
     const input = this.page.getByTestId(CategoriesTestIds.InputName)
     await expect(input).toBeVisible()
-    await fillText(this.page, CategoriesTestIds.InputName, newName)
+    await new TextField(this.page, CategoriesTestIds.InputName).fill(newName)
     await input.press('Enter')
     await expect(this.page.getByText(newName)).toBeVisible()
   }

--- a/frontend/e2e/pages/CategoriesPage.ts
+++ b/frontend/e2e/pages/CategoriesPage.ts
@@ -1,5 +1,6 @@
 import { type Page, type Locator, expect } from '@playwright/test'
 import { CategoriesTestIds } from '@/testIds'
+import { fillText } from '../helpers/formFields'
 
 export class CategoriesPage {
   readonly page: Page
@@ -25,7 +26,7 @@ export class CategoriesPage {
 
     const input = this.page.getByTestId(CategoriesTestIds.InputNewName)
     await expect(input).toBeVisible()
-    await input.fill(name)
+    await fillText(this.page, CategoriesTestIds.InputNewName, name)
     await input.press('Enter')
     await expect(this.page.getByText(name)).toBeVisible()
   }
@@ -35,7 +36,7 @@ export class CategoriesPage {
 
     const input = this.page.getByTestId(CategoriesTestIds.InputNewName)
     await expect(input).toBeVisible()
-    await input.fill(childName)
+    await fillText(this.page, CategoriesTestIds.InputNewName, childName)
     await input.press('Enter')
     await expect(this.page.getByText(childName)).toBeVisible()
   }
@@ -45,7 +46,7 @@ export class CategoriesPage {
 
     const input = this.page.getByTestId(CategoriesTestIds.InputName)
     await expect(input).toBeVisible()
-    await input.fill(newName)
+    await fillText(this.page, CategoriesTestIds.InputName, newName)
     await input.press('Enter')
     await expect(this.page.getByText(newName)).toBeVisible()
   }

--- a/frontend/e2e/pages/ChargesPage.ts
+++ b/frontend/e2e/pages/ChargesPage.ts
@@ -1,5 +1,11 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-import { ChargesTestIds, CommonTestIds } from '@/testIds'
+import { ChargesTestIds, CommonTestIds, type ChargeRole } from '@/testIds'
+import {
+  fillNumber,
+  fillTextarea,
+  pickRadio,
+  selectOption,
+} from '../helpers/formFields'
 
 export class ChargesPage {
   readonly page: Page;
@@ -63,33 +69,39 @@ export class ChargesPage {
   }
 
   async fillCreateForm(opts: {
-    accountName: string;
-    role: "charger" | "payer";
+    accountId: number;
+    connectionId?: number;
+    role: ChargeRole;
     description?: string;
     amount?: number;
   }) {
-    // If the connection dropdown is visible (multiple connections or accounts still loading),
-    // select the first available option so connection_id gets set.
-    const connectionSelect = this.createDrawer.getByTestId(ChargesTestIds.SelectConnection);
-    if (await connectionSelect.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await connectionSelect.click();
-      await this.page.getByRole("option").first().click();
+    if (opts.connectionId != null) {
+      await selectOption(
+        this.createDrawer,
+        ChargesTestIds.SelectConnection,
+        ChargesTestIds.OptionConnection(opts.connectionId),
+      );
     }
 
-    const accountSelect = this.createDrawer.getByTestId(ChargesTestIds.SelectMyAccount);
-    await accountSelect.click();
-    await this.page.getByRole("option", { name: opts.accountName }).click();
+    await selectOption(
+      this.createDrawer,
+      ChargesTestIds.SelectMyAccount,
+      ChargesTestIds.OptionMyAccount(opts.accountId),
+    );
 
-    const radioTestId = opts.role === "charger" ? "radio_role_charger" : "radio_role_payer";
-    await this.createDrawer.getByTestId(radioTestId).check();
+    await pickRadio(this.createDrawer, ChargesTestIds.RadioRole(opts.role));
 
     if (opts.amount != null) {
-      const amountInput = this.createDrawer.getByTestId(ChargesTestIds.InputAmount);
-      await amountInput.fill(opts.amount.toFixed(2).replace(".", ","));
+      // Mantine NumberInput uses comma as the decimal separator (locale pt-BR).
+      await fillNumber(
+        this.createDrawer,
+        ChargesTestIds.InputAmount,
+        opts.amount.toFixed(2).replace('.', ','),
+      );
     }
 
     if (opts.description) {
-      await this.createDrawer.getByTestId(ChargesTestIds.InputDescription).fill(opts.description);
+      await fillTextarea(this.createDrawer, ChargesTestIds.InputDescription, opts.description);
     }
   }
 
@@ -105,10 +117,12 @@ export class ChargesPage {
     await expect(this.acceptDrawer).toBeVisible({ timeout: 5000 });
   }
 
-  async fillAcceptForm(accountName: string) {
-    const accountSelect = this.acceptDrawer.getByTestId(ChargesTestIds.SelectAcceptAccount);
-    await accountSelect.click();
-    await this.page.getByRole("option", { name: accountName }).click();
+  async fillAcceptForm(accountId: number) {
+    await selectOption(
+      this.acceptDrawer,
+      ChargesTestIds.SelectAcceptAccount,
+      ChargesTestIds.OptionAcceptAccount(accountId),
+    );
   }
 
   async submitAccept() {

--- a/frontend/e2e/pages/ChargesPage.ts
+++ b/frontend/e2e/pages/ChargesPage.ts
@@ -70,12 +70,19 @@ export class ChargesPage {
 
   async fillCreateForm(opts: {
     accountId: number;
-    connectionId?: number;
+    connectionId: number;
     role: ChargeRole;
     description?: string;
     amount?: number;
   }) {
-    if (opts.connectionId != null) {
+    // The drawer hides the connection Select when there's exactly one
+    // connection (`singleConnection` branch). But on a cold render `useAccounts`
+    // hasn't resolved when the form's `defaultValues` are computed, so the
+    // Select can render briefly even for single-connection users — leaving
+    // `connection_id` undefined unless we click it. Probe visibility and pick
+    // the requested connection's option only if the Select actually rendered.
+    const connectionSelect = this.createDrawer.getByTestId(ChargesTestIds.SelectConnection);
+    if (await connectionSelect.isVisible({ timeout: 1000 }).catch(() => false)) {
       await selectOption(
         this.createDrawer,
         ChargesTestIds.SelectConnection,

--- a/frontend/e2e/pages/ChargesPage.ts
+++ b/frontend/e2e/pages/ChargesPage.ts
@@ -1,10 +1,10 @@
 import { type Page, type Locator, expect } from "@playwright/test";
 import { ChargesTestIds, CommonTestIds, type ChargeRole } from '@/testIds'
 import {
-  fillNumber,
-  fillTextarea,
-  pickRadio,
-  selectOption,
+  NumberField,
+  RadioField,
+  SelectField,
+  TextareaField,
 } from '../helpers/formFields'
 
 export class ChargesPage {
@@ -83,32 +83,28 @@ export class ChargesPage {
     // the requested connection's option only if the Select actually rendered.
     const connectionSelect = this.createDrawer.getByTestId(ChargesTestIds.SelectConnection);
     if (await connectionSelect.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await selectOption(
-        this.createDrawer,
-        ChargesTestIds.SelectConnection,
+      await new SelectField(this.createDrawer, ChargesTestIds.SelectConnection).pick(
         ChargesTestIds.OptionConnection(opts.connectionId),
       );
     }
 
-    await selectOption(
-      this.createDrawer,
-      ChargesTestIds.SelectMyAccount,
+    await new SelectField(this.createDrawer, ChargesTestIds.SelectMyAccount).pick(
       ChargesTestIds.OptionMyAccount(opts.accountId),
     );
 
-    await pickRadio(this.createDrawer, ChargesTestIds.RadioRole(opts.role));
+    await new RadioField(this.createDrawer, ChargesTestIds.RadioRole(opts.role)).pick();
 
     if (opts.amount != null) {
       // Mantine NumberInput uses comma as the decimal separator (locale pt-BR).
-      await fillNumber(
-        this.createDrawer,
-        ChargesTestIds.InputAmount,
+      await new NumberField(this.createDrawer, ChargesTestIds.InputAmount).fill(
         opts.amount.toFixed(2).replace('.', ','),
       );
     }
 
     if (opts.description) {
-      await fillTextarea(this.createDrawer, ChargesTestIds.InputDescription, opts.description);
+      await new TextareaField(this.createDrawer, ChargesTestIds.InputDescription).fill(
+        opts.description,
+      );
     }
   }
 
@@ -125,9 +121,7 @@ export class ChargesPage {
   }
 
   async fillAcceptForm(accountId: number) {
-    await selectOption(
-      this.acceptDrawer,
-      ChargesTestIds.SelectAcceptAccount,
+    await new SelectField(this.acceptDrawer, ChargesTestIds.SelectAcceptAccount).pick(
       ChargesTestIds.OptionAcceptAccount(accountId),
     );
   }

--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -1,5 +1,20 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-import { AccountsTestIds, CategoriesTestIds, ImportTestIds, RecurrenceTestIds, TransactionsTestIds } from '@/testIds'
+import {
+  AccountsTestIds,
+  CategoriesTestIds,
+  ImportTestIds,
+  RecurrenceTestIds,
+  TransactionsTestIds,
+  type ImportRowAction,
+  type RecurrenceType,
+} from '@/testIds'
+import {
+  fillNumber,
+  selectOption,
+  setFileInput,
+  fillText,
+} from '../helpers/formFields'
+
 export class ImportPage {
   readonly page: Page;
   readonly uploadStep: Locator;
@@ -26,18 +41,18 @@ export class ImportPage {
     await expect(this.uploadStep).toBeVisible({ timeout: 8000 });
   }
 
-  /** Select the account in the upload step (Mantine Select is readonly, use click+option). */
-  async selectAccount(accountName: string) {
-    const input = this.uploadStep.getByTestId(ImportTestIds.SelectAccount);
-    await input.click();
-    // Mantine Select options are portalled — documented escape (see Phase 7 plan).
-    await this.page.getByRole("option", { name: accountName }).click();
+  /** Select the account in the upload step. */
+  async selectAccount(accountId: number) {
+    await selectOption(
+      this.uploadStep,
+      ImportTestIds.SelectAccount,
+      ImportTestIds.OptionAccount(accountId),
+    );
   }
 
   /** Upload a CSV file by writing content into the hidden file input. */
   async uploadCSVContent(csvContent: string) {
-    const fileInput = this.uploadStep.getByTestId(ImportTestIds.InputCsvFile);
-    await fileInput.setInputFiles({
+    await setFileInput(this.uploadStep, ImportTestIds.InputCsvFile, {
       name: "import.csv",
       mimeType: "text/csv",
       buffer: Buffer.from(csvContent, "utf-8"),
@@ -51,8 +66,8 @@ export class ImportPage {
   }
 
   /** Full upload flow: select account, upload CSV, submit. */
-  async uploadCSV(csvContent: string, accountName: string) {
-    await this.selectAccount(accountName);
+  async uploadCSV(csvContent: string, accountId: number) {
+    await this.selectAccount(accountId);
     await this.uploadCSVContent(csvContent);
     await this.submitUpload();
   }
@@ -115,11 +130,12 @@ export class ImportPage {
   }
 
   /** Set the category for a row via the searchable category select. */
-  async setRowCategory(rowIndex: number, categoryName: string) {
-    const select = this.reviewStep.getByTestId(ImportTestIds.RowSelectCategory(rowIndex));
-    await select.click();
-    await select.fill(categoryName);
-    await this.page.getByRole("option", { name: categoryName }).click();
+  async setRowCategory(rowIndex: number, categoryId: number) {
+    await selectOption(
+      this.reviewStep,
+      ImportTestIds.RowSelectCategory(rowIndex),
+      ImportTestIds.RowOptionCategory(rowIndex, categoryId),
+    );
   }
 
   /** Click the + button next to the category select to open the category creation drawer. */
@@ -181,7 +197,7 @@ export class ImportPage {
   /** Create a new account inside the account drawer. */
   async createAccountInDrawer(name: string) {
     const form = this.page.getByTestId(AccountsTestIds.Form);
-    await form.getByTestId(AccountsTestIds.InputName).fill(name);
+    await fillText(form, AccountsTestIds.InputName, name);
     await form.getByTestId(AccountsTestIds.BtnSave).click();
     await expect(form).not.toBeVisible({ timeout: 10000 });
   }
@@ -214,15 +230,12 @@ export class ImportPage {
   }
 
   /** Change the action for a row via the action select. */
-  async setRowAction(rowIndex: number, action: "import" | "skip" | "duplicate") {
-    const labels: Record<string, string> = {
-      import: "Importar",
-      skip: "Não importar",
-      duplicate: "Duplicado",
-    };
-    const select = this.reviewStep.getByTestId(ImportTestIds.RowSelectAction(rowIndex));
-    await select.click();
-    await this.page.getByRole("option", { name: labels[action] }).click();
+  async setRowAction(rowIndex: number, action: ImportRowAction) {
+    await selectOption(
+      this.reviewStep,
+      ImportTestIds.RowSelectAction(rowIndex),
+      ImportTestIds.RowOptionAction(rowIndex, action),
+    );
   }
 
   /** Check whether a row's action select shows a particular value (by visible label). */
@@ -238,7 +251,7 @@ export class ImportPage {
    */
   async setRowInstallments(
     rowIndex: number,
-    opts: { type: "monthly" | "weekly" | "daily" | "yearly"; current: number; total: number },
+    opts: { type: RecurrenceType; current: number; total: number },
   ) {
     const btn = this.reviewStep.getByTestId(ImportTestIds.RowBtnRecurrencePopover(rowIndex));
     await btn.click();
@@ -246,24 +259,13 @@ export class ImportPage {
     const dropdown = this.page.getByTestId(ImportTestIds.RecurrencePopoverDropdown(rowIndex));
     await expect(dropdown).toBeVisible({ timeout: 5000 });
 
-    // Select frequency type
-    const typeSelect = dropdown.getByTestId(RecurrenceTestIds.TypeSelect);
-    await typeSelect.click();
-    const typeLabels: Record<string, string> = {
-      monthly: "Mensal",
-      weekly: "Semanal",
-      daily: "Diário",
-      yearly: "Anual",
-    };
-    await this.page.getByRole("option", { name: typeLabels[opts.type] }).click();
-
-    // Fill current installment
-    const currentInput = dropdown.getByTestId(RecurrenceTestIds.CurrentInstallmentInput);
-    await currentInput.fill(String(opts.current));
-
-    // Fill total installments
-    const totalInput = dropdown.getByTestId(RecurrenceTestIds.TotalInstallmentsInput);
-    await totalInput.fill(String(opts.total));
+    await selectOption(
+      dropdown,
+      RecurrenceTestIds.TypeSelect,
+      RecurrenceTestIds.OptionType(opts.type),
+    );
+    await fillNumber(dropdown, RecurrenceTestIds.CurrentInstallmentInput, opts.current);
+    await fillNumber(dropdown, RecurrenceTestIds.TotalInstallmentsInput, opts.total);
 
     // Dismiss the popover with Escape so onClose fires and syncs values to the parent form.
     // Using keyboard is more reliable than position-based clicks inside a trapFocus popover.

--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -8,12 +8,7 @@ import {
   type ImportRowAction,
   type RecurrenceType,
 } from '@/testIds'
-import {
-  fillNumber,
-  selectOption,
-  setFileInput,
-  fillText,
-} from '../helpers/formFields'
+import { FileField, NumberField, SelectField, TextField } from '../helpers/formFields'
 
 export class ImportPage {
   readonly page: Page;
@@ -43,16 +38,14 @@ export class ImportPage {
 
   /** Select the account in the upload step. */
   async selectAccount(accountId: number) {
-    await selectOption(
-      this.uploadStep,
-      ImportTestIds.SelectAccount,
+    await new SelectField(this.uploadStep, ImportTestIds.SelectAccount).pick(
       ImportTestIds.OptionAccount(accountId),
     );
   }
 
   /** Upload a CSV file by writing content into the hidden file input. */
   async uploadCSVContent(csvContent: string) {
-    await setFileInput(this.uploadStep, ImportTestIds.InputCsvFile, {
+    await new FileField(this.uploadStep, ImportTestIds.InputCsvFile).set({
       name: "import.csv",
       mimeType: "text/csv",
       buffer: Buffer.from(csvContent, "utf-8"),
@@ -131,9 +124,7 @@ export class ImportPage {
 
   /** Set the category for a row via the searchable category select. */
   async setRowCategory(rowIndex: number, categoryId: number) {
-    await selectOption(
-      this.reviewStep,
-      ImportTestIds.RowSelectCategory(rowIndex),
+    await new SelectField(this.reviewStep, ImportTestIds.RowSelectCategory(rowIndex)).pick(
       ImportTestIds.RowOptionCategory(rowIndex, categoryId),
     );
   }
@@ -197,7 +188,7 @@ export class ImportPage {
   /** Create a new account inside the account drawer. */
   async createAccountInDrawer(name: string) {
     const form = this.page.getByTestId(AccountsTestIds.Form);
-    await fillText(form, AccountsTestIds.InputName, name);
+    await new TextField(form, AccountsTestIds.InputName).fill(name);
     await form.getByTestId(AccountsTestIds.BtnSave).click();
     await expect(form).not.toBeVisible({ timeout: 10000 });
   }
@@ -231,9 +222,7 @@ export class ImportPage {
 
   /** Change the action for a row via the action select. */
   async setRowAction(rowIndex: number, action: ImportRowAction) {
-    await selectOption(
-      this.reviewStep,
-      ImportTestIds.RowSelectAction(rowIndex),
+    await new SelectField(this.reviewStep, ImportTestIds.RowSelectAction(rowIndex)).pick(
       ImportTestIds.RowOptionAction(rowIndex, action),
     );
   }
@@ -259,13 +248,11 @@ export class ImportPage {
     const dropdown = this.page.getByTestId(ImportTestIds.RecurrencePopoverDropdown(rowIndex));
     await expect(dropdown).toBeVisible({ timeout: 5000 });
 
-    await selectOption(
-      dropdown,
-      RecurrenceTestIds.TypeSelect,
+    await new SelectField(dropdown, RecurrenceTestIds.TypeSelect).pick(
       RecurrenceTestIds.OptionType(opts.type),
     );
-    await fillNumber(dropdown, RecurrenceTestIds.CurrentInstallmentInput, opts.current);
-    await fillNumber(dropdown, RecurrenceTestIds.TotalInstallmentsInput, opts.total);
+    await new NumberField(dropdown, RecurrenceTestIds.CurrentInstallmentInput).fill(opts.current);
+    await new NumberField(dropdown, RecurrenceTestIds.TotalInstallmentsInput).fill(opts.total);
 
     // Dismiss the popover with Escape so onClose fires and syncs values to the parent form.
     // Using keyboard is more reliable than position-based clicks inside a trapFocus popover.

--- a/frontend/e2e/pages/TransactionsPage.ts
+++ b/frontend/e2e/pages/TransactionsPage.ts
@@ -1,5 +1,13 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-import { TransactionsTestIds, type PropagationOption } from '@/testIds'
+import { TransactionsTestIds, type PropagationOption, type TransactionType } from '@/testIds'
+import {
+  clearAndFillCurrencyCents,
+  fillCurrencyCents,
+  fillText,
+  pickSegmented,
+  selectOption,
+} from '../helpers/formFields'
+
 export class TransactionsPage {
   readonly page: Page;
   readonly formDrawer: Locator;
@@ -26,9 +34,12 @@ export class TransactionsPage {
   }
 
   async selectGroupBy(option: 'date' | 'category' | 'account') {
-    const labelMap: Record<string, string> = { date: 'Data', category: 'Categoria', account: 'Conta' }
-    await this.page.getByTestId(TransactionsTestIds.SegmentedGroupBy).getByText(labelMap[option]).click()
-    await this.page.waitForLoadState('networkidle')
+    await pickSegmented(
+      this.page,
+      TransactionsTestIds.SegmentedGroupBy,
+      TransactionsTestIds.SegmentGroupBy(option),
+    );
+    await this.page.waitForLoadState('networkidle');
   }
 
   /** Click the transaction row for the given transaction ID to open the update drawer. */
@@ -43,18 +54,16 @@ export class TransactionsPage {
 
   /** Clear the description input and type a new value. */
   async clearAndFillDescription(description: string) {
-    const input = this.updateDrawer.getByTestId(TransactionsTestIds.InputDescription);
-    await input.fill(description);
+    await fillText(this.updateDrawer, TransactionsTestIds.InputDescription, description);
   }
 
   /** Replace amount in the update form by selecting all and pressing digits. */
   async clearAndFillAmount(amountCents: number) {
-    const input = this.updateDrawer.getByTestId(TransactionsTestIds.InputAmount);
-    await input.click();
-    await input.press("Control+a");
-    for (const digit of String(amountCents)) {
-      await input.press(digit);
-    }
+    await clearAndFillCurrencyCents(
+      this.updateDrawer,
+      TransactionsTestIds.InputAmount,
+      amountCents,
+    );
   }
 
   /** Click save in the update drawer and wait for it to close. */
@@ -83,47 +92,36 @@ export class TransactionsPage {
     await expect(this.formDrawer).toBeVisible();
   }
 
-  async selectType(type: "expense" | "income" | "transfer") {
-    if (type === "expense") return;
-    const labels: Record<string, string> = {
-      income: "Receita",
-      transfer: "Transferência",
-    };
-    await this.page
-      .getByTestId(TransactionsTestIds.SegmentedTransactionType)
-      .getByText(labels[type])
-      .click();
+  async selectType(type: TransactionType) {
+    await pickSegmented(
+      this.formDrawer,
+      TransactionsTestIds.SegmentedTransactionType,
+      TransactionsTestIds.SegmentTransactionType(type),
+    );
   }
 
   async fillAmount(amountCents: number) {
-    const amountInput = this.page.getByTestId(TransactionsTestIds.InputAmount);
-    await amountInput.click();
-    for (const digit of String(amountCents)) {
-      await amountInput.press(digit);
-    }
+    await fillCurrencyCents(this.formDrawer, TransactionsTestIds.InputAmount, amountCents);
   }
 
   async fillDescription(description: string) {
-    await this.page.getByTestId(TransactionsTestIds.InputDescription).fill(description);
+    await fillText(this.formDrawer, TransactionsTestIds.InputDescription, description);
   }
 
-  async selectAccount(accountName: string) {
-    const input = this.page.getByTestId(TransactionsTestIds.SelectAccount);
-    await input.click();
-    await input.fill(accountName);
-    // Mantine Select options are portalled and aren't instrumented with a
-    // testid; getByRole('option') is the documented fallback until we switch
-    // Select consumers to renderOption with explicit testids.
-    await this.page.getByRole("option", { name: accountName }).click();
+  async selectAccount(accountId: number) {
+    await selectOption(
+      this.formDrawer,
+      TransactionsTestIds.SelectAccount,
+      TransactionsTestIds.OptionAccount(accountId),
+    );
   }
 
-  async selectCategory(categoryName: string) {
-    const input = this.page.getByTestId(TransactionsTestIds.SelectCategory);
-    await input.click();
-    await input.fill(categoryName);
-    await this.page
-      .getByRole("option", { name: new RegExp(categoryName) })
-      .click();
+  async selectCategory(categoryId: number) {
+    await selectOption(
+      this.formDrawer,
+      TransactionsTestIds.SelectCategory,
+      TransactionsTestIds.OptionCategory(categoryId),
+    );
   }
 
   async submitForm() {
@@ -134,47 +132,48 @@ export class TransactionsPage {
   async fillExpense(
     amountCents: number,
     description: string,
-    accountName: string,
-    categoryName: string
+    accountId: number,
+    categoryId: number,
   ) {
     await this.selectType("expense");
     await this.fillDescription(description);
     await this.fillAmount(amountCents);
-    await this.selectAccount(accountName);
-    await this.selectCategory(categoryName);
+    await this.selectAccount(accountId);
+    await this.selectCategory(categoryId);
   }
 
   async fillIncome(
     amountCents: number,
     description: string,
-    accountName: string,
-    categoryName: string
+    accountId: number,
+    categoryId: number,
   ) {
     await this.selectType("income");
     await this.fillDescription(description);
     await this.fillAmount(amountCents);
-    await this.selectAccount(accountName);
-    await this.selectCategory(categoryName);
+    await this.selectAccount(accountId);
+    await this.selectCategory(categoryId);
   }
 
-  async selectDestinationAccount(accountName: string) {
-    const input = this.page.getByTestId(TransactionsTestIds.SelectDestinationAccount);
-    await input.click();
-    await input.fill(accountName);
-    await this.page.getByRole("option", { name: accountName }).click();
+  async selectDestinationAccount(accountId: number) {
+    await selectOption(
+      this.formDrawer,
+      TransactionsTestIds.SelectDestinationAccount,
+      TransactionsTestIds.OptionDestinationAccount(accountId),
+    );
   }
 
   async fillTransfer(
     amountCents: number,
     description: string,
-    sourceAccountName: string,
-    destAccountName: string
+    sourceAccountId: number,
+    destAccountId: number,
   ) {
     await this.selectType("transfer");
     await this.fillDescription(description);
     await this.fillAmount(amountCents);
-    await this.selectAccount(sourceAccountName);
-    await this.selectDestinationAccount(destAccountName);
+    await this.selectAccount(sourceAccountId);
+    await this.selectDestinationAccount(destAccountId);
   }
 
   async selectTransaction(transactionId: number) {
@@ -201,16 +200,11 @@ export class TransactionsPage {
   }
 
   async selectPropagation(
-    option: "Somente esta" | "Esta e as próximas" | "Todas",
+    option: "current" | "current_and_future" | "all",
     action: "delete" | "update" = "delete"
   ) {
-    const valueMap: Record<string, PropagationOption> = {
-      "Somente esta": "current",
-      "Esta e as próximas": "current_and_future",
-      Todas: "all",
-    };
     await this.page
-      .getByTestId(TransactionsTestIds.PropagationOption(valueMap[option]))
+      .getByTestId(TransactionsTestIds.PropagationOption(option))
       .click();
     const confirmTestId = action === "delete" ? "btn_propagation_confirm" : "btn_propagation_confirm_update";
     await this.page.getByTestId(confirmTestId).click();

--- a/frontend/e2e/pages/TransactionsPage.ts
+++ b/frontend/e2e/pages/TransactionsPage.ts
@@ -1,11 +1,10 @@
 import { type Page, type Locator, expect } from "@playwright/test";
 import { TransactionsTestIds, type PropagationOption, type TransactionType } from '@/testIds'
 import {
-  clearAndFillCurrencyCents,
-  fillCurrencyCents,
-  fillText,
-  pickSegmented,
-  selectOption,
+  CurrencyField,
+  SegmentedField,
+  SelectField,
+  TextField,
 } from '../helpers/formFields'
 
 export class TransactionsPage {
@@ -34,9 +33,7 @@ export class TransactionsPage {
   }
 
   async selectGroupBy(option: 'date' | 'category' | 'account') {
-    await pickSegmented(
-      this.page,
-      TransactionsTestIds.SegmentedGroupBy,
+    await new SegmentedField(this.page, TransactionsTestIds.SegmentedGroupBy).pick(
       TransactionsTestIds.SegmentGroupBy(option),
     );
     await this.page.waitForLoadState('networkidle');
@@ -54,14 +51,12 @@ export class TransactionsPage {
 
   /** Clear the description input and type a new value. */
   async clearAndFillDescription(description: string) {
-    await fillText(this.updateDrawer, TransactionsTestIds.InputDescription, description);
+    await new TextField(this.updateDrawer, TransactionsTestIds.InputDescription).fill(description);
   }
 
   /** Replace amount in the update form by selecting all and pressing digits. */
   async clearAndFillAmount(amountCents: number) {
-    await clearAndFillCurrencyCents(
-      this.updateDrawer,
-      TransactionsTestIds.InputAmount,
+    await new CurrencyField(this.updateDrawer, TransactionsTestIds.InputAmount).clearAndFillCents(
       amountCents,
     );
   }
@@ -93,33 +88,29 @@ export class TransactionsPage {
   }
 
   async selectType(type: TransactionType) {
-    await pickSegmented(
-      this.formDrawer,
-      TransactionsTestIds.SegmentedTransactionType,
+    await new SegmentedField(this.formDrawer, TransactionsTestIds.SegmentedTransactionType).pick(
       TransactionsTestIds.SegmentTransactionType(type),
     );
   }
 
   async fillAmount(amountCents: number) {
-    await fillCurrencyCents(this.formDrawer, TransactionsTestIds.InputAmount, amountCents);
+    await new CurrencyField(this.formDrawer, TransactionsTestIds.InputAmount).fillCents(
+      amountCents,
+    );
   }
 
   async fillDescription(description: string) {
-    await fillText(this.formDrawer, TransactionsTestIds.InputDescription, description);
+    await new TextField(this.formDrawer, TransactionsTestIds.InputDescription).fill(description);
   }
 
   async selectAccount(accountId: number) {
-    await selectOption(
-      this.formDrawer,
-      TransactionsTestIds.SelectAccount,
+    await new SelectField(this.formDrawer, TransactionsTestIds.SelectAccount).pick(
       TransactionsTestIds.OptionAccount(accountId),
     );
   }
 
   async selectCategory(categoryId: number) {
-    await selectOption(
-      this.formDrawer,
-      TransactionsTestIds.SelectCategory,
+    await new SelectField(this.formDrawer, TransactionsTestIds.SelectCategory).pick(
       TransactionsTestIds.OptionCategory(categoryId),
     );
   }
@@ -156,9 +147,7 @@ export class TransactionsPage {
   }
 
   async selectDestinationAccount(accountId: number) {
-    await selectOption(
-      this.formDrawer,
-      TransactionsTestIds.SelectDestinationAccount,
+    await new SelectField(this.formDrawer, TransactionsTestIds.SelectDestinationAccount).pick(
       TransactionsTestIds.OptionDestinationAccount(accountId),
     );
   }
@@ -200,7 +189,7 @@ export class TransactionsPage {
   }
 
   async selectPropagation(
-    option: "current" | "current_and_future" | "all",
+    option: PropagationOption,
     action: "delete" | "update" = "delete"
   ) {
     await this.page

--- a/frontend/e2e/tests/bulk-delete-transactions.spec.ts
+++ b/frontend/e2e/tests/bulk-delete-transactions.spec.ts
@@ -109,7 +109,7 @@ test.describe('Bulk Delete Transactions', () => {
     await expect(transactionsPage.page.getByTestId(TransactionsTestIds.PropagationDrawerBody)).toBeVisible()
 
     // Choose "Somente esta" and confirm
-    await transactionsPage.selectPropagation('Somente esta')
+    await transactionsPage.selectPropagation('current')
 
     await transactionsPage.closeBulkDeleteDrawer()
     await transactionsPage.goto()

--- a/frontend/e2e/tests/bulk-update-transfer.spec.ts
+++ b/frontend/e2e/tests/bulk-update-transfer.spec.ts
@@ -281,10 +281,10 @@ test.describe('Bulk Update — data preservation', () => {
     const propagationOption = page.getByTestId(TransactionsTestIds.PropagationOption('current'))
     await expect(propagationOption.or(page.getByTestId(TransactionsTestIds.BulkSuccess))).toBeVisible({ timeout: 8000 })
 
-    // If propagation appears, select "Somente esta"
+    // If propagation appears, select "current"
     const propagationVisible = await propagationOption.isVisible().catch(() => false)
     if (propagationVisible) {
-      await transactionsPage.selectPropagation('Somente esta', 'update')
+      await transactionsPage.selectPropagation('current', 'update')
     }
 
     await expect(page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible({ timeout: 15000 })

--- a/frontend/e2e/tests/charges.spec.ts
+++ b/frontend/e2e/tests/charges.spec.ts
@@ -14,7 +14,7 @@ import {
   openAuthedPage,
 } from "../helpers/api";
 import { ChargesTestIds } from "@/testIds";
-import { selectOption } from "../helpers/formFields";
+import { SelectField } from "../helpers/formFields";
 
 /**
  * Charges E2E Tests
@@ -369,9 +369,7 @@ test.describe("Charges", () => {
     // The radio is required in the schema, so submit without picking charger/payer stays on-form.
     await chargesPage.openCreateDrawer();
     // Fill everything except role — submit must stay on the form.
-    await selectOption(
-      chargesPage.createDrawer,
-      ChargesTestIds.SelectMyAccount,
+    await new SelectField(chargesPage.createDrawer, ChargesTestIds.SelectMyAccount).pick(
       ChargesTestIds.OptionMyAccount(primaryAccountId),
     );
     await chargesPage.createDrawer.getByTestId(ChargesTestIds.BtnSubmitCreate).click();

--- a/frontend/e2e/tests/charges.spec.ts
+++ b/frontend/e2e/tests/charges.spec.ts
@@ -184,6 +184,7 @@ test.describe("Charges", () => {
     await chargesPage.openCreateDrawer();
     await chargesPage.fillCreateForm({
       accountId: primaryAccountId,
+      connectionId,
       role: "charger",
       description,
     });
@@ -287,6 +288,7 @@ test.describe("Charges", () => {
     await pageCharges.openCreateDrawer();
     await pageCharges.fillCreateForm({
       accountId: privAcc.id,
+      connectionId: freshConn.id,
       role: "charger",
       amount: arbitraryAmount,
       description,
@@ -342,6 +344,7 @@ test.describe("Charges", () => {
     await pageCharges.openCreateDrawer();
     await pageCharges.fillCreateForm({
       accountId: privAcc.id,
+      connectionId: freshConn.id,
       role: "payer",
       amount: arbitraryAmount,
       description,

--- a/frontend/e2e/tests/charges.spec.ts
+++ b/frontend/e2e/tests/charges.spec.ts
@@ -13,6 +13,8 @@ import {
   apiFetchAs,
   openAuthedPage,
 } from "../helpers/api";
+import { ChargesTestIds } from "@/testIds";
+import { selectOption } from "../helpers/formFields";
 
 /**
  * Charges E2E Tests
@@ -181,7 +183,7 @@ test.describe("Charges", () => {
 
     await chargesPage.openCreateDrawer();
     await chargesPage.fillCreateForm({
-      accountName: primaryAccountName,
+      accountId: primaryAccountId,
       role: "charger",
       description,
     });
@@ -269,10 +271,11 @@ test.describe("Charges", () => {
     });
 
     const privAccName = `Arb Charger Acc ${Date.now()}`;
-    await apiFetchAs(freshPrimaryToken, "/api/accounts", {
+    const privAccRes = await apiFetchAs(freshPrimaryToken, "/api/accounts", {
       method: "POST",
       body: JSON.stringify({ name: privAccName, initial_balance: 0 }),
     });
+    const privAcc = await privAccRes.json();
 
     // Drive the UI as the fresh primary
     const page = await openAuthedPage(browser, freshPrimaryToken);
@@ -283,7 +286,7 @@ test.describe("Charges", () => {
     const arbitraryAmount = 123.45; // reais in the UI → 12345 cents in the DB
     await pageCharges.openCreateDrawer();
     await pageCharges.fillCreateForm({
-      accountName: privAccName,
+      accountId: privAcc.id,
       role: "charger",
       amount: arbitraryAmount,
       description,
@@ -324,10 +327,11 @@ test.describe("Charges", () => {
     });
 
     const privAccName = `Arb Payer Acc ${Date.now()}`;
-    await apiFetchAs(freshPrimaryToken, "/api/accounts", {
+    const privAccRes = await apiFetchAs(freshPrimaryToken, "/api/accounts", {
       method: "POST",
       body: JSON.stringify({ name: privAccName, initial_balance: 0 }),
     });
+    const privAcc = await privAccRes.json();
 
     const page = await openAuthedPage(browser, freshPrimaryToken);
     const pageCharges = new ChargesPage(page);
@@ -337,7 +341,7 @@ test.describe("Charges", () => {
     const arbitraryAmount = 67.89;
     await pageCharges.openCreateDrawer();
     await pageCharges.fillCreateForm({
-      accountName: privAccName,
+      accountId: privAcc.id,
       role: "payer",
       amount: arbitraryAmount,
       description,
@@ -361,12 +365,13 @@ test.describe("Charges", () => {
   test("submitting the create drawer without selecting a role is rejected", async () => {
     // The radio is required in the schema, so submit without picking charger/payer stays on-form.
     await chargesPage.openCreateDrawer();
-    // Fill everything except role
-    const accountSelect = chargesPage.createDrawer.getByRole("textbox", { name: "Minha conta" });
-    await accountSelect.click();
-    await chargesPage.page.getByRole("option", { name: primaryAccountName }).click();
-
-    await chargesPage.createDrawer.getByRole("button", { name: "Criar Cobrança" }).click();
+    // Fill everything except role — submit must stay on the form.
+    await selectOption(
+      chargesPage.createDrawer,
+      ChargesTestIds.SelectMyAccount,
+      ChargesTestIds.OptionMyAccount(primaryAccountId),
+    );
+    await chargesPage.createDrawer.getByTestId(ChargesTestIds.BtnSubmitCreate).click();
 
     // The drawer must stay open and show a validation error for the role field.
     await expect(chargesPage.createDrawer).toBeVisible();

--- a/frontend/e2e/tests/import-installment.spec.ts
+++ b/frontend/e2e/tests/import-installment.spec.ts
@@ -63,10 +63,10 @@ test.describe("Import with installment settings", () => {
     // Use a fixed date so we know which month/year to query
     const csv = buildCsvContent([["15/03/2026", description, "-300,00"]]);
 
-    await importPage.uploadCSV(csv, testAccountName);
+    await importPage.uploadCSV(csv, testAccountId);
 
     // Set category (required for expenses)
-    await importPage.setRowCategory(0, testCategoryName);
+    await importPage.setRowCategory(0, testCategoryId);
 
     // Configure 1/3 monthly installments
     await importPage.setRowInstallments(0, { type: "monthly", current: 1, total: 3 });

--- a/frontend/e2e/tests/import-shift-select.spec.ts
+++ b/frontend/e2e/tests/import-shift-select.spec.ts
@@ -83,7 +83,7 @@ test.describe("Import shift+click selection", () => {
     page = await context.newPage();
     importPage = new ImportPage(page);
     await importPage.goto();
-    await importPage.uploadCSV(csv, freshAccountName);
+    await importPage.uploadCSV(csv, freshAccountId);
   });
 
   test.afterEach(async () => {

--- a/frontend/e2e/tests/import-split-settings.spec.ts
+++ b/frontend/e2e/tests/import-split-settings.spec.ts
@@ -89,10 +89,10 @@ test.describe("Import with split settings", () => {
     const description = `Split Reopen ${Date.now()}`;
     const csv = buildCsvContent([["15/01/2026", description, "-100,00"]]);
 
-    await importPage.uploadCSV(csv, testAccountName);
+    await importPage.uploadCSV(csv, testAccountId);
 
     // Set category (required for expense)
-    await importPage.setRowCategory(0, testCategoryName);
+    await importPage.setRowCategory(0, testCategoryId);
 
     // The split popover button starts with text "Sem divisão"
     const splitButton = importPage.reviewStep

--- a/frontend/e2e/tests/import.spec.ts
+++ b/frontend/e2e/tests/import.spec.ts
@@ -80,14 +80,14 @@ test.describe("Import transactions", () => {
       [formatDateBR(txDate), description, "-150,00"],
     ]);
 
-    await importPage.uploadCSV(csv, testAccountName);
+    await importPage.uploadCSV(csv, testAccountId);
 
     // Verify review step shows 1 row
     const rowCount = await importPage.getRowCount();
     expect(rowCount).toBe(1);
 
     // Category is required for non-transfer rows before confirming
-    await importPage.setRowCategory(0, testCategoryName);
+    await importPage.setRowCategory(0, testCategoryId);
 
     await importPage.confirmImport();
 
@@ -122,7 +122,7 @@ test.describe("Import transactions", () => {
       [formatDateBR(txDate), description, "-80,00"],
     ]);
 
-    await importPage.uploadCSV(csv, testAccountName);
+    await importPage.uploadCSV(csv, testAccountId);
 
     // Row 0 should have action "duplicate" (detected server-side)
     const actionSelect = importPage.reviewStep.getByTestId(ImportTestIds.RowSelectAction(0));
@@ -142,13 +142,13 @@ test.describe("Import transactions", () => {
       [formatDateBR(txDate), description2, "-75,00"],
     ]);
 
-    await importPage.uploadCSV(csv, testAccountName);
+    await importPage.uploadCSV(csv, testAccountId);
 
     // Change row 1 action to "skip"
     await importPage.setRowAction(1, "skip");
 
     // Category is required for the row being imported
-    await importPage.setRowCategory(0, testCategoryName);
+    await importPage.setRowCategory(0, testCategoryId);
 
     await importPage.confirmImport();
 
@@ -173,7 +173,7 @@ test.describe("Import transactions", () => {
       [formatDateBR(txDate), description, "-30,00"],
     ]);
 
-    await importPage.uploadCSV(csv, testAccountName);
+    await importPage.uploadCSV(csv, testAccountId);
 
     // Open category drawer from the + button on row 0
     await importPage.openCreateCategoryDrawer(0);
@@ -209,7 +209,7 @@ test.describe("Import transactions", () => {
       [formatDateBR(txDate), description, "-45,00"],
     ]);
 
-    await importPage.uploadCSV(csv, testAccountName);
+    await importPage.uploadCSV(csv, testAccountId);
 
     // Open category drawer and create a category with emoji
     await importPage.openCreateCategoryDrawer(0);
@@ -239,7 +239,7 @@ test.describe("Import transactions", () => {
   test("invalid CSV: shows error message when header is missing required column", async () => {
     const invalidCsv = "Data;Descrição\n15/01/2026;Teste";
 
-    await importPage.selectAccount(testAccountName);
+    await importPage.selectAccount(testAccountId);
     await importPage.uploadCSVContent(invalidCsv);
     await importPage.processButton.click();
 

--- a/frontend/e2e/tests/recurrence.spec.ts
+++ b/frontend/e2e/tests/recurrence.spec.ts
@@ -8,7 +8,7 @@ import {
   apiCreateTransaction,
   apiDeleteTransaction,
 } from '../helpers/api'
-import { fillNumber } from '../helpers/formFields'
+import { NumberField } from '../helpers/formFields'
 import { RecurrenceTestIds, TransactionsTestIds } from '@/testIds'
 
 // ─── Suite ────────────────────────────────────────────────────────────────────
@@ -113,8 +113,8 @@ test.describe('Recurrence', () => {
     await page.locator('label', { hasText: 'Recorrência' }).click()
 
     // Fill invalid values: current (5) > total (3)
-    await fillNumber(transactionsPage.formDrawer, RecurrenceTestIds.CurrentInstallmentInput, 5)
-    await fillNumber(transactionsPage.formDrawer, RecurrenceTestIds.TotalInstallmentsInput, 3)
+    await new NumberField(transactionsPage.formDrawer, RecurrenceTestIds.CurrentInstallmentInput).fill(5)
+    await new NumberField(transactionsPage.formDrawer, RecurrenceTestIds.TotalInstallmentsInput).fill(3)
 
     // Attempt to submit
     await page.getByTestId(TransactionsTestIds.BtnSave).click()

--- a/frontend/e2e/tests/recurrence.spec.ts
+++ b/frontend/e2e/tests/recurrence.spec.ts
@@ -8,7 +8,8 @@ import {
   apiCreateTransaction,
   apiDeleteTransaction,
 } from '../helpers/api'
-import { TransactionsTestIds } from '@/testIds'
+import { fillNumber } from '../helpers/formFields'
+import { RecurrenceTestIds, TransactionsTestIds } from '@/testIds'
 
 // ─── Suite ────────────────────────────────────────────────────────────────────
 
@@ -106,14 +107,14 @@ test.describe('Recurrence', () => {
     await transactionsPage.openCreateForm()
 
     // Fill the main expense fields first
-    await transactionsPage.fillExpense(1000, `Parcela invalida - e2e ${Date.now()}`, testAccountName, testCategoryName)
+    await transactionsPage.fillExpense(1000, `Parcela invalida - e2e ${Date.now()}`, testAccountId, testCategoryId)
 
     // Enable recurrence toggle — click the visible <label> element, not the hidden input
     await page.locator('label', { hasText: 'Recorrência' }).click()
 
     // Fill invalid values: current (5) > total (3)
-    await page.getByLabel('Parcela atual').fill('5')
-    await page.getByLabel('Total de parcelas').fill('3')
+    await fillNumber(transactionsPage.formDrawer, RecurrenceTestIds.CurrentInstallmentInput, 5)
+    await fillNumber(transactionsPage.formDrawer, RecurrenceTestIds.TotalInstallmentsInput, 3)
 
     // Attempt to submit
     await page.getByTestId(TransactionsTestIds.BtnSave).click()

--- a/frontend/e2e/tests/transactions.spec.ts
+++ b/frontend/e2e/tests/transactions.spec.ts
@@ -38,7 +38,7 @@ test.describe('Transactions', () => {
     const description = `Despesa Teste ${Date.now()}`
 
     await transactionsPage.openCreateForm()
-    await transactionsPage.fillExpense(5000, description, testAccountName, testCategoryName)
+    await transactionsPage.fillExpense(5000, description, testAccountId, testCategoryId)
     await transactionsPage.submitForm()
 
     await expect(transactionsPage.page.getByText(description)).toBeVisible()
@@ -49,7 +49,7 @@ test.describe('Transactions', () => {
     const description = `Receita Teste ${Date.now()}`
 
     await transactionsPage.openCreateForm()
-    await transactionsPage.fillIncome(10000, description, testAccountName, testCategoryName)
+    await transactionsPage.fillIncome(10000, description, testAccountId, testCategoryId)
     await transactionsPage.submitForm()
 
     await expect(transactionsPage.page.getByText(description)).toBeVisible()

--- a/frontend/e2e/tests/transfer-transaction.spec.ts
+++ b/frontend/e2e/tests/transfer-transaction.spec.ts
@@ -44,7 +44,7 @@ test.describe('Transfer Transactions', () => {
     const description = `Transferência Teste ${Date.now()}`
 
     await transactionsPage.openCreateForm()
-    await transactionsPage.fillTransfer(20000, description, sourceAccountName, destAccountName)
+    await transactionsPage.fillTransfer(20000, description, sourceAccountId, destAccountId)
     await transactionsPage.submitForm()
 
     // A transfer creates two rows (debit + credit) with the same description

--- a/frontend/src/components/charges/AcceptChargeDrawer.tsx
+++ b/frontend/src/components/charges/AcceptChargeDrawer.tsx
@@ -165,6 +165,11 @@ export function AcceptChargeDrawer({ charge, partnerName }: AcceptChargeDrawerPr
                 onChange={(val) => field.onChange(val != null ? Number(val) : undefined)}
                 error={fieldState.error?.message}
                 required
+                renderOption={({ option }) => (
+                  <span data-testid={ChargesTestIds.OptionAcceptAccount(option.value)}>
+                    {option.label}
+                  </span>
+                )}
                 data-testid={ChargesTestIds.SelectAcceptAccount}
               />
             )}

--- a/frontend/src/components/charges/CreateChargeDrawer.tsx
+++ b/frontend/src/components/charges/CreateChargeDrawer.tsx
@@ -207,6 +207,11 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
                   onChange={(val) => field.onChange(val != null ? Number(val) : undefined)}
                   error={fieldState.error?.message}
                   required
+                  renderOption={({ option }) => (
+                    <span data-testid={ChargesTestIds.OptionConnection(option.value)}>
+                      {option.label}
+                    </span>
+                  )}
                   data-testid={ChargesTestIds.SelectConnection}
                 />
               )}
@@ -225,6 +230,11 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
                 onChange={(val) => field.onChange(val != null ? Number(val) : undefined)}
                 error={fieldState.error?.message}
                 required
+                renderOption={({ option }) => (
+                  <span data-testid={ChargesTestIds.OptionMyAccount(option.value)}>
+                    {option.label}
+                  </span>
+                )}
                 data-testid={ChargesTestIds.SelectMyAccount}
               />
             )}

--- a/frontend/src/components/transactions/filters/GroupBySelector.tsx
+++ b/frontend/src/components/transactions/filters/GroupBySelector.tsx
@@ -4,9 +4,18 @@ import { Transactions } from '@/types/transactions'
 import { TransactionsTestIds } from '@/testIds'
 
 const OPTIONS = [
-  { value: 'date', label: 'Data' },
-  { value: 'category', label: 'Categoria' },
-  { value: 'account', label: 'Conta' },
+  {
+    value: 'date',
+    label: <span data-testid={TransactionsTestIds.SegmentGroupBy('date')}>Data</span>,
+  },
+  {
+    value: 'category',
+    label: <span data-testid={TransactionsTestIds.SegmentGroupBy('category')}>Categoria</span>,
+  },
+  {
+    value: 'account',
+    label: <span data-testid={TransactionsTestIds.SegmentGroupBy('account')}>Conta</span>,
+  },
 ]
 
 export function GroupBySelector() {

--- a/frontend/src/components/transactions/form/RecurrenceFields.tsx
+++ b/frontend/src/components/transactions/form/RecurrenceFields.tsx
@@ -1,7 +1,7 @@
 import { Select, NumberInput, Stack, Group, Text } from "@mantine/core";
 import { Controller, useFormContext, type FieldValues } from "react-hook-form";
 import { getFieldErrorMessage } from "@/utils/getFieldErrorMessage";
-import { RecurrenceTestIds } from "@/testIds";
+import { RecurrenceTestIds, type RecurrenceType } from "@/testIds";
 
 interface RecurrenceFieldsProps {
   /**
@@ -56,6 +56,11 @@ export function RecurrenceFields({
             error={fieldError("recurrenceType")}
             comboboxProps={{ withinPortal: comboboxWithinPortal }}
             clearable
+            renderOption={({ option }) => (
+              <span data-testid={RecurrenceTestIds.OptionType(option.value as RecurrenceType)}>
+                {option.label}
+              </span>
+            )}
             data-testid={RecurrenceTestIds.TypeSelect}
           />
         )}

--- a/frontend/src/components/transactions/form/TransactionForm.tsx
+++ b/frontend/src/components/transactions/form/TransactionForm.tsx
@@ -180,9 +180,30 @@ export const TransactionForm = ({
           render={({ field }) => (
             <SegmentedControl
               data={[
-                { value: "expense", label: "Despesa" },
-                { value: "income", label: "Receita" },
-                { value: "transfer", label: "Transferência" },
+                {
+                  value: "expense",
+                  label: (
+                    <span data-testid={TransactionsTestIds.SegmentTransactionType("expense")}>
+                      Despesa
+                    </span>
+                  ),
+                },
+                {
+                  value: "income",
+                  label: (
+                    <span data-testid={TransactionsTestIds.SegmentTransactionType("income")}>
+                      Receita
+                    </span>
+                  ),
+                },
+                {
+                  value: "transfer",
+                  label: (
+                    <span data-testid={TransactionsTestIds.SegmentTransactionType("transfer")}>
+                      Transferência
+                    </span>
+                  ),
+                },
               ]}
               value={field.value}
               onChange={(val) => {
@@ -260,6 +281,11 @@ export const TransactionForm = ({
                   onBlur={makeSelectBlurHandler(accountOptions, (val) => field.onChange(val))}
                   error={errors.account_id?.message}
                   searchable
+                  renderOption={({ option }) => (
+                    <span data-testid={TransactionsTestIds.OptionAccount(option.value)}>
+                      {option.label}
+                    </span>
+                  )}
                   data-testid={TransactionsTestIds.SelectAccount}
                 />
               )}
@@ -278,6 +304,11 @@ export const TransactionForm = ({
                   onBlur={makeSelectBlurHandler(destinationAccountOptions, (val) => field.onChange(val))}
                   error={errors.destination_account_id?.message}
                   searchable
+                  renderOption={({ option }) => (
+                    <span data-testid={TransactionsTestIds.OptionDestinationAccount(option.value)}>
+                      {option.label}
+                    </span>
+                  )}
                   data-testid={TransactionsTestIds.SelectDestinationAccount}
                 />
               )}
@@ -300,6 +331,11 @@ export const TransactionForm = ({
                     error={errors.category_id?.message}
                     searchable
                     clearable
+                    renderOption={({ option }) => (
+                      <span data-testid={TransactionsTestIds.OptionCategory(option.value)}>
+                        {option.label}
+                      </span>
+                    )}
                     data-testid={TransactionsTestIds.SelectCategory}
                   />
                 )}
@@ -318,6 +354,11 @@ export const TransactionForm = ({
                     onBlur={makeSelectBlurHandler(accountOptions, (val) => field.onChange(val))}
                     error={errors.account_id?.message}
                     searchable
+                    renderOption={({ option }) => (
+                      <span data-testid={TransactionsTestIds.OptionAccount(option.value)}>
+                        {option.label}
+                      </span>
+                    )}
                     data-testid={TransactionsTestIds.SelectAccount}
                   />
                 )}

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -17,7 +17,7 @@ import { useSplitSummary } from "@/hooks/import/useSplitSummary";
 import { renderDrawer } from "@/utils/renderDrawer";
 import { CreateCategoryDrawer } from "./CreateCategoryDrawer";
 import { AccountDrawer } from "@/components/accounts/AccountDrawer";
-import { ImportTestIds } from '@/testIds'
+import { ImportTestIds, type ImportRowAction, type ImportRowTransactionType } from '@/testIds'
 
 const TRANSACTION_TYPE_OPTIONS = [
   { value: "expense", label: "Despesa" },
@@ -246,6 +246,17 @@ export const ImportReviewRow = memo(
                 }}
                 disabled={disabled || isSkipped}
                 withCheckIcon={false}
+                renderOption={({ option }) => (
+                  <span
+                    data-testid={ImportTestIds.RowOptionTransactionType(
+                      rowIndex,
+                      option.value as ImportRowTransactionType,
+                    )}
+                  >
+                    {option.label}
+                  </span>
+                )}
+                data-testid={ImportTestIds.RowSelectTransactionType(rowIndex)}
               />
             )}
           />
@@ -270,6 +281,11 @@ export const ImportReviewRow = memo(
                     clearable
                     placeholder="Selecionar..."
                     withCheckIcon={false}
+                    renderOption={({ option }) => (
+                      <span data-testid={ImportTestIds.RowOptionCategory(rowIndex, option.value)}>
+                        {option.label}
+                      </span>
+                    )}
                     data-testid={ImportTestIds.RowSelectCategory(rowIndex)}
                     style={{ flex: 1 }}
                   />
@@ -318,6 +334,14 @@ export const ImportReviewRow = memo(
                     placeholder="Selecionar..."
                     withCheckIcon={false}
                     error={rowErrors?.destination_account_id?.message}
+                    renderOption={({ option }) => (
+                      <span
+                        data-testid={ImportTestIds.RowOptionDestinationAccount(rowIndex, option.value)}
+                      >
+                        {option.label}
+                      </span>
+                    )}
+                    data-testid={ImportTestIds.RowSelectDestinationAccount(rowIndex)}
                     style={{ flex: 1 }}
                   />
                 )}
@@ -385,6 +409,16 @@ export const ImportReviewRow = memo(
                 onChange={field.onChange}
                 disabled={disabled}
                 withCheckIcon={false}
+                renderOption={({ option }) => (
+                  <span
+                    data-testid={ImportTestIds.RowOptionAction(
+                      rowIndex,
+                      option.value as ImportRowAction,
+                    )}
+                  >
+                    {option.label}
+                  </span>
+                )}
                 data-testid={ImportTestIds.RowSelectAction(rowIndex)}
               />
             )}

--- a/frontend/src/components/transactions/import/UploadStep.tsx
+++ b/frontend/src/components/transactions/import/UploadStep.tsx
@@ -23,7 +23,7 @@ import { Transactions } from '@/types/transactions'
 import { parseApiError } from '@/utils/apiErrors'
 import { renderDrawer } from '@/utils/renderDrawer'
 import { CSV_COLUMNS } from './importPayload'
-import { ImportTestIds } from '@/testIds'
+import { ImportTestIds, type ImportDecimalSeparator, type ImportTypeRule } from '@/testIds'
 
 type Props = {
   onParsed: (rows: Transactions.ParsedImportRow[], accountId: number) => void
@@ -95,6 +95,9 @@ export function UploadStep({ onParsed, onBack }: Props) {
           data={ownAccountOptions}
           value={accountId ? String(accountId) : null}
           onChange={(val) => setAccountId(val ? Number(val) : null)}
+          renderOption={({ option }) => (
+            <span data-testid={ImportTestIds.OptionAccount(option.value)}>{option.label}</span>
+          )}
           data-testid={ImportTestIds.SelectAccount}
         />
         <ActionIcon
@@ -123,6 +126,13 @@ export function UploadStep({ onParsed, onBack }: Props) {
           ]}
           value={decimalSeparator}
           onChange={(val) => setDecimalSeparator((val as Transactions.DecimalSeparatorValue | null) ?? 'comma')}
+          renderOption={({ option }) => (
+            <span
+              data-testid={ImportTestIds.OptionDecimalSeparator(option.value as ImportDecimalSeparator)}
+            >
+              {option.label}
+            </span>
+          )}
           data-testid={ImportTestIds.SelectDecimalSeparator}
         />
         <Select
@@ -136,7 +146,12 @@ export function UploadStep({ onParsed, onBack }: Props) {
           onChange={(val) =>
             setTypeDefinitionRule((val as Transactions.TypeDefinitionRule | null) ?? 'positive_as_income')
           }
-          data-testid={ImportTestIds.SelectDecimalSeparator}
+          renderOption={({ option }) => (
+            <span data-testid={ImportTestIds.OptionTypeRule(option.value as ImportTypeRule)}>
+              {option.label}
+            </span>
+          )}
+          data-testid={ImportTestIds.SelectTypeRule}
         />
       </Flex>
 

--- a/frontend/src/testIds/charges.ts
+++ b/frontend/src/testIds/charges.ts
@@ -21,4 +21,11 @@ export const ChargesTestIds = {
   BtnSubmitCreate: 'btn_submit_create_charge',
   SelectAcceptAccount: 'select_accept_account',
   BtnSubmitAccept: 'btn_submit_accept_charge',
+
+  // Select options (renderOption testids — pass the entity id)
+  OptionConnection: (connectionId: number | string) =>
+    `option_connection_${connectionId}` as const,
+  OptionMyAccount: (accountId: number | string) => `option_my_account_${accountId}` as const,
+  OptionAcceptAccount: (accountId: number | string) =>
+    `option_accept_account_${accountId}` as const,
 } as const

--- a/frontend/src/testIds/import.ts
+++ b/frontend/src/testIds/import.ts
@@ -1,3 +1,8 @@
+export type ImportRowAction = 'import' | 'skip' | 'duplicate'
+export type ImportRowTransactionType = 'expense' | 'income' | 'transfer'
+export type ImportDecimalSeparator = 'comma' | 'dot'
+export type ImportTypeRule = 'positive_as_income' | 'positive_as_expense'
+
 export const ImportTestIds = {
   // Steps
   UploadStep: 'import_upload_step',
@@ -8,8 +13,15 @@ export const ImportTestIds = {
   BtnProcessCSV: 'btn_process_csv',
   SelectAccount: 'select_import_account',
   SelectDecimalSeparator: 'select_decimal_separator',
+  SelectTypeRule: 'select_type_rule',
   InputCsvFile: 'input_csv_file',
   BtnCreateAccountHeader: 'btn_create_account_header',
+
+  // Upload-step option testids
+  OptionAccount: (accountId: number | string) => `option_import_account_${accountId}` as const,
+  OptionDecimalSeparator: (value: ImportDecimalSeparator) =>
+    `option_decimal_separator_${value}` as const,
+  OptionTypeRule: (value: ImportTypeRule) => `option_type_rule_${value}` as const,
 
   // Review-step controls
   BtnConfirm: 'btn_confirm_import',
@@ -21,9 +33,23 @@ export const ImportTestIds = {
   RowStatus: (rowIndex: number) => `import_status_${rowIndex}` as const,
   RowSelectCategory: (rowIndex: number) => `select_category_${rowIndex}` as const,
   RowSelectAction: (rowIndex: number) => `select_import_action_${rowIndex}` as const,
+  RowSelectTransactionType: (rowIndex: number) =>
+    `select_row_transaction_type_${rowIndex}` as const,
+  RowSelectDestinationAccount: (rowIndex: number) =>
+    `select_row_destination_account_${rowIndex}` as const,
   RowCheckbox: (rowIndex: number) => `checkbox_import_row_${rowIndex}` as const,
   RowBtnCreateCategory: (rowIndex: number) =>
     `btn_create_category_row_${rowIndex}` as const,
+
+  // Row-scoped option testids
+  RowOptionCategory: (rowIndex: number, categoryId: number | string) =>
+    `option_row_category_${rowIndex}_${categoryId}` as const,
+  RowOptionAction: (rowIndex: number, action: ImportRowAction) =>
+    `option_row_action_${rowIndex}_${action}` as const,
+  RowOptionTransactionType: (rowIndex: number, type: ImportRowTransactionType) =>
+    `option_row_transaction_type_${rowIndex}_${type}` as const,
+  RowOptionDestinationAccount: (rowIndex: number, accountId: number | string) =>
+    `option_row_destination_account_${rowIndex}_${accountId}` as const,
 
   // Bulk toolbar
   BtnBulkRemove: 'btn_bulk_remove',

--- a/frontend/src/testIds/index.ts
+++ b/frontend/src/testIds/index.ts
@@ -18,11 +18,18 @@
 export { CommonTestIds } from './common'
 export { AccountsTestIds } from './accounts'
 export { CategoriesTestIds } from './categories'
-export { ChargesTestIds, type ChargeAction } from './charges'
+export { ChargesTestIds, type ChargeAction, type ChargeRole, type ChargesTab } from './charges'
 export {
   TransactionsTestIds,
   type TransactionType,
   type PropagationOption,
+  type TransactionFilterKind,
 } from './transactions'
-export { ImportTestIds } from './import'
-export { RecurrenceTestIds } from './recurrence'
+export {
+  ImportTestIds,
+  type ImportRowAction,
+  type ImportRowTransactionType,
+  type ImportDecimalSeparator,
+  type ImportTypeRule,
+} from './import'
+export { RecurrenceTestIds, type RecurrenceType } from './recurrence'

--- a/frontend/src/testIds/recurrence.ts
+++ b/frontend/src/testIds/recurrence.ts
@@ -5,8 +5,11 @@
  * Parametric (per-row) ids stay as factory functions in the domain-specific
  * testid files (e.g. ImportTestIds).
  */
+export type RecurrenceType = 'daily' | 'weekly' | 'monthly' | 'yearly'
+
 export const RecurrenceTestIds = {
   TypeSelect: 'select_recurrence_type',
   CurrentInstallmentInput: 'input_recurrence_current_installment',
   TotalInstallmentsInput: 'input_recurrence_total_installments',
+  OptionType: (type: RecurrenceType) => `option_recurrence_type_${type}` as const,
 } as const

--- a/frontend/src/testIds/transactions.ts
+++ b/frontend/src/testIds/transactions.ts
@@ -22,6 +22,17 @@ export const TransactionsTestIds = {
   SelectCategory: 'select_category',
   SegmentedTransactionType: 'segmented_transaction_type',
 
+  // Select options (renderOption testids — pass the entity id)
+  OptionAccount: (accountId: number | string) => `option_account_${accountId}` as const,
+  OptionDestinationAccount: (accountId: number | string) =>
+    `option_destination_account_${accountId}` as const,
+  OptionCategory: (categoryId: number | string) => `option_category_${categoryId}` as const,
+
+  // SegmentedControl items
+  SegmentTransactionType: (type: TransactionType) => `segment_transaction_type_${type}` as const,
+  SegmentGroupBy: (option: 'date' | 'category' | 'account') =>
+    `segment_group_by_${option}` as const,
+
   // Split
   InputSplitAmount: 'input_split_amount',
   InputSplitPercentage: 'input_split_percentage',


### PR DESCRIPTION
## Summary

- New `frontend/e2e/helpers/formFields.ts`: a flat library of async helpers (`fillText`, `fillCurrencyCents`, `selectOption`, `pickSegmented`, `pickRadio`, `setSwitch`, `setCheckbox`, `fillDateInput`, `fillNumber`, `setFileInput`, `fillTagsInput`) that encapsulate Mantine-specific form quirks — the `CurrencyInput` keydown digit-loop, combobox option portals, SegmentedControl item targeting, etc.
- All Mantine `Select` consumers exercised by the e2e suite now ship `renderOption` testids, and the relevant `SegmentedControl`s render JSX labels with per-option testids. The helpers therefore **require an option testid** — no `getByRole('option', { name })` / `getByText(label)` fallback — in line with the testid-only selector policy in `frontend/CLAUDE.md`.
- All five Page Objects (`TransactionsPage`, `ImportPage`, `ChargesPage`, `AccountsPage`, `CategoriesPage`) consume the helpers. Methods that picked options by name now take the entity `id` returned by `helpers/api.ts`.
- New parametric testid factories in `src/testIds/{transactions,recurrence,charges,import}.ts`. Existing factories untouched.
- Specs updated to pass entity ids (mechanical: `testAccountName` → `testAccountId`).

## Test plan

- [ ] `cd frontend && npx tsc -b` — passes
- [ ] `cd frontend && npx tsc -p e2e/tsconfig.json` — passes
- [ ] `cd frontend && npm run e2e:docker-up && npm run e2e` — full Playwright suite passes (parity gate; no behavioural change intended)
- [ ] Spot-check that the migrated `TransactionsPage.fillExpense` / `fillTransfer` / `selectGroupBy` flows do not regress (covered by `transactions.spec.ts`, `transfer-transaction.spec.ts`, `filter-transactions.spec.ts`)
- [ ] Confirm import flow (`import.spec.ts`, `import-installment.spec.ts`, `import-split-settings.spec.ts`, `import-shift-select.spec.ts`) still runs end-to-end
- [ ] Confirm charges flow (`charges.spec.ts`) still runs, including the no-role validation path

## Notes

- Pre-existing lint error in `src/hooks/usePWAInstall.ts` is unrelated to this PR (was already failing on `main`).
- The `selectOption` helper accepts an optional `search` string for searchable comboboxes; not used in v1 but kept for ergonomics.

https://claude.ai/code/session_01AQHpk6PipdLVez3B6VX8GN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQHpk6PipdLVez3B6VX8GN)_