### PR TITLE
ci: add manual PR preview workflow + multi-origin CORS

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,72 @@
+name: Preview Frontend (PR)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to deploy as preview"
+        type: string
+        required: true
+      expires:
+        description: "Preview channel TTL (e.g. 7d, 30d)"
+        type: string
+        default: "7d"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: preview-pr-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Build & deploy preview channel
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ inputs.pr_number }}/head
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci --legacy-peer-deps
+
+      - name: Build frontend (against prod backend)
+        working-directory: frontend
+        env:
+          VITE_API_URL: ${{ vars.VITE_API_URL }}
+        run: npm run build
+
+      - name: Deploy to Firebase Hosting preview channel
+        id: deploy
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: ${{ vars.FIREBASE_PROJECT_ID }}
+          channelId: pr-${{ inputs.pr_number }}
+          expires: ${{ inputs.expires }}
+          entryPoint: frontend
+
+      - name: Comment preview URL on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          URLS: ${{ steps.deploy.outputs.urls }}
+          EXPIRES: ${{ inputs.expires }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "Preview frontend (apontando para o backend de prod): $URLS
+
+          Channel: \`pr-$PR_NUMBER\` — expira em $EXPIRES."

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -107,7 +107,7 @@ func main() {
 	e.Use(middleware.LoggingMiddleware(globalLogger))
 	e.Use(echomiddleware.Recover())
 	e.Use(echomiddleware.CORSWithConfig(echomiddleware.CORSConfig{
-		AllowOrigins:     []string{cfg.App.FrontendURL},
+		AllowOrigins:     append([]string{cfg.App.FrontendURL}, cfg.App.AllowedOrigins...),
 		AllowMethods:     []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions},
 		AllowHeaders:     []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAuthorization},
 		AllowCredentials: true,

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -58,10 +59,11 @@ type OAuthProviderConfig struct {
 }
 
 type AppConfig struct {
-	URL         string
-	FrontendURL string
-	Env         string
-	LogLevel    string
+	URL            string
+	FrontendURL    string
+	AllowedOrigins []string
+	Env            string
+	LogLevel       string
 }
 
 func Load(files ...string) (*Config, error) {
@@ -99,10 +101,11 @@ func Load(files ...string) (*Config, error) {
 			SessionSecret: getEnv("OAUTH_SESSION_SECRET", "change-me-in-production"),
 		},
 		App: AppConfig{
-			URL:         getEnv("APP_URL", "http://localhost:8080"),
-			FrontendURL: getEnv("FRONTEND_URL", "http://localhost:3000"),
-			Env:         getEnv("ENV", "development"),
-			LogLevel:    getEnv("LOG_LEVEL", "info"),
+			URL:            getEnv("APP_URL", "http://localhost:8080"),
+			FrontendURL:    getEnv("FRONTEND_URL", "http://localhost:3000"),
+			AllowedOrigins: parseCSV(getEnv("ALLOWED_ORIGINS", "")),
+			Env:            getEnv("ENV", "development"),
+			LogLevel:       getEnv("LOG_LEVEL", "info"),
 		},
 	}
 
@@ -122,4 +125,18 @@ func getEnvAsInt(key string, defaultValue int) int {
 		return value
 	}
 	return defaultValue
+}
+
+func parseCSV(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
Adds .github/workflows/preview.yml — workflow_dispatch only, takes a PR
number, builds the frontend against prod backend (VITE_API_URL) and
deploys to a Firebase Hosting preview channel (pr-<N>), then posts the
URL as a PR comment.

To make CORS work from preview subdomains, AppConfig now accepts an
ALLOWED_ORIGINS env var (CSV) that is appended to FRONTEND_URL when
building the Echo CORS allow-list. Set it to the Firebase preview
pattern (e.g. https://<project>--*.web.app) on the prod environment.