### PR TITLE
fix: portal FAB to escape stacking context behind mobile tab bar in PWA

### DIFF
--- a/frontend/src/components/Fab.tsx
+++ b/frontend/src/components/Fab.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, type MantineColor } from '@mantine/core'
+import { ActionIcon, Portal, type MantineColor } from '@mantine/core'
 import { ReactNode } from 'react'
 import { tapHaptic } from '@/utils/haptics'
 import classes from './Fab.module.css'
@@ -16,26 +16,32 @@ interface FabProps {
  * the mobile tab bar (which lives at z-index 90 with height 56 + safe-area).
  * Mobile-only; the desktop layout uses inline page buttons instead.
  *
+ * Rendered through a Portal so it escapes any parent stacking context (notably
+ * AppShell.Main, which is a scroll container in iOS standalone PWA and traps
+ * the z-index, causing the tab bar to render on top of the FAB).
+ *
  * Each consumer is responsible for gating render with `useIsMobile()` — this
  * component doesn't gate itself so callers can keep the existing desktop
  * "Nova X" buttons intact and avoid double-rendering.
  */
 export function Fab({ onClick, ariaLabel, testId, color = 'blue', children }: FabProps) {
   return (
-    <ActionIcon
-      size={56}
-      radius="xl"
-      variant="filled"
-      color={color}
-      className={classes.fab}
-      onClick={() => {
-        tapHaptic()
-        onClick()
-      }}
-      aria-label={ariaLabel}
-      data-testid={testId}
-    >
-      {children}
-    </ActionIcon>
+    <Portal>
+      <ActionIcon
+        size={56}
+        radius="xl"
+        variant="filled"
+        color={color}
+        className={classes.fab}
+        onClick={() => {
+          tapHaptic()
+          onClick()
+        }}
+        aria-label={ariaLabel}
+        data-testid={testId}
+      >
+        {children}
+      </ActionIcon>
+    </Portal>
   )
 }


### PR DESCRIPTION
In iOS standalone PWA, AppShell.Main becomes a scroll container that traps
the FAB's z-index, so the mobile tab bar (rendered as a sibling) paints on
top of the FAB. Rendering the FAB through a Portal lifts it to document.body
so its z-index competes in the same stacking context as the tab bar.