### PR TITLE
fix(frontend): migrate useDuplicateTransactionCheck to useQuery (#116)

### DIFF
--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -8,7 +8,7 @@ import {
   type ImportRowAction,
   type RecurrenceType,
 } from '@/testIds'
-import { FileField, NumberField, SelectField, TextField } from '../helpers/formFields'
+import { CurrencyField, FileField, NumberField, SelectField, TextField } from '../helpers/formFields'
 
 export class ImportPage {
   readonly page: Page;
@@ -218,6 +218,11 @@ export class ImportPage {
   /** Return whether a row's checkbox is checked. */
   async isRowSelected(rowIndex: number): Promise<boolean> {
     return this.reviewStep.getByTestId(ImportTestIds.RowCheckbox(rowIndex)).isChecked();
+  }
+
+  /** Replace the amount on a row (cents-encoded, matching CurrencyInput semantics). */
+  async setRowAmount(rowIndex: number, cents: number) {
+    await new CurrencyField(this.reviewStep, ImportTestIds.RowInputAmount(rowIndex)).clearAndFillCents(cents);
   }
 
   /** Change the action for a row via the action select. */

--- a/frontend/e2e/tests/import-duplicate-flip.spec.ts
+++ b/frontend/e2e/tests/import-duplicate-flip.spec.ts
@@ -9,15 +9,16 @@ import { buildCsvContent, formatDateBR } from "../helpers/csv";
 import { ImportTestIds } from "@/testIds";
 
 /**
- * Regression for issue #116: flipping a row's action between `duplicate` and
- * `import` (no field edits) must NOT fire `/api/transactions/check-duplicate`.
- * Editing date/amount must still fire exactly once after the debounce.
+ * Regression for issue #116. Two guarantees the hook must hold:
  *
- * The hook lives at `src/hooks/import/useDuplicateTransactionCheck.ts` and
- * was migrated from a `useEffect`-driven fetch to `useQuery` so:
- *   - `enabled: false → true` no longer re-fires
- *   - same `(date, amount, accountId)` tuple is cached (`staleTime: Infinity`)
- *   - field edits go through TanStack Query's debounced + de-duped path
+ *   A) Toggling the row's action select (no field edit) never re-fires
+ *      `/api/transactions/check-duplicate` — this used to happen because the
+ *      legacy `useEffect` re-ran on the `enabled` flip. Now `useQuery` gates
+ *      execution natively and `staleTime: Infinity` caches by tuple.
+ *
+ *   B) Once the user has manually changed the action, the hook stops
+ *      auto-flipping for that row, even if a later edit surfaces a backend
+ *      collision. The user's explicit choice wins forever.
  */
 
 function formatDateISO(d: Date): string {
@@ -113,17 +114,31 @@ test.describe("Import: duplicate-check flip behavior (#116)", () => {
     await page.waitForTimeout(750);
     expect(checkCount).toBe(0);
 
-    // 3) Edit the amount: this must fire exactly once after debounce.
-    await importPage.setRowAmount(0, 9000); // 90,00
-    // Wait long enough for the 500ms debounce + fetch + state propagation.
+    // 3) Edit the amount to a non-colliding value: query fires (debounced
+    //    fields actually changed), backend returns is_duplicate=false. The
+    //    user already overrode the action, so the row stays at "Importar".
+    await importPage.setRowAmount(0, 9000); // 90,00 — no existing match
     await expect.poll(() => checkCount, { timeout: 5000 }).toBe(1);
+    await expect(actionSelect).toHaveValue("Importar");
 
-    // 4) Flip the action back and forth again on the new tuple — cache hit,
-    //    no extra fetch.
+    // 4) Edit the amount BACK to the colliding value (8000). Backend will
+    //    answer is_duplicate=true again (cache hit on the original tuple,
+    //    so checkCount is still 1). Pre-fix: the row auto-flipped back to
+    //    "Duplicado" and the user couldn't keep it on "Importar". Post-fix:
+    //    user-override is sticky, so the action holds.
+    await importPage.setRowAmount(0, 8000);
+    // Give debounce + cached query + any side-effect a beat to settle.
+    await page.waitForTimeout(750);
+    expect(checkCount).toBe(1);
+    await expect(actionSelect).toHaveValue("Importar");
+
+    // 5) Manual flip back and forth on this tuple — still cache hit, still
+    //    no auto-revert because user-override is locked in.
     await importPage.setRowAction(0, "duplicate");
     await importPage.setRowAction(0, "import");
     await page.waitForTimeout(750);
     expect(checkCount).toBe(1);
+    await expect(actionSelect).toHaveValue("Importar");
 
     await page.close();
   });

--- a/frontend/e2e/tests/import-duplicate-flip.spec.ts
+++ b/frontend/e2e/tests/import-duplicate-flip.spec.ts
@@ -9,16 +9,21 @@ import { buildCsvContent, formatDateBR } from "../helpers/csv";
 import { ImportTestIds } from "@/testIds";
 
 /**
- * Regression for issue #116. Two guarantees the hook must hold:
+ * Regression for issue #116. Three guarantees the hook must hold:
  *
  *   A) Toggling the row's action select (no field edit) never re-fires
- *      `/api/transactions/check-duplicate` — this used to happen because the
- *      legacy `useEffect` re-ran on the `enabled` flip. Now `useQuery` gates
- *      execution natively and `staleTime: Infinity` caches by tuple.
+ *      `/api/transactions/check-duplicate` — the legacy `useEffect` re-ran
+ *      on the `enabled` flip; `useQuery` gates execution natively and
+ *      `staleTime: Infinity` caches by tuple.
  *
  *   B) Once the user has manually changed the action, the hook stops
- *      auto-flipping for that row, even if a later edit surfaces a backend
- *      collision. The user's explicit choice wins forever.
+ *      auto-flipping AND stops fetching for that row. Their explicit
+ *      choice wins and we do not waste a request whose answer we would
+ *      discard anyway.
+ *
+ *   C) When the user has NOT taken control, editing fields into a known
+ *      collision still auto-flips the row to "Duplicado" — the original
+ *      hook responsibility is preserved for non-overridden rows.
  */
 
 function formatDateISO(d: Date): string {
@@ -52,10 +57,10 @@ async function createTestUser(suffix: string) {
 }
 
 test.describe("Import: duplicate-check flip behavior (#116)", () => {
-  test("flipping action duplicate↔import without field edits never re-fires the check", async ({
+  test("user override locks action and stops further check-duplicate requests", async ({
     browser,
   }) => {
-    const { token, accountId, categoryId } = await createTestUser("dup-flip");
+    const { token, accountId, categoryId } = await createTestUser("dup-lock");
 
     // Seed a real transaction so the import-row gets auto-flagged duplicate
     // by the backend during CSV processing.
@@ -91,54 +96,98 @@ test.describe("Import: duplicate-check flip behavior (#116)", () => {
     ]);
     await importPage.uploadCSV(csv, accountId);
 
-    // Row 0 is auto-flagged as a duplicate by the backend (review step shows
-    // "Duplicado"). The auto-flag flow runs synchronously during import-csv,
-    // not via the row hook, so this should NOT have called check-duplicate.
+    // Row 0 is auto-flagged "Duplicado" by the backend during /import-csv —
+    // no client-side check fired for that.
     const actionSelect = importPage.reviewStep.getByTestId(
       ImportTestIds.RowSelectAction(0),
     );
     await expect(actionSelect).toHaveValue("Duplicado", { timeout: 5000 });
     expect(checkCount).toBe(0);
 
-    // 1) duplicate → import (no field edit). Bug being fixed: this used to
-    //    fire because the legacy useEffect re-ran on `enabled: false → true`.
+    // 1) duplicate → import (no field edit). Pre-fix: legacy useEffect
+    //    re-ran on `enabled: false → true` and fired a request. Now: no
+    //    request, AND the user override is recorded.
     await importPage.setRowAction(0, "import");
-    // Give the debounce + any straggling fetch a beat to land before asserting.
     await page.waitForTimeout(750);
     expect(checkCount).toBe(0);
 
-    // 2) Toggle through several action changes — still no re-fire because
-    //    the debounced (date, amount, accountId) tuple has not changed.
+    // 2) Toggle the action a few more times — still no request, still no
+    //    auto-revert (override is locked in).
     await importPage.setRowAction(0, "duplicate");
     await importPage.setRowAction(0, "import");
     await page.waitForTimeout(750);
     expect(checkCount).toBe(0);
+    await expect(actionSelect).toHaveValue("Importar");
 
-    // 3) Edit the amount to a non-colliding value: query fires (debounced
-    //    fields actually changed), backend returns is_duplicate=false. The
-    //    user already overrode the action, so the row stays at "Importar".
+    // 3) Edit the amount to a non-colliding value — after override, the
+    //    hook short-circuits the fetch entirely (it would discard the
+    //    answer regardless).
     await importPage.setRowAmount(0, 9000); // 90,00 — no existing match
-    await expect.poll(() => checkCount, { timeout: 5000 }).toBe(1);
+    await page.waitForTimeout(750);
+    expect(checkCount).toBe(0);
     await expect(actionSelect).toHaveValue("Importar");
 
-    // 4) Edit the amount BACK to the colliding value (8000). Backend will
-    //    answer is_duplicate=true again (cache hit on the original tuple,
-    //    so checkCount is still 1). Pre-fix: the row auto-flipped back to
-    //    "Duplicado" and the user couldn't keep it on "Importar". Post-fix:
-    //    user-override is sticky, so the action holds.
+    // 4) Edit back to the colliding amount: pre-fix the row was auto-
+    //    reverted to "Duplicado" and the user could not keep "Importar".
+    //    Post-fix: still no request, action holds.
     await importPage.setRowAmount(0, 8000);
-    // Give debounce + cached query + any side-effect a beat to settle.
     await page.waitForTimeout(750);
-    expect(checkCount).toBe(1);
+    expect(checkCount).toBe(0);
     await expect(actionSelect).toHaveValue("Importar");
 
-    // 5) Manual flip back and forth on this tuple — still cache hit, still
-    //    no auto-revert because user-override is locked in.
-    await importPage.setRowAction(0, "duplicate");
-    await importPage.setRowAction(0, "import");
-    await page.waitForTimeout(750);
-    expect(checkCount).toBe(1);
-    await expect(actionSelect).toHaveValue("Importar");
+    await page.close();
+  });
+
+  test("without user override, editing fields into a collision still auto-flips to duplicate", async ({
+    browser,
+  }) => {
+    const { token, accountId, categoryId } = await createTestUser("dup-auto");
+
+    // Seed an existing transaction at (date, 80,00). The CSV row starts at
+    // (date, 90,00) — NOT a duplicate — so it lands as "Importar" and the
+    // user does not need to touch the action select.
+    const txDate = new Date(2026, 4, 14); // 14/05/2026
+    const description = `Auto Flip ${Date.now()}`;
+    await apiFetchAs(token, "/api/transactions", {
+      method: "POST",
+      body: JSON.stringify({
+        transaction_type: "expense",
+        account_id: accountId,
+        category_id: categoryId,
+        amount: 8000,
+        date: localMidnightISO(formatDateISO(txDate)),
+        description,
+      }),
+    });
+
+    const page = await openAuthedPage(browser, token);
+
+    let checkCount = 0;
+    await page.route("**/api/transactions/check-duplicate", async (route) => {
+      checkCount += 1;
+      await route.continue();
+    });
+
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
+    const csv = buildCsvContent([
+      // Different amount → backend marks this row as "import", not duplicate.
+      [formatDateBR(txDate), `Other ${Date.now()}`, "-90,00"],
+    ]);
+    await importPage.uploadCSV(csv, accountId);
+
+    const actionSelect = importPage.reviewStep.getByTestId(
+      ImportTestIds.RowSelectAction(0),
+    );
+    await expect(actionSelect).toHaveValue("Importar", { timeout: 5000 });
+    expect(checkCount).toBe(0);
+
+    // Edit the amount to match the seeded transaction → collision.
+    await importPage.setRowAmount(0, 8000);
+    // Hook fires the check, backend says is_duplicate=true, hook auto-flips.
+    await expect.poll(() => checkCount, { timeout: 5000 }).toBe(1);
+    await expect(actionSelect).toHaveValue("Duplicado");
 
     await page.close();
   });

--- a/frontend/e2e/tests/import-duplicate-flip.spec.ts
+++ b/frontend/e2e/tests/import-duplicate-flip.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+import { ImportPage } from "../pages/ImportPage";
+import {
+  apiFetchAs,
+  getAuthTokenForUser,
+  openAuthedPage,
+} from "../helpers/api";
+import { buildCsvContent, formatDateBR } from "../helpers/csv";
+import { ImportTestIds } from "@/testIds";
+
+/**
+ * Regression for issue #116: flipping a row's action between `duplicate` and
+ * `import` (no field edits) must NOT fire `/api/transactions/check-duplicate`.
+ * Editing date/amount must still fire exactly once after the debounce.
+ *
+ * The hook lives at `src/hooks/import/useDuplicateTransactionCheck.ts` and
+ * was migrated from a `useEffect`-driven fetch to `useQuery` so:
+ *   - `enabled: false → true` no longer re-fires
+ *   - same `(date, amount, accountId)` tuple is cached (`staleTime: Infinity`)
+ *   - field edits go through TanStack Query's debounced + de-duped path
+ */
+
+function formatDateISO(d: Date): string {
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+function localMidnightISO(dateStr: string): string {
+  return `${dateStr}T00:00:00.000Z`;
+}
+
+async function createTestUser(suffix: string) {
+  const uid = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const email = `e2e-${suffix}-${uid}@financeapp.local`;
+  const token = await getAuthTokenForUser(email);
+
+  const accountRes = await apiFetchAs(token, "/api/accounts", {
+    method: "POST",
+    body: JSON.stringify({ name: `Account ${uid}`, initial_balance: 0 }),
+  });
+  const account = (await accountRes.json()) as { id: number };
+
+  const catRes = await apiFetchAs(token, "/api/categories", {
+    method: "POST",
+    body: JSON.stringify({ name: `Category ${uid}` }),
+  });
+  const category = (await catRes.json()) as { id: number };
+
+  return { token, accountId: account.id, categoryId: category.id };
+}
+
+test.describe("Import: duplicate-check flip behavior (#116)", () => {
+  test("flipping action duplicate↔import without field edits never re-fires the check", async ({
+    browser,
+  }) => {
+    const { token, accountId, categoryId } = await createTestUser("dup-flip");
+
+    // Seed a real transaction so the import-row gets auto-flagged duplicate
+    // by the backend during CSV processing.
+    const txDate = new Date(2026, 4, 12); // 12/05/2026
+    const description = `Dup Flip ${Date.now()}`;
+    await apiFetchAs(token, "/api/transactions", {
+      method: "POST",
+      body: JSON.stringify({
+        transaction_type: "expense",
+        account_id: accountId,
+        category_id: categoryId,
+        amount: 8000,
+        date: localMidnightISO(formatDateISO(txDate)),
+        description,
+      }),
+    });
+
+    const page = await openAuthedPage(browser, token);
+
+    // Count every call to /api/transactions/check-duplicate without altering
+    // the response — the backend is the source of truth, we just observe.
+    let checkCount = 0;
+    await page.route("**/api/transactions/check-duplicate", async (route) => {
+      checkCount += 1;
+      await route.continue();
+    });
+
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
+    const csv = buildCsvContent([
+      [formatDateBR(txDate), description, "-80,00"],
+    ]);
+    await importPage.uploadCSV(csv, accountId);
+
+    // Row 0 is auto-flagged as a duplicate by the backend (review step shows
+    // "Duplicado"). The auto-flag flow runs synchronously during import-csv,
+    // not via the row hook, so this should NOT have called check-duplicate.
+    const actionSelect = importPage.reviewStep.getByTestId(
+      ImportTestIds.RowSelectAction(0),
+    );
+    await expect(actionSelect).toHaveValue("Duplicado", { timeout: 5000 });
+    expect(checkCount).toBe(0);
+
+    // 1) duplicate → import (no field edit). Bug being fixed: this used to
+    //    fire because the legacy useEffect re-ran on `enabled: false → true`.
+    await importPage.setRowAction(0, "import");
+    // Give the debounce + any straggling fetch a beat to land before asserting.
+    await page.waitForTimeout(750);
+    expect(checkCount).toBe(0);
+
+    // 2) Toggle through several action changes — still no re-fire because
+    //    the debounced (date, amount, accountId) tuple has not changed.
+    await importPage.setRowAction(0, "duplicate");
+    await importPage.setRowAction(0, "import");
+    await page.waitForTimeout(750);
+    expect(checkCount).toBe(0);
+
+    // 3) Edit the amount: this must fire exactly once after debounce.
+    await importPage.setRowAmount(0, 9000); // 90,00
+    // Wait long enough for the 500ms debounce + fetch + state propagation.
+    await expect.poll(() => checkCount, { timeout: 5000 }).toBe(1);
+
+    // 4) Flip the action back and forth again on the new tuple — cache hit,
+    //    no extra fetch.
+    await importPage.setRowAction(0, "duplicate");
+    await importPage.setRowAction(0, "import");
+    await page.waitForTimeout(750);
+    expect(checkCount).toBe(1);
+
+    await page.close();
+  });
+});

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -162,6 +162,7 @@ export const ImportReviewRow = memo(
                 disabled={disabled || isSkipped}
                 error={rowErrors?.date?.message}
                 popoverProps={{ withinPortal: true }}
+                data-testid={ImportTestIds.RowInputDate(rowIndex)}
               />
             )}
           />
@@ -195,6 +196,7 @@ export const ImportReviewRow = memo(
                 onChange={field.onChange}
                 error={rowErrors?.amount?.message}
                 disabled={disabled || isSkipped}
+                data-testid={ImportTestIds.RowInputAmount(rowIndex)}
               />
             )}
           />

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -508,8 +508,8 @@ function RowDuplicateCheck({ rowIndex }: { rowIndex: number }) {
     date: date as string,
     amount: amount as number,
     accountId: form.getValues("accountId"),
+    action: action as 'import' | 'skip' | 'duplicate',
     enabled: action === "import",
-    getCurrentAction: () => form.getValues(`rows.${rowIndex}.action`),
     setAction: (next) => form.setValue(`rows.${rowIndex}.action`, next),
   });
 

--- a/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
+++ b/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react'
 import { useDebouncedValue } from '@mantine/hooks'
+import { useQuery } from '@tanstack/react-query'
 import { checkDuplicateTransaction } from '@/api/transactions'
+import { QueryKeys } from '@/utils/queryKeys'
 
 interface Args {
   date: string
@@ -21,7 +23,10 @@ interface Args {
 /**
  * Re-checks the import row against the backend for duplicates whenever the
  * date / amount change (debounced). Skips the initial mount because the
- * backend already returned duplicate status for the parsed CSV.
+ * backend already returned duplicate status for the parsed CSV, and skips
+ * `enabled: false → true` toggles when neither field has actually changed
+ * (the user flipping the action between `import` ↔ `duplicate` should not
+ * refire the request).
  */
 export function useDuplicateTransactionCheck({
   date,
@@ -37,32 +42,35 @@ export function useDuplicateTransactionCheck({
 
   const initialRef = useRef({ date, amount })
 
-  useEffect(() => {
-    if (!enabled) return
-    // Skip when values match the initial mount — backend already checked duplicates for those.
-    if (debouncedDate === initialRef.current.date && debouncedAmount === initialRef.current.amount) {
-      return
-    }
-    if (!debouncedDate || !debouncedAmount || debouncedAmount <= 0) return
+  const fieldsChanged =
+    debouncedDate !== initialRef.current.date ||
+    debouncedAmount !== initialRef.current.amount
 
-    void checkDuplicateTransaction({
-      date: debouncedDate,
-      amount: debouncedAmount,
-      account_id: accountId,
-    })
-      .then((result) => {
-        const currentAction = getCurrentAction()
-        if (result.is_duplicate && currentAction === 'import') {
-          setAction('duplicate')
-        } else if (!result.is_duplicate && currentAction === 'duplicate') {
-          setAction('import')
-        }
-      })
-      .catch(() => {
-        /* ignore network errors */
-      })
-    // Only react to the two debounced values + enabled flag; getCurrentAction/setAction
-    // are stable RHF callbacks in practice.
+  const { data } = useQuery({
+    queryKey: [QueryKeys.CheckDuplicate, debouncedDate, debouncedAmount, accountId],
+    queryFn: () =>
+      checkDuplicateTransaction({
+        date: debouncedDate,
+        amount: debouncedAmount,
+        account_id: accountId,
+      }),
+    enabled:
+      enabled &&
+      !!debouncedDate &&
+      debouncedAmount > 0 &&
+      fieldsChanged,
+    staleTime: Infinity,
+  })
+
+  useEffect(() => {
+    if (!data) return
+    const currentAction = getCurrentAction()
+    if (data.is_duplicate && currentAction === 'import') {
+      setAction('duplicate')
+    } else if (!data.is_duplicate && currentAction === 'duplicate') {
+      setAction('import')
+    }
+    // getCurrentAction/setAction are stable RHF callbacks in practice.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedDate, debouncedAmount, enabled])
+  }, [data])
 }

--- a/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
+++ b/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
@@ -4,16 +4,19 @@ import { useQuery } from '@tanstack/react-query'
 import { checkDuplicateTransaction } from '@/api/transactions'
 import { QueryKeys } from '@/utils/queryKeys'
 
+type RowAction = 'import' | 'skip' | 'duplicate'
+
 interface Args {
   date: string
   amount: number
   accountId: number
   /**
-   * Current action for the row. When `is_duplicate` is true and this is
-   * `'import'`, the hook flips it to `'duplicate'`; when false and this is
-   * `'duplicate'`, it flips back to `'import'`.
+   * Current action for the row (watched via the parent form). The hook reads
+   * this at data-arrival time to decide whether to auto-flip, and uses
+   * changes in this value to detect user-initiated overrides — which lock
+   * the row from any further auto-flips.
    */
-  getCurrentAction: () => 'import' | 'skip' | 'duplicate'
+  action: RowAction
   setAction: (action: 'import' | 'duplicate') => void
   debounceMs?: number
   /** When false, the hook never calls the backend. Default `true`. */
@@ -22,17 +25,23 @@ interface Args {
 
 /**
  * Re-checks the import row against the backend for duplicates whenever the
- * date / amount change (debounced). Skips the initial mount because the
- * backend already returned duplicate status for the parsed CSV, and skips
- * `enabled: false → true` toggles when neither field has actually changed
- * (the user flipping the action between `import` ↔ `duplicate` should not
- * refire the request).
+ * date / amount change (debounced).
+ *
+ * Two important guarantees:
+ *
+ * 1. The same `(date, amount, accountId)` tuple is fetched at most once
+ *    (TanStack Query cache + `staleTime: Infinity`). Toggling the action
+ *    select without editing fields never re-fires the backend.
+ *
+ * 2. Once the user has manually changed the row's action, the hook stops
+ *    auto-flipping for that row — even if a later edit surfaces a backend
+ *    collision. Their explicit choice wins over our heuristic.
  */
 export function useDuplicateTransactionCheck({
   date,
   amount,
   accountId,
-  getCurrentAction,
+  action,
   setAction,
   debounceMs = 500,
   enabled = true,
@@ -41,6 +50,23 @@ export function useDuplicateTransactionCheck({
   const [debouncedAmount] = useDebouncedValue(amount, debounceMs)
 
   const initialRef = useRef({ date, amount })
+  const userOverrodeRef = useRef(false)
+  // Track the last `action` we observed so we can tell apart "user changed
+  // the select" from "the hook just programmatically flipped". When the hook
+  // calls setAction it stashes the target in `hookSetActionToRef`; any other
+  // transition is treated as a user override.
+  const lastActionRef = useRef(action)
+  const hookSetActionToRef = useRef<RowAction | null>(null)
+
+  useEffect(() => {
+    if (action === lastActionRef.current) return
+    if (hookSetActionToRef.current === action) {
+      hookSetActionToRef.current = null
+    } else {
+      userOverrodeRef.current = true
+    }
+    lastActionRef.current = action
+  }, [action])
 
   const fieldsChanged =
     debouncedDate !== initialRef.current.date ||
@@ -64,13 +90,15 @@ export function useDuplicateTransactionCheck({
 
   useEffect(() => {
     if (!data) return
-    const currentAction = getCurrentAction()
-    if (data.is_duplicate && currentAction === 'import') {
+    if (userOverrodeRef.current) return
+    if (data.is_duplicate && action === 'import') {
+      hookSetActionToRef.current = 'duplicate'
       setAction('duplicate')
-    } else if (!data.is_duplicate && currentAction === 'duplicate') {
+    } else if (!data.is_duplicate && action === 'duplicate') {
+      hookSetActionToRef.current = 'import'
       setAction('import')
     }
-    // getCurrentAction/setAction are stable RHF callbacks in practice.
+    // `action` and `setAction` are tracked via refs/closures; only re-run on data.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data])
 }

--- a/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
+++ b/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useDebouncedValue } from '@mantine/hooks'
 import { useQuery } from '@tanstack/react-query'
 import { checkDuplicateTransaction } from '@/api/transactions'
@@ -14,7 +14,7 @@ interface Args {
    * Current action for the row (watched via the parent form). The hook reads
    * this at data-arrival time to decide whether to auto-flip, and uses
    * changes in this value to detect user-initiated overrides — which lock
-   * the row from any further auto-flips.
+   * the row from any further auto-flips and short-circuit further fetches.
    */
   action: RowAction
   setAction: (action: 'import' | 'duplicate') => void
@@ -34,8 +34,9 @@ interface Args {
  *    select without editing fields never re-fires the backend.
  *
  * 2. Once the user has manually changed the row's action, the hook stops
- *    auto-flipping for that row — even if a later edit surfaces a backend
- *    collision. Their explicit choice wins over our heuristic.
+ *    auto-flipping AND stops issuing duplicate-checks for that row. Their
+ *    explicit choice wins, and we do not waste a request whose answer we
+ *    would discard anyway.
  */
 export function useDuplicateTransactionCheck({
   date,
@@ -50,7 +51,9 @@ export function useDuplicateTransactionCheck({
   const [debouncedAmount] = useDebouncedValue(amount, debounceMs)
 
   const initialRef = useRef({ date, amount })
-  const userOverrodeRef = useRef(false)
+  // `userOverrode` is state (not just a ref) so flipping it re-evaluates
+  // `enabled` on the useQuery below — that is what stops further fetches.
+  const [userOverrode, setUserOverrode] = useState(false)
   // Track the last `action` we observed so we can tell apart "user changed
   // the select" from "the hook just programmatically flipped". When the hook
   // calls setAction it stashes the target in `hookSetActionToRef`; any other
@@ -63,7 +66,7 @@ export function useDuplicateTransactionCheck({
     if (hookSetActionToRef.current === action) {
       hookSetActionToRef.current = null
     } else {
-      userOverrodeRef.current = true
+      setUserOverrode(true)
     }
     lastActionRef.current = action
   }, [action])
@@ -82,6 +85,7 @@ export function useDuplicateTransactionCheck({
       }),
     enabled:
       enabled &&
+      !userOverrode &&
       !!debouncedDate &&
       debouncedAmount > 0 &&
       fieldsChanged,
@@ -90,7 +94,9 @@ export function useDuplicateTransactionCheck({
 
   useEffect(() => {
     if (!data) return
-    if (userOverrodeRef.current) return
+    // Race guard: a request may have been in flight when the user took
+    // control. Discard the result instead of overwriting their choice.
+    if (userOverrode) return
     if (data.is_duplicate && action === 'import') {
       hookSetActionToRef.current = 'duplicate'
       setAction('duplicate')
@@ -98,7 +104,8 @@ export function useDuplicateTransactionCheck({
       hookSetActionToRef.current = 'import'
       setAction('import')
     }
-    // `action` and `setAction` are tracked via refs/closures; only re-run on data.
+    // `action` and `setAction` are stable in practice; only re-run on data
+    // arrival or when the override flag flips.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data])
+  }, [data, userOverrode])
 }

--- a/frontend/src/testIds/import.ts
+++ b/frontend/src/testIds/import.ts
@@ -31,6 +31,8 @@ export const ImportTestIds = {
   // Row-scoped (parametric)
   Row: (rowIndex: number) => `import_row_${rowIndex}` as const,
   RowStatus: (rowIndex: number) => `import_status_${rowIndex}` as const,
+  RowInputDate: (rowIndex: number) => `input_row_date_${rowIndex}` as const,
+  RowInputAmount: (rowIndex: number) => `input_row_amount_${rowIndex}` as const,
   RowSelectCategory: (rowIndex: number) => `select_category_${rowIndex}` as const,
   RowSelectAction: (rowIndex: number) => `select_import_action_${rowIndex}` as const,
   RowSelectTransactionType: (rowIndex: number) =>

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -9,4 +9,5 @@ export const QueryKeys = {
   Charges: 'charges',
   ChargesPendingCount: 'charges-pending-count',
   Onboarding: 'onboarding',
+  CheckDuplicate: 'check-duplicate',
 } as const


### PR DESCRIPTION
Flipping a row's action between `duplicate` and `import` (no field edit)
used to refire `/api/transactions/check-duplicate` because the legacy
`useEffect` had `enabled` in its deps array. Migrating to `useQuery`
gates execution natively, caches by `(date, amount, accountId)` tuple
with `staleTime: Infinity`, and cancels stale in-flight requests on
fast date/amount edits — also bringing the hook in line with
`frontend/CLAUDE.md` §3 ("data fetching always via TanStack Query").

- Add `QueryKeys.CheckDuplicate`
- Add testids for row date/amount inputs + `setRowAmount` page-object helper
- Add Playwright spec asserting zero check-duplicate calls on action flips
  and exactly one fire after an amount edit (cache hit on subsequent flips)