### PR TITLE
feat: CSV import — optional category, installment inference, simpler duplicates

### DIFF
--- a/backend/internal/domain/category.go
+++ b/backend/internal/domain/category.go
@@ -16,10 +16,12 @@ type Category struct {
 
 type CategorySearchOptions struct {
 	IDs           []int   `json:"ids"`
+	ExcludeIDs    []int   `json:"exclude_ids,omitempty"`
 	UserIDs       []int   `json:"user_ids"`
 	ParentID      *int    `json:"parent_id,omitempty"`
-	Name          *string `json:"name,omitempty"`           // case-insensitive exact match
+	Name          *string `json:"name,omitempty"`            // case-insensitive exact match
 	OnlyRootLevel bool    `json:"only_root_level,omitempty"` // when true, filters parent_id IS NULL
+	Limit         int     `json:"limit,omitempty"`
 }
 
 type DeleteCategoryRequest struct {

--- a/backend/internal/domain/category.go
+++ b/backend/internal/domain/category.go
@@ -15,10 +15,11 @@ type Category struct {
 }
 
 type CategorySearchOptions struct {
-	IDs      []int   `json:"ids"`
-	UserIDs  []int   `json:"user_ids"`
-	ParentID *int    `json:"parent_id,omitempty"`
-	Name     *string `json:"name,omitempty"` // case-insensitive exact match
+	IDs           []int   `json:"ids"`
+	UserIDs       []int   `json:"user_ids"`
+	ParentID      *int    `json:"parent_id,omitempty"`
+	Name          *string `json:"name,omitempty"`           // case-insensitive exact match
+	OnlyRootLevel bool    `json:"only_root_level,omitempty"` // when true, filters parent_id IS NULL
 }
 
 type DeleteCategoryRequest struct {

--- a/backend/internal/domain/category.go
+++ b/backend/internal/domain/category.go
@@ -15,9 +15,10 @@ type Category struct {
 }
 
 type CategorySearchOptions struct {
-	IDs      []int `json:"ids"`
-	UserIDs  []int `json:"user_ids"`
-	ParentID *int  `json:"parent_id,omitempty"`
+	IDs      []int   `json:"ids"`
+	UserIDs  []int   `json:"user_ids"`
+	ParentID *int    `json:"parent_id,omitempty"`
+	Name     *string `json:"name,omitempty"` // case-insensitive exact match
 }
 
 type DeleteCategoryRequest struct {

--- a/backend/internal/domain/transaction_import.go
+++ b/backend/internal/domain/transaction_import.go
@@ -30,18 +30,19 @@ const (
 // It includes inferred values (e.g. category from transaction history) and
 // a status flag for duplicate detection.
 type ParsedImportRow struct {
-	RowIndex             int             `json:"row_index"`
-	Status               ImportRowStatus `json:"status"`
-	Date                 *time.Time      `json:"date,omitempty"`
-	Description          string          `json:"description"`
-	Type                 TransactionType `json:"type"`
-	Amount               int64           `json:"amount"` // cents
-	CategoryID           *int            `json:"category_id,omitempty"`
-	CategoryInferred     bool            `json:"category_inferred"`
-	DestinationAccountID *int            `json:"destination_account_id,omitempty"`
-	RecurrenceType       *RecurrenceType `json:"recurrence_type,omitempty"`
-	RecurrenceCount      *int            `json:"recurrence_count,omitempty"`
-	ParseErrors          []string        `json:"parse_errors,omitempty"`
+	RowIndex                      int             `json:"row_index"`
+	Status                        ImportRowStatus `json:"status"`
+	Date                          *time.Time      `json:"date,omitempty"`
+	Description                   string          `json:"description"`
+	Type                          TransactionType `json:"type"`
+	Amount                        int64           `json:"amount"` // cents
+	CategoryID                    *int            `json:"category_id,omitempty"`
+	CategoryInferred              bool            `json:"category_inferred"`
+	DestinationAccountID          *int            `json:"destination_account_id,omitempty"`
+	RecurrenceType                *RecurrenceType `json:"recurrence_type,omitempty"`
+	RecurrenceCount               *int            `json:"recurrence_count,omitempty"`
+	RecurrenceCurrentInstallment  *int            `json:"recurrence_current_installment,omitempty"`
+	ParseErrors                   []string        `json:"parse_errors,omitempty"`
 }
 
 // ImportCSVResponse is the response returned by the CSV parse endpoint.
@@ -54,8 +55,7 @@ type ImportCSVResponse struct {
 
 // CheckDuplicateRequest is the request body for the check-duplicate endpoint.
 type CheckDuplicateRequest struct {
-	Date        string `json:"date"`        // YYYY-MM-DD
-	Description string `json:"description"`
-	Amount      int64  `json:"amount"`      // cents
-	AccountID   *int   `json:"account_id"`  // optional; when set, only checks within that account
+	Date      string `json:"date"`       // YYYY-MM-DD
+	Amount    int64  `json:"amount"`     // cents
+	AccountID *int   `json:"account_id"` // optional; when set, only checks within that account
 }

--- a/backend/internal/handler/transaction_handler.go
+++ b/backend/internal/handler/transaction_handler.go
@@ -338,7 +338,7 @@ func (h *TransactionHandler) CheckDuplicate(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
 	}
 
-	isDup, err := h.transactionService.CheckDuplicateTransaction(c.Request().Context(), userID, req.Date, req.Description, req.Amount, req.AccountID)
+	isDup, err := h.transactionService.CheckDuplicateTransaction(c.Request().Context(), userID, req.Date, req.Amount, req.AccountID)
 	if err != nil {
 		return pkgErrors.ToHTTPError(err)
 	}

--- a/backend/internal/repository/category_repository.go
+++ b/backend/internal/repository/category_repository.go
@@ -43,6 +43,10 @@ func (r *categoryRepository) Search(ctx context.Context, options domain.Category
 		}
 	}
 
+	if options.OnlyRootLevel {
+		query = query.Where("parent_id IS NULL")
+	}
+
 	if options.Name != nil {
 		query = query.Where("LOWER(name) = LOWER(?)", *options.Name)
 	}

--- a/backend/internal/repository/category_repository.go
+++ b/backend/internal/repository/category_repository.go
@@ -47,11 +47,19 @@ func (r *categoryRepository) Search(ctx context.Context, options domain.Category
 		query = query.Where("parent_id IS NULL")
 	}
 
+	if len(options.ExcludeIDs) > 0 {
+		query = query.Where("id NOT IN ?", options.ExcludeIDs)
+	}
+
 	if options.Name != nil {
 		query = query.Where("LOWER(name) = LOWER(?)", *options.Name)
 	}
 
 	query = query.Order("parent_id desc, name ASC")
+
+	if options.Limit > 0 {
+		query = query.Limit(options.Limit)
+	}
 
 	if err := query.Find(&ents).Error; err != nil {
 		return nil, err

--- a/backend/internal/repository/category_repository.go
+++ b/backend/internal/repository/category_repository.go
@@ -43,6 +43,10 @@ func (r *categoryRepository) Search(ctx context.Context, options domain.Category
 		}
 	}
 
+	if options.Name != nil {
+		query = query.Where("LOWER(name) = LOWER(?)", *options.Name)
+	}
+
 	query = query.Order("parent_id desc, name ASC")
 
 	if err := query.Find(&ents).Error; err != nil {

--- a/backend/internal/service/category_service.go
+++ b/backend/internal/service/category_service.go
@@ -217,6 +217,8 @@ func (s *categoryService) checkSiblingUniqueness(ctx context.Context, userID int
 	}
 	if parentID != nil {
 		opts.ParentID = parentID
+	} else {
+		opts.OnlyRootLevel = true
 	}
 	siblings, err := s.categoryRepo.Search(ctx, opts)
 	if err != nil {
@@ -225,11 +227,6 @@ func (s *categoryService) checkSiblingUniqueness(ctx context.Context, userID int
 
 	for _, sibling := range siblings {
 		if excludeID != 0 && sibling.ID == excludeID {
-			continue
-		}
-		// For root-level categories (parentID == nil), the DB can't filter
-		// parent_id IS NULL via the current SearchOptions, so check in-memory.
-		if lo.FromPtr(sibling.ParentID) != lo.FromPtr(parentID) {
 			continue
 		}
 		return pkgErrors.NewWithTag(

--- a/backend/internal/service/category_service.go
+++ b/backend/internal/service/category_service.go
@@ -210,29 +210,33 @@ func (s *categoryService) Delete(ctx context.Context, userID, id int, req domain
 // checkSiblingUniqueness returns an error if a sibling with the same trimmed, case-insensitive name exists.
 // excludeID = 0 means no exclusion (create case); pass the category's own ID for update.
 func (s *categoryService) checkSiblingUniqueness(ctx context.Context, userID int, parentID *int, name string, excludeID int) error {
-	siblings, err := s.categoryRepo.Search(ctx, domain.CategorySearchOptions{
+	trimmed := strings.TrimSpace(name)
+	opts := domain.CategorySearchOptions{
 		UserIDs: []int{userID},
-	})
+		Name:    &trimmed,
+	}
+	if parentID != nil {
+		opts.ParentID = parentID
+	}
+	siblings, err := s.categoryRepo.Search(ctx, opts)
 	if err != nil {
 		return pkgErrors.Internal("failed to check sibling categories", err)
 	}
 
-	trimmed := strings.ToLower(strings.TrimSpace(name))
 	for _, sibling := range siblings {
 		if excludeID != 0 && sibling.ID == excludeID {
 			continue
 		}
-		// Same parent level check
+		// For root-level categories (parentID == nil), the DB can't filter
+		// parent_id IS NULL via the current SearchOptions, so check in-memory.
 		if lo.FromPtr(sibling.ParentID) != lo.FromPtr(parentID) {
 			continue
 		}
-		if strings.ToLower(strings.TrimSpace(sibling.Name)) == trimmed {
-			return pkgErrors.NewWithTag(
-				pkgErrors.ErrCodeValidation,
-				[]string{string(pkgErrors.ErrorTagDuplicateCategoryName)},
-				"a category with this name already exists at this level",
-			)
-		}
+		return pkgErrors.NewWithTag(
+			pkgErrors.ErrCodeValidation,
+			[]string{string(pkgErrors.ErrorTagDuplicateCategoryName)},
+			"a category with this name already exists at this level",
+		)
 	}
 	return nil
 }

--- a/backend/internal/service/category_service.go
+++ b/backend/internal/service/category_service.go
@@ -214,21 +214,22 @@ func (s *categoryService) checkSiblingUniqueness(ctx context.Context, userID int
 	opts := domain.CategorySearchOptions{
 		UserIDs: []int{userID},
 		Name:    &trimmed,
+		Limit:   1,
 	}
 	if parentID != nil {
 		opts.ParentID = parentID
 	} else {
 		opts.OnlyRootLevel = true
 	}
+	if excludeID != 0 {
+		opts.ExcludeIDs = []int{excludeID}
+	}
 	siblings, err := s.categoryRepo.Search(ctx, opts)
 	if err != nil {
 		return pkgErrors.Internal("failed to check sibling categories", err)
 	}
 
-	for _, sibling := range siblings {
-		if excludeID != 0 && sibling.ID == excludeID {
-			continue
-		}
+	if len(siblings) > 0 {
 		return pkgErrors.NewWithTag(
 			pkgErrors.ErrCodeValidation,
 			[]string{string(pkgErrors.ErrorTagDuplicateCategoryName)},

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -25,7 +25,7 @@ type TransactionService interface {
 	Delete(ctx context.Context, userID int, id int, propagationSettings domain.TransactionPropagationSettings) error
 	GetBalance(ctx context.Context, userID int, period domain.Period, filter domain.BalanceFilter) (*domain.BalanceResult, error)
 	ParseImportCSV(ctx context.Context, userID, accountID int, decimalSeparator domain.ImportDecimalSeparatorValue, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte) (*domain.ImportCSVResponse, error)
-	CheckDuplicateTransaction(ctx context.Context, userID int, date string, description string, amount int64, accountID *int) (bool, error)
+	CheckDuplicateTransaction(ctx context.Context, userID int, date string, amount int64, accountID *int) (bool, error)
 }
 
 type AccountService interface {

--- a/backend/internal/service/transaction_check_duplicate.go
+++ b/backend/internal/service/transaction_check_duplicate.go
@@ -7,12 +7,12 @@ import (
 	pkgErrors "github.com/finance_app/backend/pkg/errors"
 )
 
-// CheckDuplicateTransaction checks whether a transaction with the given date, description,
+// CheckDuplicateTransaction checks whether a transaction with the given date
 // and amount already exists for the user. date must be in "YYYY-MM-DD" format.
-func (s *transactionService) CheckDuplicateTransaction(ctx context.Context, userID int, date string, description string, amount int64, accountID *int) (bool, error) {
+func (s *transactionService) CheckDuplicateTransaction(ctx context.Context, userID int, date string, amount int64, accountID *int) (bool, error) {
 	t, err := time.Parse("2006-01-02", date)
 	if err != nil {
 		return false, pkgErrors.New(pkgErrors.ErrCodeBadRequest, "invalid date format, expected YYYY-MM-DD")
 	}
-	return isDuplicate(ctx, s, userID, description, t, amount, accountID), nil
+	return isDuplicate(ctx, s, userID, t, amount, accountID), nil
 }

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -339,7 +339,7 @@ var (
 // inferInstallment detects installment patterns in a transaction description.
 // When multiple matches exist, the last one wins.
 // Returns the cleaned description, current installment, total installments, and whether a match was found.
-func inferInstallment(description string) (cleanDesc string, current int, total int, found bool) {
+func inferInstallment(description string) (string, int, int, bool) {
 	type match struct {
 		current int
 		total   int
@@ -365,12 +365,9 @@ func inferInstallment(description string) (cleanDesc string, current int, total 
 
 	// Last match wins for values
 	last := matches[len(matches)-1]
-	current = last.current
-	total = last.total
 
 	// Remove all matches from description (right to left to preserve indices)
 	cleaned := description
-	// Sort by start position descending
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
 		cleaned = cleaned[:m.start] + cleaned[m.end:]
@@ -379,7 +376,7 @@ func inferInstallment(description string) (cleanDesc string, current int, total 
 	cleaned = strings.TrimRight(cleaned, " -–—")
 	cleaned = strings.TrimSpace(cleaned)
 
-	return cleaned, current, total, true
+	return cleaned, last.current, last.total, true
 }
 
 func normalize(s string) string {

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -23,6 +24,7 @@ type csvColumnIndex struct {
 	date        int
 	description int
 	amount      int
+	category    int // optional column; -1 when absent
 }
 
 func (s *transactionService) ParseImportCSV(ctx context.Context, userID, accountID int, decimalSeparator domain.ImportDecimalSeparatorValue, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte) (*domain.ImportCSVResponse, error) {
@@ -135,7 +137,7 @@ func detectSeparator(line string) rune {
 
 func parseCSVHeader(header []string) (csvColumnIndex, error) {
 	idx := csvColumnIndex{
-		date: -1, description: -1, amount: -1,
+		date: -1, description: -1, amount: -1, category: -1,
 	}
 
 	for i, col := range header {
@@ -146,6 +148,8 @@ func parseCSVHeader(header []string) (csvColumnIndex, error) {
 			idx.description = i
 		case "valor", "amount", "total":
 			idx.amount = i
+		case "categoria", "category":
+			idx.category = i
 		}
 	}
 
@@ -210,10 +214,19 @@ func parseCSVRow(
 		}
 	}
 
-	// 2. Descrição
+	// 2. Descrição + inferência de parcelamento
 	row.Description = getField(colIdx.description)
 	if row.Description == "" {
 		row.ParseErrors = append(row.ParseErrors, "Descrição é obrigatória")
+	} else {
+		cleanDesc, current, total, found := inferInstallment(row.Description)
+		if found {
+			row.Description = cleanDesc
+			recType := domain.RecurrenceTypeMonthly
+			row.RecurrenceType = &recType
+			row.RecurrenceCount = &total
+			row.RecurrenceCurrentInstallment = &current
+		}
 	}
 
 	// 3. Valor e Inferência de Tipo
@@ -242,9 +255,28 @@ func parseCSVRow(
 		}
 	}
 
-	// 4. Detecção de duplicados
-	if row.Date != nil && row.Description != "" && row.Amount > 0 {
-		if isDuplicate(ctx, s, userID, row.Description, *row.Date, row.Amount, &accountID) {
+	// 4. Categoria opcional
+	categoryName := getField(colIdx.category)
+	if categoryName != "" {
+		categories, err := s.services.Category.Search(ctx, domain.CategorySearchOptions{
+			UserIDs: []int{userID},
+		})
+		if err == nil {
+			normalizedInput := normalize(categoryName)
+			for _, cat := range categories {
+				if normalize(cat.Name) == normalizedInput {
+					catID := cat.ID
+					row.CategoryID = &catID
+					row.CategoryInferred = true
+					break
+				}
+			}
+		}
+	}
+
+	// 5. Detecção de duplicados
+	if row.Date != nil && row.Amount > 0 {
+		if isDuplicate(ctx, s, userID, *row.Date, row.Amount, &accountID) {
 			row.Status = domain.ImportRowStatusDuplicate
 		}
 	}
@@ -271,16 +303,15 @@ func parseAmountSigned(s string, decimalSeparator domain.ImportDecimalSeparatorV
 	return int64(math.Round(f * 100)), nil
 }
 
-// isDuplicate verifica se a transação já existe.
-func isDuplicate(ctx context.Context, s *transactionService, userID int, description string, date time.Time, amount int64, accountID *int) bool {
+// isDuplicate verifica se a transação já existe baseado em data, valor e conta.
+func isDuplicate(ctx context.Context, s *transactionService, userID int, date time.Time, amount int64, accountID *int) bool {
 	dayStart := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.UTC)
 	dayEnd := dayStart.Add(24*time.Hour - time.Nanosecond)
 
 	filter := domain.TransactionFilter{
-		UserID:      &userID,
-		Description: &domain.TextSearch{Query: description, Exact: true},
-		StartDate:   &domain.ComparableSearch[time.Time]{GreaterThanOrEqual: &dayStart},
-		EndDate:     &domain.ComparableSearch[time.Time]{LessThanOrEqual: &dayEnd},
+		UserID:    &userID,
+		StartDate: &domain.ComparableSearch[time.Time]{GreaterThanOrEqual: &dayStart},
+		EndDate:   &domain.ComparableSearch[time.Time]{LessThanOrEqual: &dayEnd},
 	}
 	if accountID != nil {
 		filter.AccountIDs = []int{*accountID}
@@ -296,6 +327,59 @@ func isDuplicate(ctx context.Context, s *transactionService, userID int, descrip
 		}
 	}
 	return false
+}
+
+var (
+	// "Parcela 1 de 2", "parcela 3 de 12"
+	installmentParcelaRe = regexp.MustCompile(`(?i)[-–—\s]*parcela\s+(\d+)\s+de\s+(\d+)`)
+	// "(1/2)", "(1 / 12)", "( 3 / 12 )"
+	installmentSlashRe = regexp.MustCompile(`\(\s*(\d+)\s*/\s*(\d+)\s*\)`)
+)
+
+// inferInstallment detects installment patterns in a transaction description.
+// When multiple matches exist, the last one wins.
+// Returns the cleaned description, current installment, total installments, and whether a match was found.
+func inferInstallment(description string) (cleanDesc string, current int, total int, found bool) {
+	type match struct {
+		current int
+		total   int
+		start   int
+		end     int
+	}
+
+	var matches []match
+
+	for _, re := range []*regexp.Regexp{installmentParcelaRe, installmentSlashRe} {
+		for _, loc := range re.FindAllStringSubmatchIndex(description, -1) {
+			cur, _ := strconv.Atoi(description[loc[2]:loc[3]])
+			tot, _ := strconv.Atoi(description[loc[4]:loc[5]])
+			if cur > 0 && tot > 0 {
+				matches = append(matches, match{current: cur, total: tot, start: loc[0], end: loc[1]})
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		return description, 0, 0, false
+	}
+
+	// Last match wins for values
+	last := matches[len(matches)-1]
+	current = last.current
+	total = last.total
+
+	// Remove all matches from description (right to left to preserve indices)
+	cleaned := description
+	// Sort by start position descending
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+		cleaned = cleaned[:m.start] + cleaned[m.end:]
+	}
+
+	cleaned = strings.TrimRight(cleaned, " -–—")
+	cleaned = strings.TrimSpace(cleaned)
+
+	return cleaned, current, total, true
 }
 
 func normalize(s string) string {

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -260,17 +260,12 @@ func parseCSVRow(
 	if categoryName != "" {
 		categories, err := s.services.Category.Search(ctx, domain.CategorySearchOptions{
 			UserIDs: []int{userID},
+			Name:    &categoryName,
 		})
-		if err == nil {
-			normalizedInput := normalize(categoryName)
-			for _, cat := range categories {
-				if normalize(cat.Name) == normalizedInput {
-					catID := cat.ID
-					row.CategoryID = &catID
-					row.CategoryInferred = true
-					break
-				}
-			}
+		if err == nil && len(categories) > 0 {
+			catID := categories[0].ID
+			row.CategoryID = &catID
+			row.CategoryInferred = true
 		}
 	}
 

--- a/backend/internal/service/transaction_import_test.go
+++ b/backend/internal/service/transaction_import_test.go
@@ -95,6 +95,36 @@ func TestParseCSVHeader(t *testing.T) {
 				assert.Equal(t, 1, idx.description)
 			},
 		},
+		{
+			name:    "with optional category column",
+			header:  []string{"Data", "Descrição", "Valor", "Categoria"},
+			wantErr: false,
+			checks: func(t *testing.T, idx csvColumnIndex) {
+				t.Helper()
+				assert.Equal(t, 0, idx.date)
+				assert.Equal(t, 1, idx.description)
+				assert.Equal(t, 2, idx.amount)
+				assert.Equal(t, 3, idx.category)
+			},
+		},
+		{
+			name:    "category column english",
+			header:  []string{"Data", "Descrição", "Valor", "Category"},
+			wantErr: false,
+			checks: func(t *testing.T, idx csvColumnIndex) {
+				t.Helper()
+				assert.Equal(t, 3, idx.category)
+			},
+		},
+		{
+			name:    "without category column keeps -1",
+			header:  []string{"Data", "Descrição", "Valor"},
+			wantErr: false,
+			checks: func(t *testing.T, idx csvColumnIndex) {
+				t.Helper()
+				assert.Equal(t, -1, idx.category)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -118,10 +148,15 @@ func TestParseCSVHeader(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 const csvSimpleHeader = "Data;Descrição;Valor"
+const csvHeaderWithCategory = "Data;Descrição;Valor;Categoria"
 
 func buildCSV(rows [][]string) []byte {
+	return buildCSVWithHeader(csvSimpleHeader, rows)
+}
+
+func buildCSVWithHeader(header string, rows [][]string) []byte {
 	lines := make([]string, 0, len(rows)+1)
-	lines = append(lines, csvSimpleHeader)
+	lines = append(lines, header)
 	for _, row := range rows {
 		lines = append(lines, strings.Join(row, ";"))
 	}
@@ -266,15 +301,232 @@ func (suite *TransactionImportWithDBTestSuite) TestCheckDuplicateTransaction() {
 		})
 		suite.Require().NoError(err)
 
-		isDup, err := suite.Services.Transaction.CheckDuplicateTransaction(ctx, user.ID, "2026-03-20", "Spotify Check", 7500, &account.ID)
+		isDup, err := suite.Services.Transaction.CheckDuplicateTransaction(ctx, user.ID, "2026-03-20", 7500, &account.ID)
 		suite.Require().NoError(err)
 		suite.True(isDup)
 	})
 
-	suite.Run("no matching transaction returns false", func() {
-		isDup, err := suite.Services.Transaction.CheckDuplicateTransaction(ctx, user.ID, "2026-03-20", "NonExistentDesc12345", 9999, &account.ID)
+	suite.Run("duplicate detected regardless of description", func() {
+		_, err := suite.Services.Transaction.Create(ctx, user.ID, &domain.TransactionCreateRequest{
+			AccountID:       account.ID,
+			TransactionType: domain.TransactionTypeExpense,
+			CategoryID:      category.ID,
+			Amount:          8800,
+			Date:            domain.Date{Time: txDate},
+			Description:     "Original Description",
+		})
+		suite.Require().NoError(err)
+
+		isDup, err := suite.Services.Transaction.CheckDuplicateTransaction(ctx, user.ID, "2026-03-20", 8800, &account.ID)
+		suite.Require().NoError(err)
+		suite.True(isDup)
+	})
+
+	suite.Run("no matching amount returns false", func() {
+		isDup, err := suite.Services.Transaction.CheckDuplicateTransaction(ctx, user.ID, "2026-03-20", 9999, &account.ID)
 		suite.Require().NoError(err)
 		suite.False(isDup)
+	})
+
+	suite.Run("different date returns false", func() {
+		isDup, err := suite.Services.Transaction.CheckDuplicateTransaction(ctx, user.ID, "2026-04-01", 7500, &account.ID)
+		suite.Require().NoError(err)
+		suite.False(isDup)
+	})
+}
+
+func TestInferInstallment(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		wantDesc    string
+		wantCurrent int
+		wantTotal   int
+		wantFound   bool
+	}{
+		{
+			name:        "Parcela X de Y",
+			input:       "Compra - Parcela 1 de 2",
+			wantDesc:    "Compra",
+			wantCurrent: 1,
+			wantTotal:   2,
+			wantFound:   true,
+		},
+		{
+			name:        "Parcela X de Y case insensitive",
+			input:       "Compra - parcela 3 de 12",
+			wantDesc:    "Compra",
+			wantCurrent: 3,
+			wantTotal:   12,
+			wantFound:   true,
+		},
+		{
+			name:        "(X/Y) no spaces",
+			input:       "Compra (1/12)",
+			wantDesc:    "Compra",
+			wantCurrent: 1,
+			wantTotal:   12,
+			wantFound:   true,
+		},
+		{
+			name:        "(X / Y) with spaces",
+			input:       "Compra (1 / 2)",
+			wantDesc:    "Compra",
+			wantCurrent: 1,
+			wantTotal:   2,
+			wantFound:   true,
+		},
+		{
+			name:        "multiple matches uses last",
+			input:       "Compra (1 / 12) (3 / 12)",
+			wantDesc:    "Compra",
+			wantCurrent: 3,
+			wantTotal:   12,
+			wantFound:   true,
+		},
+		{
+			name:        "no match",
+			input:       "Aluguel Janeiro",
+			wantDesc:    "Aluguel Janeiro",
+			wantCurrent: 0,
+			wantTotal:   0,
+			wantFound:   false,
+		},
+		{
+			name:        "parcela with em-dash separator",
+			input:       "Compra — Parcela 2 de 6",
+			wantDesc:    "Compra",
+			wantCurrent: 2,
+			wantTotal:   6,
+			wantFound:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			desc, current, total, found := inferInstallment(tc.input)
+			assert.Equal(t, tc.wantFound, found)
+			assert.Equal(t, tc.wantDesc, desc)
+			assert.Equal(t, tc.wantCurrent, current)
+			assert.Equal(t, tc.wantTotal, total)
+		})
+	}
+}
+
+func (suite *TransactionImportWithDBTestSuite) TestCategoryInference() {
+	ctx := context.Background()
+
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	account, err := suite.createTestAccount(ctx, user)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, user)
+	suite.Require().NoError(err)
+
+	suite.Run("category column with valid name", func() {
+		csv := buildCSVWithHeader(csvHeaderWithCategory, [][]string{
+			{"01/01/2026", "Compra", "-50,00", category.Name},
+		})
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		suite.Require().NoError(err)
+		suite.Require().NotNil(resp.Rows[0].CategoryID)
+		suite.Equal(category.ID, *resp.Rows[0].CategoryID)
+		suite.True(resp.Rows[0].CategoryInferred)
+	})
+
+	suite.Run("category column case insensitive match", func() {
+		csv := buildCSVWithHeader(csvHeaderWithCategory, [][]string{
+			{"01/01/2026", "Compra", "-50,00", strings.ToUpper(category.Name)},
+		})
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		suite.Require().NoError(err)
+		suite.Require().NotNil(resp.Rows[0].CategoryID)
+		suite.Equal(category.ID, *resp.Rows[0].CategoryID)
+	})
+
+	suite.Run("category column with invalid name", func() {
+		csv := buildCSVWithHeader(csvHeaderWithCategory, [][]string{
+			{"01/01/2026", "Compra", "-50,00", "NonExistent Category 12345"},
+		})
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		suite.Require().NoError(err)
+		suite.Nil(resp.Rows[0].CategoryID)
+		suite.False(resp.Rows[0].CategoryInferred)
+	})
+
+	suite.Run("category column empty", func() {
+		csv := buildCSVWithHeader(csvHeaderWithCategory, [][]string{
+			{"01/01/2026", "Compra", "-50,00", ""},
+		})
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		suite.Require().NoError(err)
+		suite.Nil(resp.Rows[0].CategoryID)
+		suite.False(resp.Rows[0].CategoryInferred)
+	})
+
+	suite.Run("no category column same as before", func() {
+		csv := buildCSV([][]string{
+			{"01/01/2026", "Compra", "-50,00"},
+		})
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		suite.Require().NoError(err)
+		suite.Nil(resp.Rows[0].CategoryID)
+		suite.False(resp.Rows[0].CategoryInferred)
+	})
+}
+
+func (suite *TransactionImportWithDBTestSuite) TestInstallmentInference() {
+	ctx := context.Background()
+
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	account, err := suite.createTestAccount(ctx, user)
+	suite.Require().NoError(err)
+
+	suite.Run("parcela pattern", func() {
+		csv := buildCSV([][]string{
+			{"01/01/2026", "Compra - Parcela 1 de 3", "-150,00"},
+		})
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		suite.Require().NoError(err)
+		row := resp.Rows[0]
+		suite.Equal("Compra", row.Description)
+		suite.Require().NotNil(row.RecurrenceType)
+		suite.Equal(domain.RecurrenceTypeMonthly, *row.RecurrenceType)
+		suite.Require().NotNil(row.RecurrenceCount)
+		suite.Equal(3, *row.RecurrenceCount)
+		suite.Require().NotNil(row.RecurrenceCurrentInstallment)
+		suite.Equal(1, *row.RecurrenceCurrentInstallment)
+	})
+
+	suite.Run("slash pattern", func() {
+		csv := buildCSV([][]string{
+			{"01/01/2026", "Compra (2/12)", "-100,00"},
+		})
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		suite.Require().NoError(err)
+		row := resp.Rows[0]
+		suite.Equal("Compra", row.Description)
+		suite.Require().NotNil(row.RecurrenceCurrentInstallment)
+		suite.Equal(2, *row.RecurrenceCurrentInstallment)
+		suite.Require().NotNil(row.RecurrenceCount)
+		suite.Equal(12, *row.RecurrenceCount)
+	})
+
+	suite.Run("no installment pattern", func() {
+		csv := buildCSV([][]string{
+			{"01/01/2026", "Aluguel", "-1500,00"},
+		})
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		suite.Require().NoError(err)
+		row := resp.Rows[0]
+		suite.Equal("Aluguel", row.Description)
+		suite.Nil(row.RecurrenceType)
+		suite.Nil(row.RecurrenceCount)
+		suite.Nil(row.RecurrenceCurrentInstallment)
 	})
 }
 

--- a/backend/migrations/20260429171825_add_category_name_index.sql
+++ b/backend/migrations/20260429171825_add_category_name_index.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+CREATE INDEX idx_categories_user_lower_name ON categories(user_id, (LOWER(name)));
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_categories_user_lower_name;

--- a/backend/mocks/mock_TransactionService.go
+++ b/backend/mocks/mock_TransactionService.go
@@ -22,9 +22,9 @@ func (_m *MockTransactionService) EXPECT() *MockTransactionService_Expecter {
 	return &MockTransactionService_Expecter{mock: &_m.Mock}
 }
 
-// CheckDuplicateTransaction provides a mock function with given fields: ctx, userID, date, description, amount, accountID
-func (_m *MockTransactionService) CheckDuplicateTransaction(ctx context.Context, userID int, date string, description string, amount int64, accountID *int) (bool, error) {
-	ret := _m.Called(ctx, userID, date, description, amount, accountID)
+// CheckDuplicateTransaction provides a mock function with given fields: ctx, userID, date, amount, accountID
+func (_m *MockTransactionService) CheckDuplicateTransaction(ctx context.Context, userID int, date string, amount int64, accountID *int) (bool, error) {
+	ret := _m.Called(ctx, userID, date, amount, accountID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckDuplicateTransaction")
@@ -32,17 +32,17 @@ func (_m *MockTransactionService) CheckDuplicateTransaction(ctx context.Context,
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int, string, string, int64, *int) (bool, error)); ok {
-		return rf(ctx, userID, date, description, amount, accountID)
+	if rf, ok := ret.Get(0).(func(context.Context, int, string, int64, *int) (bool, error)); ok {
+		return rf(ctx, userID, date, amount, accountID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int, string, string, int64, *int) bool); ok {
-		r0 = rf(ctx, userID, date, description, amount, accountID)
+	if rf, ok := ret.Get(0).(func(context.Context, int, string, int64, *int) bool); ok {
+		r0 = rf(ctx, userID, date, amount, accountID)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int, string, string, int64, *int) error); ok {
-		r1 = rf(ctx, userID, date, description, amount, accountID)
+	if rf, ok := ret.Get(1).(func(context.Context, int, string, int64, *int) error); ok {
+		r1 = rf(ctx, userID, date, amount, accountID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,16 +59,15 @@ type MockTransactionService_CheckDuplicateTransaction_Call struct {
 //   - ctx context.Context
 //   - userID int
 //   - date string
-//   - description string
 //   - amount int64
 //   - accountID *int
-func (_e *MockTransactionService_Expecter) CheckDuplicateTransaction(ctx interface{}, userID interface{}, date interface{}, description interface{}, amount interface{}, accountID interface{}) *MockTransactionService_CheckDuplicateTransaction_Call {
-	return &MockTransactionService_CheckDuplicateTransaction_Call{Call: _e.mock.On("CheckDuplicateTransaction", ctx, userID, date, description, amount, accountID)}
+func (_e *MockTransactionService_Expecter) CheckDuplicateTransaction(ctx interface{}, userID interface{}, date interface{}, amount interface{}, accountID interface{}) *MockTransactionService_CheckDuplicateTransaction_Call {
+	return &MockTransactionService_CheckDuplicateTransaction_Call{Call: _e.mock.On("CheckDuplicateTransaction", ctx, userID, date, amount, accountID)}
 }
 
-func (_c *MockTransactionService_CheckDuplicateTransaction_Call) Run(run func(ctx context.Context, userID int, date string, description string, amount int64, accountID *int)) *MockTransactionService_CheckDuplicateTransaction_Call {
+func (_c *MockTransactionService_CheckDuplicateTransaction_Call) Run(run func(ctx context.Context, userID int, date string, amount int64, accountID *int)) *MockTransactionService_CheckDuplicateTransaction_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int), args[2].(string), args[3].(string), args[4].(int64), args[5].(*int))
+		run(args[0].(context.Context), args[1].(int), args[2].(string), args[3].(int64), args[4].(*int))
 	})
 	return _c
 }
@@ -78,7 +77,7 @@ func (_c *MockTransactionService_CheckDuplicateTransaction_Call) Return(_a0 bool
 	return _c
 }
 
-func (_c *MockTransactionService_CheckDuplicateTransaction_Call) RunAndReturn(run func(context.Context, int, string, string, int64, *int) (bool, error)) *MockTransactionService_CheckDuplicateTransaction_Call {
+func (_c *MockTransactionService_CheckDuplicateTransaction_Call) RunAndReturn(run func(context.Context, int, string, int64, *int) (bool, error)) *MockTransactionService_CheckDuplicateTransaction_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -254,6 +254,39 @@ Mobile is the primary target.
 
 Tests live in `frontend/e2e/` (tests in `tests/`, page objects in `pages/`, helpers in `helpers/`). Run with `npm run test:e2e`.
 
+### Test isolation: one user per test case
+
+Each test case must create a **fresh user** with its own account and category via `getAuthTokenForUser` + `apiFetchAs` (from `e2e/helpers/api.ts`). Use `openAuthedPage(browser, token)` to get a browser page authenticated as that user. This prevents cross-test state pollution and makes tests order-independent.
+
+```ts
+test("my test", async ({ browser }) => {
+  const email = `e2e-mytest-${Date.now()}@financeapp.local`;
+  const token = await getAuthTokenForUser(email);
+
+  // Create test data as this user
+  const accRes = await apiFetchAs(token, "/api/accounts", {
+    method: "POST",
+    body: JSON.stringify({ name: "Test Account", initial_balance: 0 }),
+  });
+  const account = (await accRes.json()) as { id: number };
+
+  // Get an authenticated browser page
+  const page = await openAuthedPage(browser, token);
+  const myPage = new MyPageObject(page);
+  await myPage.goto();
+
+  // ... test logic ...
+
+  await page.close();
+});
+```
+
+Rules:
+- Use `{ browser }` fixture (not `{ page }`) so you can create a fresh context per user.
+- Always `await page.close()` at the end to release the browser context.
+- No `beforeAll` for shared accounts/categories — each test is self-contained.
+- API verification calls (e.g. listing transactions) must use `apiFetchAs(token, ...)` with the test user's token, not the global helpers.
+
 ### Selectors: `data-testid` only
 
 **E2E selectors must use `data-testid`.** This is non-negotiable: the library is an implementation detail and may change — testid-based selectors are the only ones that survive a component-library swap or a Mantine upgrade.
@@ -353,3 +386,4 @@ These exist in the codebase and agents should **not** copy them. When touching a
   - `e2e/pages/AccountsPage.ts` — `locator('input[inputmode="numeric"]')`.
 
   Replacement approach: add a `data-testid` on the target element in the component, then switch the test to `getByTestId`.
+- **Shared test users via `beforeAll`** — `e2e/tests/import.spec.ts`, `import-installment.spec.ts`, `import-split-settings.spec.ts`, `import-shift-select.spec.ts` use a shared account/category created in `beforeAll`. Migrate to one fresh user per test case using `getAuthTokenForUser` + `openAuthedPage` (see "Test isolation" section above).

--- a/frontend/e2e/tests/import-enhancements.spec.ts
+++ b/frontend/e2e/tests/import-enhancements.spec.ts
@@ -1,0 +1,296 @@
+import { test, expect } from "@playwright/test";
+import { ImportPage } from "../pages/ImportPage";
+import {
+  apiCreateAccount,
+  apiDeleteAccount,
+  apiCreateTransaction,
+  apiDeleteTransaction,
+  apiCreateCategory,
+  apiDeleteCategory,
+  apiListTransactions,
+} from "../helpers/api";
+import { ImportTestIds } from '@/testIds'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const CSV_HEADER = "Data;Descrição;Valor";
+const CSV_HEADER_WITH_CATEGORY = "Data;Descrição;Valor;Categoria";
+
+function buildCsvContent(rows: string[][], header = CSV_HEADER): string {
+  return [header, ...rows.map((r) => r.join(";"))].join("\n");
+}
+
+function formatDateBR(d: Date): string {
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}/${mm}/${d.getFullYear()}`;
+}
+
+function formatDateISO(d: Date): string {
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+// ─── Category inference ─────────────────────────────────────────────────────
+
+test.describe("Import: category column inference", () => {
+  let importPage: ImportPage;
+  let testAccountId: number;
+  let testCategoryId: number;
+  let testCategoryName: string;
+
+  test.beforeAll(async () => {
+    const uid = Date.now();
+    const account = await apiCreateAccount({
+      name: `Conta CatInf ${uid}`,
+      initial_balance: 0,
+    });
+    testAccountId = account.id;
+
+    testCategoryName = `CatInfer ${uid}`;
+    const category = await apiCreateCategory({ name: testCategoryName });
+    testCategoryId = category.id;
+  });
+
+  test.afterAll(async () => {
+    await apiDeleteCategory(testCategoryId).catch(() => undefined);
+    await apiDeleteAccount(testAccountId).catch(() => undefined);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    importPage = new ImportPage(page);
+    await importPage.goto();
+  });
+
+  test("CSV with Categoria column pre-selects matching category", async () => {
+    const description = `Cat Col Match ${Date.now()}`;
+    const txDate = new Date(2026, 6, 10);
+
+    const csv = buildCsvContent(
+      [[formatDateBR(txDate), description, "-100,00", testCategoryName]],
+      CSV_HEADER_WITH_CATEGORY,
+    );
+
+    await importPage.uploadCSV(csv, testAccountId);
+
+    // Category should be auto-selected
+    const categoryValue = await importPage.getRowCategoryValue(0);
+    expect(categoryValue).toContain(testCategoryName);
+
+    // Confirm import succeeds without manually selecting category
+    await importPage.confirmImport();
+
+    const transactions = await apiListTransactions(7, 2026);
+    const tx = transactions.find((t) => t.description === description);
+    expect(tx, "transaction should exist").toBeDefined();
+    expect(tx!.category_id).toBe(testCategoryId);
+  });
+
+  test("CSV with Categoria column case-insensitive match", async () => {
+    const description = `Cat Col Case ${Date.now()}`;
+    const txDate = new Date(2026, 6, 11);
+
+    const csv = buildCsvContent(
+      [[formatDateBR(txDate), description, "-50,00", testCategoryName.toUpperCase()]],
+      CSV_HEADER_WITH_CATEGORY,
+    );
+
+    await importPage.uploadCSV(csv, testAccountId);
+
+    const categoryValue = await importPage.getRowCategoryValue(0);
+    expect(categoryValue).toContain(testCategoryName);
+  });
+
+  test("CSV with Categoria column unknown name leaves category empty", async () => {
+    const description = `Cat Col Unknown ${Date.now()}`;
+    const txDate = new Date(2026, 6, 12);
+
+    const csv = buildCsvContent(
+      [[formatDateBR(txDate), description, "-75,00", "NonExistentCategory12345"]],
+      CSV_HEADER_WITH_CATEGORY,
+    );
+
+    await importPage.uploadCSV(csv, testAccountId);
+
+    const categoryValue = await importPage.getRowCategoryValue(0);
+    expect(categoryValue).toBe("");
+  });
+});
+
+// ─── Installment inference ─────────────────────────────────────────────────
+
+test.describe("Import: installment inference from description", () => {
+  let importPage: ImportPage;
+  let testAccountId: number;
+  let testCategoryId: number;
+
+  test.beforeAll(async () => {
+    const uid = Date.now();
+    const account = await apiCreateAccount({
+      name: `Conta InstInf ${uid}`,
+      initial_balance: 0,
+    });
+    testAccountId = account.id;
+
+    const category = await apiCreateCategory({ name: `CatInstInf ${uid}` });
+    testCategoryId = category.id;
+  });
+
+  test.afterAll(async () => {
+    await apiDeleteCategory(testCategoryId).catch(() => undefined);
+    await apiDeleteAccount(testAccountId).catch(() => undefined);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    importPage = new ImportPage(page);
+    await importPage.goto();
+  });
+
+  test("Parcela X de Y pattern: recurrence pre-filled and description cleaned", async () => {
+    const txDate = new Date(2026, 7, 15);
+    const rawDesc = `Compra Parcela - Parcela 2 de 6`;
+
+    const csv = buildCsvContent([[formatDateBR(txDate), rawDesc, "-200,00"]]);
+
+    await importPage.uploadCSV(csv, testAccountId);
+    await importPage.setRowCategory(0, testCategoryId);
+
+    // Recurrence button should show pre-filled summary (e.g. "6x (Mensal)")
+    const recurrenceBtn = importPage.reviewStep.getByTestId(
+      ImportTestIds.RowBtnRecurrencePopover(0),
+    );
+    await expect(recurrenceBtn).toContainText("6x", { timeout: 5000 });
+
+    await importPage.confirmImport();
+
+    const transactions = await apiListTransactions(8, 2026);
+    const tx = transactions.find((t) => t.description === "Compra Parcela");
+    expect(tx, "transaction should exist with cleaned description").toBeDefined();
+    expect(tx!.installment_number).toBe(2);
+    expect(tx!.transaction_recurrence?.type).toBe("monthly");
+    expect(tx!.transaction_recurrence?.installments).toBe(6);
+  });
+
+  test("(X/Y) slash pattern: recurrence pre-filled and description cleaned", async () => {
+    const txDate = new Date(2026, 7, 16);
+    const rawDesc = `Loja Online (3/12)`;
+
+    const csv = buildCsvContent([[formatDateBR(txDate), rawDesc, "-150,00"]]);
+
+    await importPage.uploadCSV(csv, testAccountId);
+    await importPage.setRowCategory(0, testCategoryId);
+
+    const recurrenceBtn = importPage.reviewStep.getByTestId(
+      ImportTestIds.RowBtnRecurrencePopover(0),
+    );
+    await expect(recurrenceBtn).toContainText("12x", { timeout: 5000 });
+
+    await importPage.confirmImport();
+
+    const transactions = await apiListTransactions(8, 2026);
+    const tx = transactions.find((t) => t.description === "Loja Online");
+    expect(tx, "transaction should exist with cleaned description").toBeDefined();
+    expect(tx!.installment_number).toBe(3);
+    expect(tx!.transaction_recurrence?.installments).toBe(12);
+  });
+
+  test("no installment pattern: no recurrence pre-filled", async () => {
+    const description = `Aluguel Normal ${Date.now()}`;
+    const txDate = new Date(2026, 7, 17);
+
+    const csv = buildCsvContent([[formatDateBR(txDate), description, "-1500,00"]]);
+
+    await importPage.uploadCSV(csv, testAccountId);
+
+    // Recurrence button should show default "Parcelamento" (no pre-fill)
+    const recurrenceBtn = importPage.reviewStep.getByTestId(
+      ImportTestIds.RowBtnRecurrencePopover(0),
+    );
+    await expect(recurrenceBtn).toContainText("Parcelamento");
+  });
+});
+
+// ─── Duplicate detection without description ────────────────────────────────
+
+test.describe("Import: duplicate detection ignores description", () => {
+  let importPage: ImportPage;
+  let testAccountId: number;
+  let testCategoryId: number;
+  const createdTransactionIds: number[] = [];
+
+  test.beforeAll(async () => {
+    const uid = Date.now();
+    const account = await apiCreateAccount({
+      name: `Conta DupNoDesc ${uid}`,
+      initial_balance: 0,
+    });
+    testAccountId = account.id;
+
+    const category = await apiCreateCategory({ name: `CatDupNoDesc ${uid}` });
+    testCategoryId = category.id;
+  });
+
+  test.afterAll(async () => {
+    for (const id of createdTransactionIds) {
+      await apiDeleteTransaction(id).catch(() => undefined);
+    }
+    await apiDeleteCategory(testCategoryId).catch(() => undefined);
+    await apiDeleteAccount(testAccountId).catch(() => undefined);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    importPage = new ImportPage(page);
+    await importPage.goto();
+  });
+
+  test("same date+amount but different description is detected as duplicate", async () => {
+    const txDate = new Date(2026, 8, 10);
+
+    // Pre-create transaction with one description
+    const created = await apiCreateTransaction({
+      account_id: testAccountId,
+      transaction_type: "expense",
+      category_id: testCategoryId,
+      amount: 15000,
+      date: formatDateISO(txDate),
+      description: `Original Desc ${Date.now()}`,
+    });
+    createdTransactionIds.push(created.id);
+
+    // Import CSV with same date+amount but completely different description
+    const csv = buildCsvContent([
+      [formatDateBR(txDate), `Totally Different ${Date.now()}`, "-150,00"],
+    ]);
+
+    await importPage.uploadCSV(csv, testAccountId);
+
+    // Should be marked as duplicate despite different description
+    const actionLabel = await importPage.getRowActionLabel(0);
+    expect(actionLabel).toBe("Duplicado");
+  });
+
+  test("same date but different amount is NOT a duplicate", async () => {
+    const txDate = new Date(2026, 8, 11);
+
+    const created = await apiCreateTransaction({
+      account_id: testAccountId,
+      transaction_type: "expense",
+      category_id: testCategoryId,
+      amount: 20000,
+      date: formatDateISO(txDate),
+      description: `Amt Diff ${Date.now()}`,
+    });
+    createdTransactionIds.push(created.id);
+
+    // Import CSV with same date but different amount
+    const csv = buildCsvContent([
+      [formatDateBR(txDate), `Amt Diff Other ${Date.now()}`, "-99,00"],
+    ]);
+
+    await importPage.uploadCSV(csv, testAccountId);
+
+    const actionLabel = await importPage.getRowActionLabel(0);
+    expect(actionLabel).toBe("Importar");
+  });
+});

--- a/frontend/e2e/tests/import-enhancements.spec.ts
+++ b/frontend/e2e/tests/import-enhancements.spec.ts
@@ -1,15 +1,12 @@
 import { test, expect } from "@playwright/test";
 import { ImportPage } from "../pages/ImportPage";
 import {
-  apiCreateAccount,
-  apiDeleteAccount,
-  apiCreateTransaction,
-  apiDeleteTransaction,
-  apiCreateCategory,
-  apiDeleteCategory,
-  apiListTransactions,
+  getAuthTokenForUser,
+  openAuthedPage,
+  apiFetchAs,
 } from "../helpers/api";
 import { ImportTestIds } from '@/testIds'
+import type { Transactions } from '@/types/transactions'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -32,131 +29,142 @@ function formatDateISO(d: Date): string {
   return `${d.getFullYear()}-${mm}-${dd}`;
 }
 
+function localMidnightISO(dateStr: string): string {
+  return `${dateStr}T00:00:00.000Z`;
+}
+
+/** Create a fresh user with account and category, return all handles. */
+async function createTestUser(suffix: string) {
+  const uid = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const email = `e2e-${suffix}-${uid}@financeapp.local`;
+  const token = await getAuthTokenForUser(email);
+
+  const accountRes = await apiFetchAs(token, "/api/accounts", {
+    method: "POST",
+    body: JSON.stringify({ name: `Account ${uid}`, initial_balance: 0 }),
+  });
+  const account = (await accountRes.json()) as { id: number; name: string };
+
+  const categoryName = `Category ${uid}`;
+  const catRes = await apiFetchAs(token, "/api/categories", {
+    method: "POST",
+    body: JSON.stringify({ name: categoryName }),
+  });
+  const category = (await catRes.json()) as { id: number; name: string };
+
+  return { token, email, accountId: account.id, categoryId: category.id, categoryName };
+}
+
+async function createTransactionAs(
+  token: string,
+  payload: { account_id: number; category_id: number; amount: number; date: string; description: string },
+) {
+  const res = await apiFetchAs(token, "/api/transactions", {
+    method: "POST",
+    body: JSON.stringify({
+      transaction_type: "expense",
+      ...payload,
+      date: localMidnightISO(payload.date),
+    }),
+  });
+  return (await res.json()) as { id: number };
+}
+
+async function listTransactionsAs(token: string, month: number, year: number) {
+  const res = await apiFetchAs(token, `/api/transactions?month=${month}&year=${year}`);
+  return (await res.json()) as Transactions.Transaction[];
+}
+
 // ─── Category inference ─────────────────────────────────────────────────────
 
 test.describe("Import: category column inference", () => {
-  let importPage: ImportPage;
-  let testAccountId: number;
-  let testCategoryId: number;
-  let testCategoryName: string;
-
-  test.beforeAll(async () => {
-    const uid = Date.now();
-    const account = await apiCreateAccount({
-      name: `Conta CatInf ${uid}`,
-      initial_balance: 0,
-    });
-    testAccountId = account.id;
-
-    testCategoryName = `CatInfer ${uid}`;
-    const category = await apiCreateCategory({ name: testCategoryName });
-    testCategoryId = category.id;
-  });
-
-  test.afterAll(async () => {
-    await apiDeleteCategory(testCategoryId).catch(() => undefined);
-    await apiDeleteAccount(testAccountId).catch(() => undefined);
-  });
-
-  test.beforeEach(async ({ page }) => {
-    importPage = new ImportPage(page);
+  test("CSV with Categoria column pre-selects matching category", async ({ browser }) => {
+    const user = await createTestUser("cat-match");
+    const page = await openAuthedPage(browser, user.token);
+    const importPage = new ImportPage(page);
     await importPage.goto();
-  });
 
-  test("CSV with Categoria column pre-selects matching category", async () => {
     const description = `Cat Col Match ${Date.now()}`;
     const txDate = new Date(2026, 6, 10);
 
     const csv = buildCsvContent(
-      [[formatDateBR(txDate), description, "-100,00", testCategoryName]],
+      [[formatDateBR(txDate), description, "-100,00", user.categoryName]],
       CSV_HEADER_WITH_CATEGORY,
     );
 
-    await importPage.uploadCSV(csv, testAccountId);
+    await importPage.uploadCSV(csv, user.accountId);
 
-    // Category should be auto-selected
     const categoryValue = await importPage.getRowCategoryValue(0);
-    expect(categoryValue).toContain(testCategoryName);
+    expect(categoryValue).toContain(user.categoryName);
 
-    // Confirm import succeeds without manually selecting category
     await importPage.confirmImport();
 
-    const transactions = await apiListTransactions(7, 2026);
+    const transactions = await listTransactionsAs(user.token, 7, 2026);
     const tx = transactions.find((t) => t.description === description);
     expect(tx, "transaction should exist").toBeDefined();
-    expect(tx!.category_id).toBe(testCategoryId);
+    expect(tx!.category_id).toBe(user.categoryId);
+
+    await page.close();
   });
 
-  test("CSV with Categoria column case-insensitive match", async () => {
-    const description = `Cat Col Case ${Date.now()}`;
+  test("CSV with Categoria column case-insensitive match", async ({ browser }) => {
+    const user = await createTestUser("cat-case");
+    const page = await openAuthedPage(browser, user.token);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
     const txDate = new Date(2026, 6, 11);
 
     const csv = buildCsvContent(
-      [[formatDateBR(txDate), description, "-50,00", testCategoryName.toUpperCase()]],
+      [[formatDateBR(txDate), `Cat Case ${Date.now()}`, "-50,00", user.categoryName.toUpperCase()]],
       CSV_HEADER_WITH_CATEGORY,
     );
 
-    await importPage.uploadCSV(csv, testAccountId);
+    await importPage.uploadCSV(csv, user.accountId);
 
     const categoryValue = await importPage.getRowCategoryValue(0);
-    expect(categoryValue).toContain(testCategoryName);
+    expect(categoryValue).toContain(user.categoryName);
+
+    await page.close();
   });
 
-  test("CSV with Categoria column unknown name leaves category empty", async () => {
-    const description = `Cat Col Unknown ${Date.now()}`;
+  test("CSV with Categoria column unknown name leaves category empty", async ({ browser }) => {
+    const user = await createTestUser("cat-unknown");
+    const page = await openAuthedPage(browser, user.token);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
     const txDate = new Date(2026, 6, 12);
 
     const csv = buildCsvContent(
-      [[formatDateBR(txDate), description, "-75,00", "NonExistentCategory12345"]],
+      [[formatDateBR(txDate), `Cat Unknown ${Date.now()}`, "-75,00", "NonExistentCategory12345"]],
       CSV_HEADER_WITH_CATEGORY,
     );
 
-    await importPage.uploadCSV(csv, testAccountId);
+    await importPage.uploadCSV(csv, user.accountId);
 
     const categoryValue = await importPage.getRowCategoryValue(0);
     expect(categoryValue).toBe("");
+
+    await page.close();
   });
 });
 
 // ─── Installment inference ─────────────────────────────────────────────────
 
 test.describe("Import: installment inference from description", () => {
-  let importPage: ImportPage;
-  let testAccountId: number;
-  let testCategoryId: number;
-
-  test.beforeAll(async () => {
-    const uid = Date.now();
-    const account = await apiCreateAccount({
-      name: `Conta InstInf ${uid}`,
-      initial_balance: 0,
-    });
-    testAccountId = account.id;
-
-    const category = await apiCreateCategory({ name: `CatInstInf ${uid}` });
-    testCategoryId = category.id;
-  });
-
-  test.afterAll(async () => {
-    await apiDeleteCategory(testCategoryId).catch(() => undefined);
-    await apiDeleteAccount(testAccountId).catch(() => undefined);
-  });
-
-  test.beforeEach(async ({ page }) => {
-    importPage = new ImportPage(page);
+  test("Parcela X de Y pattern: recurrence pre-filled and description cleaned", async ({ browser }) => {
+    const user = await createTestUser("inst-parcela");
+    const page = await openAuthedPage(browser, user.token);
+    const importPage = new ImportPage(page);
     await importPage.goto();
-  });
 
-  test("Parcela X de Y pattern: recurrence pre-filled and description cleaned", async () => {
     const txDate = new Date(2026, 7, 15);
-    const rawDesc = `Compra Parcela - Parcela 2 de 6`;
+    const csv = buildCsvContent([[formatDateBR(txDate), "Compra Parcela - Parcela 2 de 6", "-200,00"]]);
 
-    const csv = buildCsvContent([[formatDateBR(txDate), rawDesc, "-200,00"]]);
+    await importPage.uploadCSV(csv, user.accountId);
+    await importPage.setRowCategory(0, user.categoryId);
 
-    await importPage.uploadCSV(csv, testAccountId);
-    await importPage.setRowCategory(0, testCategoryId);
-
-    // Recurrence button should show pre-filled summary (e.g. "6x (Mensal)")
     const recurrenceBtn = importPage.reviewStep.getByTestId(
       ImportTestIds.RowBtnRecurrencePopover(0),
     );
@@ -164,22 +172,27 @@ test.describe("Import: installment inference from description", () => {
 
     await importPage.confirmImport();
 
-    const transactions = await apiListTransactions(8, 2026);
+    const transactions = await listTransactionsAs(user.token, 8, 2026);
     const tx = transactions.find((t) => t.description === "Compra Parcela");
     expect(tx, "transaction should exist with cleaned description").toBeDefined();
     expect(tx!.installment_number).toBe(2);
     expect(tx!.transaction_recurrence?.type).toBe("monthly");
     expect(tx!.transaction_recurrence?.installments).toBe(6);
+
+    await page.close();
   });
 
-  test("(X/Y) slash pattern: recurrence pre-filled and description cleaned", async () => {
+  test("(X/Y) slash pattern: recurrence pre-filled and description cleaned", async ({ browser }) => {
+    const user = await createTestUser("inst-slash");
+    const page = await openAuthedPage(browser, user.token);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
     const txDate = new Date(2026, 7, 16);
-    const rawDesc = `Loja Online (3/12)`;
+    const csv = buildCsvContent([[formatDateBR(txDate), "Loja Online (3/12)", "-150,00"]]);
 
-    const csv = buildCsvContent([[formatDateBR(txDate), rawDesc, "-150,00"]]);
-
-    await importPage.uploadCSV(csv, testAccountId);
-    await importPage.setRowCategory(0, testCategoryId);
+    await importPage.uploadCSV(csv, user.accountId);
+    await importPage.setRowCategory(0, user.categoryId);
 
     const recurrenceBtn = importPage.reviewStep.getByTestId(
       ImportTestIds.RowBtnRecurrencePopover(0),
@@ -188,109 +201,91 @@ test.describe("Import: installment inference from description", () => {
 
     await importPage.confirmImport();
 
-    const transactions = await apiListTransactions(8, 2026);
+    const transactions = await listTransactionsAs(user.token, 8, 2026);
     const tx = transactions.find((t) => t.description === "Loja Online");
     expect(tx, "transaction should exist with cleaned description").toBeDefined();
     expect(tx!.installment_number).toBe(3);
     expect(tx!.transaction_recurrence?.installments).toBe(12);
+
+    await page.close();
   });
 
-  test("no installment pattern: no recurrence pre-filled", async () => {
-    const description = `Aluguel Normal ${Date.now()}`;
+  test("no installment pattern: no recurrence pre-filled", async ({ browser }) => {
+    const user = await createTestUser("inst-none");
+    const page = await openAuthedPage(browser, user.token);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
     const txDate = new Date(2026, 7, 17);
+    const csv = buildCsvContent([[formatDateBR(txDate), `Aluguel Normal ${Date.now()}`, "-1500,00"]]);
 
-    const csv = buildCsvContent([[formatDateBR(txDate), description, "-1500,00"]]);
+    await importPage.uploadCSV(csv, user.accountId);
 
-    await importPage.uploadCSV(csv, testAccountId);
-
-    // Recurrence button should show default "Parcelamento" (no pre-fill)
     const recurrenceBtn = importPage.reviewStep.getByTestId(
       ImportTestIds.RowBtnRecurrencePopover(0),
     );
     await expect(recurrenceBtn).toContainText("Parcelamento");
+
+    await page.close();
   });
 });
 
 // ─── Duplicate detection without description ────────────────────────────────
 
 test.describe("Import: duplicate detection ignores description", () => {
-  let importPage: ImportPage;
-  let testAccountId: number;
-  let testCategoryId: number;
-  const createdTransactionIds: number[] = [];
-
-  test.beforeAll(async () => {
-    const uid = Date.now();
-    const account = await apiCreateAccount({
-      name: `Conta DupNoDesc ${uid}`,
-      initial_balance: 0,
-    });
-    testAccountId = account.id;
-
-    const category = await apiCreateCategory({ name: `CatDupNoDesc ${uid}` });
-    testCategoryId = category.id;
-  });
-
-  test.afterAll(async () => {
-    for (const id of createdTransactionIds) {
-      await apiDeleteTransaction(id).catch(() => undefined);
-    }
-    await apiDeleteCategory(testCategoryId).catch(() => undefined);
-    await apiDeleteAccount(testAccountId).catch(() => undefined);
-  });
-
-  test.beforeEach(async ({ page }) => {
-    importPage = new ImportPage(page);
-    await importPage.goto();
-  });
-
-  test("same date+amount but different description is detected as duplicate", async () => {
+  test("same date+amount but different description is detected as duplicate", async ({ browser }) => {
+    const user = await createTestUser("dup-desc");
     const txDate = new Date(2026, 8, 10);
 
-    // Pre-create transaction with one description
-    const created = await apiCreateTransaction({
-      account_id: testAccountId,
-      transaction_type: "expense",
-      category_id: testCategoryId,
+    await createTransactionAs(user.token, {
+      account_id: user.accountId,
+      category_id: user.categoryId,
       amount: 15000,
       date: formatDateISO(txDate),
       description: `Original Desc ${Date.now()}`,
     });
-    createdTransactionIds.push(created.id);
 
-    // Import CSV with same date+amount but completely different description
+    const page = await openAuthedPage(browser, user.token);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
     const csv = buildCsvContent([
       [formatDateBR(txDate), `Totally Different ${Date.now()}`, "-150,00"],
     ]);
 
-    await importPage.uploadCSV(csv, testAccountId);
+    await importPage.uploadCSV(csv, user.accountId);
 
-    // Should be marked as duplicate despite different description
     const actionSelect = importPage.reviewStep.getByTestId(ImportTestIds.RowSelectAction(0));
     await expect(actionSelect).toHaveValue("Duplicado", { timeout: 5000 });
+
+    await page.close();
   });
 
-  test("same date but different amount is NOT a duplicate", async () => {
+  test("same date but different amount is NOT a duplicate", async ({ browser }) => {
+    const user = await createTestUser("dup-amt");
     const txDate = new Date(2026, 8, 11);
 
-    const created = await apiCreateTransaction({
-      account_id: testAccountId,
-      transaction_type: "expense",
-      category_id: testCategoryId,
+    await createTransactionAs(user.token, {
+      account_id: user.accountId,
+      category_id: user.categoryId,
       amount: 20000,
       date: formatDateISO(txDate),
       description: `Amt Diff ${Date.now()}`,
     });
-    createdTransactionIds.push(created.id);
 
-    // Import CSV with same date but different amount
+    const page = await openAuthedPage(browser, user.token);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
     const csv = buildCsvContent([
       [formatDateBR(txDate), `Amt Diff Other ${Date.now()}`, "-99,00"],
     ]);
 
-    await importPage.uploadCSV(csv, testAccountId);
+    await importPage.uploadCSV(csv, user.accountId);
 
     const actionSelect = importPage.reviewStep.getByTestId(ImportTestIds.RowSelectAction(0));
     await expect(actionSelect).toHaveValue("Importar", { timeout: 5000 });
+
+    await page.close();
   });
 });

--- a/frontend/e2e/tests/import-enhancements.spec.ts
+++ b/frontend/e2e/tests/import-enhancements.spec.ts
@@ -266,8 +266,8 @@ test.describe("Import: duplicate detection ignores description", () => {
     await importPage.uploadCSV(csv, testAccountId);
 
     // Should be marked as duplicate despite different description
-    const actionLabel = await importPage.getRowActionLabel(0);
-    expect(actionLabel).toBe("Duplicado");
+    const actionSelect = importPage.reviewStep.getByTestId(ImportTestIds.RowSelectAction(0));
+    await expect(actionSelect).toHaveValue("Duplicado", { timeout: 5000 });
   });
 
   test("same date but different amount is NOT a duplicate", async () => {
@@ -290,7 +290,7 @@ test.describe("Import: duplicate detection ignores description", () => {
 
     await importPage.uploadCSV(csv, testAccountId);
 
-    const actionLabel = await importPage.getRowActionLabel(0);
-    expect(actionLabel).toBe("Importar");
+    const actionSelect = importPage.reviewStep.getByTestId(ImportTestIds.RowSelectAction(0));
+    await expect(actionSelect).toHaveValue("Importar", { timeout: 5000 });
   });
 });

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -138,7 +138,6 @@ export async function parseImportCSV(
 
 export async function checkDuplicateTransaction(params: {
   date: string;
-  description: string;
   amount: number;
   account_id: number;
 }): Promise<{ is_duplicate: boolean }> {

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -81,7 +81,6 @@ export const ImportReviewRow = memo(
       importError,
       parseErrors,
       date,
-      description,
       amount,
     ] = useWatch({
       control: form.control,
@@ -95,7 +94,6 @@ export const ImportReviewRow = memo(
         `rows.${rowIndex}.import_error`,
         `rows.${rowIndex}.parse_errors`,
         `rows.${rowIndex}.date`,
-        `rows.${rowIndex}.description`,
         `rows.${rowIndex}.amount`,
       ],
     });

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -104,7 +104,6 @@ export const ImportReviewRow = memo(
 
     useDuplicateTransactionCheck({
       date: date as string,
-      description: description as string,
       amount: amount as number,
       accountId: form.getValues("accountId"),
       getCurrentAction: () => form.getValues(`rows.${rowIndex}.action`),

--- a/frontend/src/components/transactions/import/importPayload.ts
+++ b/frontend/src/components/transactions/import/importPayload.ts
@@ -9,6 +9,11 @@ export const CSV_COLUMNS = [
     required: true,
     description: 'Valor da transação, se negativo será considerada uma despesa, se positivo uma receita',
   },
+  {
+    col: 'Categoria',
+    required: false,
+    description: 'Nome da categoria (opcional). Se informada e encontrada, será pré-selecionada',
+  },
 ]
 
 export function buildPayload(row: ImportRowFormValues): Transactions.CreateTransactionPayload {
@@ -65,7 +70,7 @@ export function parsedRowToFormValues(
     destination_account_id: r.destination_account_id ?? null,
     recurrenceEnabled: !!r.recurrence_type,
     recurrenceType: r.recurrence_type ?? null,
-    recurrenceCurrentInstallment: null,
+    recurrenceCurrentInstallment: r.recurrence_current_installment ?? null,
     recurrenceTotalInstallments: r.recurrence_count ?? null,
     split_settings: [],
   }

--- a/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
+++ b/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
@@ -4,7 +4,6 @@ import { checkDuplicateTransaction } from '@/api/transactions'
 
 interface Args {
   date: string
-  description: string
   amount: number
   accountId: number
   /**
@@ -19,12 +18,11 @@ interface Args {
 
 /**
  * Re-checks the import row against the backend for duplicates whenever the
- * date / description / amount change (debounced). Skips the initial mount
- * because the backend already returned duplicate status for the parsed CSV.
+ * date / amount change (debounced). Skips the initial mount because the
+ * backend already returned duplicate status for the parsed CSV.
  */
 export function useDuplicateTransactionCheck({
   date,
-  description,
   amount,
   accountId,
   getCurrentAction,
@@ -32,7 +30,6 @@ export function useDuplicateTransactionCheck({
   debounceMs = 500,
 }: Args) {
   const [debouncedDate] = useDebouncedValue(date, debounceMs)
-  const [debouncedDescription] = useDebouncedValue(description, debounceMs)
   const [debouncedAmount] = useDebouncedValue(amount, debounceMs)
 
   const isFirstRender = useRef(true)
@@ -42,11 +39,10 @@ export function useDuplicateTransactionCheck({
       isFirstRender.current = false
       return
     }
-    if (!debouncedDate || !debouncedDescription || !debouncedAmount || debouncedAmount <= 0) return
+    if (!debouncedDate || !debouncedAmount || debouncedAmount <= 0) return
 
     void checkDuplicateTransaction({
       date: debouncedDate,
-      description: debouncedDescription,
       amount: debouncedAmount,
       account_id: accountId,
     })
@@ -61,8 +57,8 @@ export function useDuplicateTransactionCheck({
       .catch(() => {
         /* ignore network errors */
       })
-    // Only react to the three debounced values; getCurrentAction/setAction
+    // Only react to the two debounced values; getCurrentAction/setAction
     // are stable RHF callbacks in practice.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedDate, debouncedDescription, debouncedAmount])
+  }, [debouncedDate, debouncedAmount])
 }

--- a/frontend/src/types/transactions.ts
+++ b/frontend/src/types/transactions.ts
@@ -209,6 +209,7 @@ export namespace Transactions {
     destination_account_id?: number;
     recurrence_type?: RecurrenceType;
     recurrence_count?: number;
+    recurrence_current_installment?: number;
     parse_errors?: string[];
   }
 


### PR DESCRIPTION
## Summary

Closes #109

- **Optional category column in CSV** — parser recognizes `Categoria`/`Category` header, looks up user categories by name (case-insensitive), and pre-fills `category_id` + `category_inferred` on matched rows. Unmatched names are silently ignored.
- **Installment inference from description** — detects `Parcela X de Y` and `(X/Y)` patterns via regex, extracts `recurrence_type=monthly` + current/total installments, and cleans the description. When multiple patterns match, last one wins.
- **Simplified duplicate detection** — removed `description` from the duplicate check criteria (both `isDuplicate` internal and `CheckDuplicateTransaction` API). Duplicates now match on date + amount + account only, fixing false negatives when the same transaction appears with slightly different descriptions across CSVs.

### Backend changes
| File | Change |
|------|--------|
| `domain/transaction_import.go` | Added `RecurrenceCurrentInstallment` to `ParsedImportRow`, removed `Description` from `CheckDuplicateRequest` |
| `service/transaction_import.go` | `inferInstallment()` function, category lookup in `parseCSVRow`, `isDuplicate` without description |
| `service/transaction_check_duplicate.go` | Removed `description` param from `CheckDuplicateTransaction` |
| `service/interfaces.go` | Updated `CheckDuplicateTransaction` signature |
| `handler/transaction_handler.go` | Updated `CheckDuplicate` handler call |
| `service/transaction_import_test.go` | 15+ new test cases (installment inference, category inference, updated duplicate tests) |

### Frontend changes
| File | Change |
|------|--------|
| `types/transactions.ts` | Added `recurrence_current_installment` to `ParsedImportRow` |
| `importPayload.ts` | Wire `recurrence_current_installment` to form, added Categoria to `CSV_COLUMNS` |
| `api/transactions.ts` | Removed `description` from `checkDuplicateTransaction` params |
| `useDuplicateTransactionCheck.ts` | Removed `description` from hook args and debounce |
| `ImportReviewRow.tsx` | Removed `description` from duplicate check hook call |

## Test plan

- [x] Unit tests pass: `TestInferInstallment` (7 cases — Parcela, slash, spaces, multiple matches, no match, em-dash)
- [x] Unit tests pass: `TestParseCSVHeader` (3 new cases — category column present, english, absent)
- [ ] Integration tests: `TestCategoryInference` (5 cases — valid name, case-insensitive, not found, empty, no column)
- [ ] Integration tests: `TestInstallmentInference` (3 cases — parcela, slash, no match)
- [ ] Integration tests: `TestCheckDuplicateTransaction` (updated — without description, new cases for amount/date mismatch)
- [ ] Integration tests: `TestParseImportCSV` existing tests still pass
- [ ] Frontend TypeScript compiles clean (`tsc --noEmit`)
- [ ] Manual: upload CSV with Categoria column → category pre-selected
- [ ] Manual: upload CSV with installment descriptions → recurrence pre-filled, description cleaned
- [ ] Manual: duplicate detection works without description match

🤖 Generated with [Claude Code](https://claude.com/claude-code)