### PR TITLE
Add favicon and icon links to HTML head

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,9 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="FinanceApp" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/icon-512.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>FinanceApp</title>
   </head>


### PR DESCRIPTION
## Summary
Added favicon and app icon link tags to the HTML document head to improve branding and user experience across different platforms and browsers.

## Key Changes
- Added SVG favicon link for modern browsers (`/icon.svg`)
- Added 192x192 PNG icon for Android and PWA home screen (`/icon-192.png`)
- Added 512x512 PNG icon for larger displays and PWA splash screens (`/icon-512.png`)

## Implementation Details
The icon links are placed in the `<head>` section before the existing Apple touch icon, following standard favicon conventions. This ensures the FinanceApp branding appears consistently in browser tabs, bookmarks, and when added to home screens on mobile devices.

https://claude.ai/code/session_01GG9679v23xpNE3dBsP8qNW