### PR TITLE
Remove decimal separator parameter and auto-detect number format

### DIFF
--- a/backend/internal/domain/transaction_import.go
+++ b/backend/internal/domain/transaction_import.go
@@ -2,14 +2,6 @@ package domain
 
 import "time"
 
-// ImportDecimalSeparatorValue controls how decimal numbers are parsed in CSV imports.
-type ImportDecimalSeparatorValue string
-
-const (
-	DecimalSeparatorComma ImportDecimalSeparatorValue = "comma"
-	DecimalSeparatorDot   ImportDecimalSeparatorValue = "dot"
-)
-
 // ImportTypeDefinitionRule controls how transaction type is inferred from CSV amount sign.
 type ImportTypeDefinitionRule string
 

--- a/backend/internal/handler/transaction_handler.go
+++ b/backend/internal/handler/transaction_handler.go
@@ -399,18 +399,13 @@ func (h *TransactionHandler) ImportCSV(c echo.Context) error {
 		}
 	}
 
-	decimalSeparator := service.ImportDecimalSeparatorValue(c.FormValue("decimal_separator"))
-	if !slices.Contains([]service.ImportDecimalSeparatorValue{service.DecimalSeparatorComma, service.DecimalSeparatorDot}, decimalSeparator) {
-		decimalSeparator = service.DecimalSeparatorComma
-	}
-
 	typeDefinitionRule := service.ImportTypeDefinitionRule(c.FormValue("type_definition_rule"))
 	if !slices.Contains([]service.ImportTypeDefinitionRule{service.TypeDefinitionPositiveAsExpense, service.TypeDefinitionPositiveAsIncome}, typeDefinitionRule) {
 		typeDefinitionRule = service.TypeDefinitionPositiveAsIncome
 	}
 
 	ctx := c.Request().Context()
-	result, err := h.transactionService.ParseImportCSV(ctx, userID, accountID, decimalSeparator, typeDefinitionRule, data)
+	result, err := h.transactionService.ParseImportCSV(ctx, userID, accountID, typeDefinitionRule, data)
 	if err != nil {
 		return pkgErrors.ToHTTPError(err)
 	}

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -25,7 +25,7 @@ type TransactionService interface {
 	Suggestions(ctx context.Context, userID int, filter domain.TransactionFilter) ([]*domain.Transaction, error)
 	Delete(ctx context.Context, userID int, id int, propagationSettings domain.TransactionPropagationSettings) error
 	GetBalance(ctx context.Context, userID int, period domain.Period, filter domain.BalanceFilter) (*domain.BalanceResult, error)
-	ParseImportCSV(ctx context.Context, userID, accountID int, decimalSeparator domain.ImportDecimalSeparatorValue, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte) (*domain.ImportCSVResponse, error)
+	ParseImportCSV(ctx context.Context, userID, accountID int, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte) (*domain.ImportCSVResponse, error)
 	CheckDuplicateTransaction(ctx context.Context, userID int, date time.Time, amount int64, accountID *int) (bool, error)
 }
 

--- a/backend/internal/service/structs.go
+++ b/backend/internal/service/structs.go
@@ -35,15 +35,9 @@ func UpdateNotChangedType() updateChanges {
 	}
 }
 
-// ImportDecimalSeparatorValue and ImportTypeDefinitionRule are defined in domain package.
-// Re-exported here for backward compatibility.
-type ImportDecimalSeparatorValue = domain.ImportDecimalSeparatorValue
 type ImportTypeDefinitionRule = domain.ImportTypeDefinitionRule
 
 const (
-	DecimalSeparatorComma ImportDecimalSeparatorValue = domain.DecimalSeparatorComma
-	DecimalSeparatorDot   ImportDecimalSeparatorValue = domain.DecimalSeparatorDot
-
 	TypeDefinitionPositiveAsIncome  ImportTypeDefinitionRule = domain.TypeDefinitionPositiveAsIncome
 	TypeDefinitionPositiveAsExpense ImportTypeDefinitionRule = domain.TypeDefinitionPositiveAsExpense
 )

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -28,7 +28,7 @@ type csvColumnIndex struct {
 	category    int // optional column; -1 when absent
 }
 
-func (s *transactionService) ParseImportCSV(ctx context.Context, userID, accountID int, decimalSeparator domain.ImportDecimalSeparatorValue, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte) (*domain.ImportCSVResponse, error) {
+func (s *transactionService) ParseImportCSV(ctx context.Context, userID, accountID int, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte) (*domain.ImportCSVResponse, error) {
 	// Valida propriedade da conta
 	if _, err := s.services.Account.GetByID(ctx, userID, accountID); err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func (s *transactionService) ParseImportCSV(ctx context.Context, userID, account
 				ParseErrors: []string{errorMessage},
 			}
 		} else {
-			row = parseCSVRow(ctx, s, userID, accountID, dataRowIndex, record, colIdx, decimalSeparator, typeDefinitionRule)
+			row = parseCSVRow(ctx, s, userID, accountID, dataRowIndex, record, colIdx, typeDefinitionRule)
 		}
 
 		if row.Status == domain.ImportRowStatusDuplicate {
@@ -182,7 +182,6 @@ func parseCSVRow(
 	rowIndex int,
 	record []string,
 	colIdx csvColumnIndex,
-	decimalSeparator domain.ImportDecimalSeparatorValue,
 	typeDefinitionRule domain.ImportTypeDefinitionRule,
 ) domain.ParsedImportRow {
 	row := domain.ParsedImportRow{
@@ -237,7 +236,7 @@ func parseCSVRow(
 		row.ParseErrors = append(row.ParseErrors, "Valor é obrigatório")
 	} else {
 		// parseAmountSigned retorna o valor em centavos mantendo o sinal
-		signedCents, err := parseAmountSigned(amountStr, decimalSeparator)
+		signedCents, err := parseAmountSigned(amountStr)
 		if err != nil {
 			row.ParseErrors = append(row.ParseErrors, fmt.Sprintf("Valor inválido: %q", amountStr))
 		} else {
@@ -294,19 +293,59 @@ func parseCSVRow(
 	return row
 }
 
-// parseAmountSigned converte uma string numérica para centavos (int64) mantendo o sinal.
-func parseAmountSigned(s string, decimalSeparator domain.ImportDecimalSeparatorValue) (int64, error) {
+// parseAmountSigned converte uma string numérica para centavos (int64) mantendo o sinal,
+// inferindo o formato linha a linha. Aceita inteiros ("150"), floats com ponto ("150.00",
+// "1,234.56") ou strings no formato pt-BR ("150,00", "1.234,56"). Quando há ambos os
+// separadores, o último ocorrente é tratado como decimal; quando há apenas um e ele
+// aparece exatamente uma vez seguido por 3 dígitos, é tratado como separador de milhar.
+func parseAmountSigned(s string) (int64, error) {
 	s = strings.TrimSpace(s)
-	if decimalSeparator == "dot" {
-		// Padrão Internacional: 1,234.56 -> Remove vírgulas de milhar
-		s = strings.ReplaceAll(s, ",", "")
-	} else {
-		// Padrão Brasileiro: 1.234,56 -> Remove pontos de milhar e troca vírgula por ponto
-		s = strings.ReplaceAll(s, ".", "")
-		s = strings.ReplaceAll(s, ",", ".")
+	if s == "" {
+		return 0, fmt.Errorf("empty amount")
 	}
 
-	f, err := strconv.ParseFloat(s, 64)
+	lastDot := strings.LastIndex(s, ".")
+	lastComma := strings.LastIndex(s, ",")
+	countDot := strings.Count(s, ".")
+	countComma := strings.Count(s, ",")
+
+	var normalized string
+	switch {
+	case countDot == 0 && countComma == 0:
+		normalized = s
+	case countDot > 0 && countComma > 0:
+		// Ambos: o último ocorrente é o decimal, o outro é separador de milhar.
+		if lastComma > lastDot {
+			// pt-BR: "." milhar, "," decimal
+			normalized = strings.ReplaceAll(s, ".", "")
+			normalized = strings.Replace(normalized, ",", ".", 1)
+		} else {
+			// US: "," milhar, "." decimal
+			normalized = strings.ReplaceAll(s, ",", "")
+		}
+	case countDot > 0:
+		if countDot > 1 {
+			// Múltiplos pontos só fazem sentido como separadores de milhar (pt-BR).
+			normalized = strings.ReplaceAll(s, ".", "")
+		} else if len(s)-lastDot-1 == 3 {
+			// Caso ambíguo "1.234": tratar como milhar.
+			normalized = strings.ReplaceAll(s, ".", "")
+		} else {
+			normalized = s
+		}
+	default:
+		if countComma > 1 {
+			// Múltiplas vírgulas só fazem sentido como separadores de milhar (US).
+			normalized = strings.ReplaceAll(s, ",", "")
+		} else if len(s)-lastComma-1 == 3 {
+			// Caso ambíguo "1,234": tratar como milhar.
+			normalized = strings.ReplaceAll(s, ",", "")
+		} else {
+			normalized = strings.Replace(s, ",", ".", 1)
+		}
+	}
+
+	f, err := strconv.ParseFloat(normalized, 64)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -301,7 +301,7 @@ func parseCSVRow(
 func parseAmountSigned(s string) (int64, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return 0, fmt.Errorf("empty amount")
+		return 0, errors.New("empty amount")
 	}
 
 	lastDot := strings.LastIndex(s, ".")

--- a/backend/internal/service/transaction_import_test.go
+++ b/backend/internal/service/transaction_import_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -20,28 +19,38 @@ import (
 
 func TestParseAmountSigned(t *testing.T) {
 	cases := []struct {
-		input     string
-		separator ImportDecimalSeparatorValue
-		want      int64
-		wantErr   bool
+		name    string
+		input   string
+		want    int64
+		wantErr bool
 	}{
-		// Comma (Brazilian)
-		{"150,00", DecimalSeparatorComma, 15000, false},
-		{"1.234,56", DecimalSeparatorComma, 123456, false},
-		{"-50,00", DecimalSeparatorComma, -5000, false},
-		// Dot (International)
-		{"150.00", DecimalSeparatorDot, 15000, false},
-		{"1,234.56", DecimalSeparatorDot, 123456, false},
-		{"-50.00", DecimalSeparatorDot, -5000, false},
-		// General
-		{"100", DecimalSeparatorComma, 10000, false},
-		{"abc", DecimalSeparatorComma, 0, true},
-		{"", DecimalSeparatorComma, 0, true},
+		// Integers
+		{"integer", "150", 15000, false},
+		{"integer negative", "-150", -15000, false},
+		// pt-BR (comma decimal)
+		{"ptbr decimal only", "150,00", 15000, false},
+		{"ptbr thousand and decimal", "1.234,56", 123456, false},
+		{"ptbr negative", "-50,00", -5000, false},
+		{"ptbr millions", "1.234.567,89", 123456789, false},
+		// US / float with dot
+		{"float dot", "150.00", 15000, false},
+		{"us thousand and decimal", "1,234.56", 123456, false},
+		{"float negative", "-50.00", -5000, false},
+		{"us millions", "1,234,567.89", 123456789, false},
+		// Single separator with 3 digits → thousands
+		{"ambiguous dot thousand", "1.234", 123400, false},
+		{"ambiguous comma thousand", "1,234", 123400, false},
+		// Multiple thousands separators
+		{"multi dot thousand", "1.234.567", 123456700, false},
+		{"multi comma thousand", "1,234,567", 123456700, false},
+		// Errors
+		{"non numeric", "abc", 0, true},
+		{"empty", "", 0, true},
 	}
 
 	for _, tc := range cases {
-		t.Run(fmt.Sprintf("%s_%s", tc.input, tc.separator), func(t *testing.T) {
-			got, err := parseAmountSigned(tc.input, tc.separator)
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseAmountSigned(tc.input)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -177,18 +186,18 @@ func (suite *TransactionImportWithDBTestSuite) TestParseImportCSV() {
 	suite.Require().NoError(err)
 
 	suite.Run("empty file", func() {
-		_, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, []byte{})
+		_, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, []byte{})
 		suite.ErrorIs(err, pkgErrors.ErrImportEmptyFile)
 	})
 
 	suite.Run("only header no data rows", func() {
-		_, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, []byte(csvSimpleHeader))
+		_, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, []byte(csvSimpleHeader))
 		suite.ErrorIs(err, pkgErrors.ErrImportNoRows)
 	})
 
 	suite.Run("invalid layout missing Valor", func() {
 		csv := []byte("Data;Descrição\n01/01/2026;Test")
-		_, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		_, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.ErrorIs(err, pkgErrors.ErrImportInvalidLayout)
 	})
 
@@ -197,7 +206,7 @@ func (suite *TransactionImportWithDBTestSuite) TestParseImportCSV() {
 		for i := range rows {
 			rows[i] = []string{"01/01/2026", "Test", "100,00"}
 		}
-		_, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, buildCSV(rows))
+		_, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, buildCSV(rows))
 		suite.ErrorIs(err, pkgErrors.ErrImportMaxRowsExceeded)
 	})
 
@@ -205,7 +214,7 @@ func (suite *TransactionImportWithDBTestSuite) TestParseImportCSV() {
 		csv := append([]byte{0xEF, 0xBB, 0xBF}, buildCSV([][]string{
 			{"01/01/2026", "Aluguel", "-150,00"},
 		})...)
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		suite.Equal(1, resp.TotalRows)
 	})
@@ -214,7 +223,7 @@ func (suite *TransactionImportWithDBTestSuite) TestParseImportCSV() {
 		csv := buildCSV([][]string{
 			{"15/03/2026", "Supermercado", "-250,00"},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		suite.Equal(1, resp.TotalRows)
 		row := resp.Rows[0]
@@ -229,7 +238,7 @@ func (suite *TransactionImportWithDBTestSuite) TestParseImportCSV() {
 		csv := buildCSV([][]string{
 			{"15/03/2026", "Salário", "5000,00"},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		row := resp.Rows[0]
 		suite.Equal(domain.TransactionTypeIncome, row.Type)
@@ -255,7 +264,7 @@ func (suite *TransactionImportWithDBTestSuite) TestParseImportCSV() {
 		csv := buildCSV([][]string{
 			{"10/02/2026", "Netflix", "-50,00"},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		suite.Equal(domain.ImportRowStatusDuplicate, resp.Rows[0].Status)
 		suite.Equal(1, resp.DuplicateCount)
@@ -266,7 +275,7 @@ func (suite *TransactionImportWithDBTestSuite) TestParseImportCSV() {
 		corruptedLine := "01/01/2026;\"Texto mal fechado;100,00"
 		csv := []byte(csvSimpleHeader + "\n" + corruptedLine)
 
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		suite.Equal(1, resp.TotalRows)
 		suite.Contains(resp.Rows[0].Description, "Conteúdo ilegível")
@@ -446,7 +455,7 @@ func (suite *TransactionImportWithDBTestSuite) TestCategoryInference() {
 		csv := buildCSVWithHeader(csvHeaderWithCategory, [][]string{
 			{"01/01/2026", "Compra", "-50,00", category.Name},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		suite.Require().NotNil(resp.Rows[0].CategoryID)
 		suite.Equal(category.ID, *resp.Rows[0].CategoryID)
@@ -457,7 +466,7 @@ func (suite *TransactionImportWithDBTestSuite) TestCategoryInference() {
 		csv := buildCSVWithHeader(csvHeaderWithCategory, [][]string{
 			{"01/01/2026", "Compra", "-50,00", strings.ToUpper(category.Name)},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		suite.Require().NotNil(resp.Rows[0].CategoryID)
 		suite.Equal(category.ID, *resp.Rows[0].CategoryID)
@@ -467,7 +476,7 @@ func (suite *TransactionImportWithDBTestSuite) TestCategoryInference() {
 		csv := buildCSVWithHeader(csvHeaderWithCategory, [][]string{
 			{"01/01/2026", "Compra", "-50,00", "NonExistent Category 12345"},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		suite.Nil(resp.Rows[0].CategoryID)
 		suite.False(resp.Rows[0].CategoryInferred)
@@ -477,7 +486,7 @@ func (suite *TransactionImportWithDBTestSuite) TestCategoryInference() {
 		csv := buildCSVWithHeader(csvHeaderWithCategory, [][]string{
 			{"01/01/2026", "Compra", "-50,00", ""},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		suite.Nil(resp.Rows[0].CategoryID)
 		suite.False(resp.Rows[0].CategoryInferred)
@@ -487,7 +496,7 @@ func (suite *TransactionImportWithDBTestSuite) TestCategoryInference() {
 		csv := buildCSV([][]string{
 			{"01/01/2026", "Compra", "-50,00"},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		suite.Nil(resp.Rows[0].CategoryID)
 		suite.False(resp.Rows[0].CategoryInferred)
@@ -507,7 +516,7 @@ func (suite *TransactionImportWithDBTestSuite) TestInstallmentInference() {
 		csv := buildCSV([][]string{
 			{"01/01/2026", "Compra - Parcela 1 de 3", "-150,00"},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		row := resp.Rows[0]
 		suite.Equal("Compra", row.Description)
@@ -523,7 +532,7 @@ func (suite *TransactionImportWithDBTestSuite) TestInstallmentInference() {
 		csv := buildCSV([][]string{
 			{"01/01/2026", "Compra (2/12)", "-100,00"},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		row := resp.Rows[0]
 		suite.Equal("Compra", row.Description)
@@ -537,7 +546,7 @@ func (suite *TransactionImportWithDBTestSuite) TestInstallmentInference() {
 		csv := buildCSV([][]string{
 			{"01/01/2026", "Aluguel", "-1500,00"},
 		})
-		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+		resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 		suite.Require().NoError(err)
 		row := resp.Rows[0]
 		suite.Equal("Aluguel", row.Description)

--- a/backend/internal/service/transaction_import_xls_test.go
+++ b/backend/internal/service/transaction_import_xls_test.go
@@ -151,7 +151,7 @@ func (suite *TransactionImportXLSWithDBTestSuite) TestParseImportCSV_FromXLS() {
 	csv, err := ConvertXLSToCSV(xlsSampleFixture)
 	suite.Require().NoError(err)
 
-	resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+	resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 	suite.Require().NoError(err)
 	suite.Require().Equal(3, resp.TotalRows)
 

--- a/backend/internal/service/transaction_import_xlsx_test.go
+++ b/backend/internal/service/transaction_import_xlsx_test.go
@@ -150,7 +150,7 @@ func (suite *TransactionImportXLSXWithDBTestSuite) TestParseImportCSV_FromXLSX()
 	csv, err := ConvertXLSXToCSV(xlsx)
 	suite.Require().NoError(err)
 
-	resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, DecimalSeparatorComma, TypeDefinitionPositiveAsIncome, csv)
+	resp, err := suite.Services.Transaction.ParseImportCSV(ctx, user.ID, account.ID, TypeDefinitionPositiveAsIncome, csv)
 	suite.Require().NoError(err)
 	suite.Require().Equal(2, resp.TotalRows)
 

--- a/backend/mocks/mock_TransactionService.go
+++ b/backend/mocks/mock_TransactionService.go
@@ -252,9 +252,9 @@ func (_c *MockTransactionService_GetBalance_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// ParseImportCSV provides a mock function with given fields: ctx, userID, accountID, decimalSeparator, typeDefinitionRule, csvData
-func (_m *MockTransactionService) ParseImportCSV(ctx context.Context, userID int, accountID int, decimalSeparator domain.ImportDecimalSeparatorValue, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte) (*domain.ImportCSVResponse, error) {
-	ret := _m.Called(ctx, userID, accountID, decimalSeparator, typeDefinitionRule, csvData)
+// ParseImportCSV provides a mock function with given fields: ctx, userID, accountID, typeDefinitionRule, csvData
+func (_m *MockTransactionService) ParseImportCSV(ctx context.Context, userID int, accountID int, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte) (*domain.ImportCSVResponse, error) {
+	ret := _m.Called(ctx, userID, accountID, typeDefinitionRule, csvData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ParseImportCSV")
@@ -262,19 +262,19 @@ func (_m *MockTransactionService) ParseImportCSV(ctx context.Context, userID int
 
 	var r0 *domain.ImportCSVResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int, int, domain.ImportDecimalSeparatorValue, domain.ImportTypeDefinitionRule, []byte) (*domain.ImportCSVResponse, error)); ok {
-		return rf(ctx, userID, accountID, decimalSeparator, typeDefinitionRule, csvData)
+	if rf, ok := ret.Get(0).(func(context.Context, int, int, domain.ImportTypeDefinitionRule, []byte) (*domain.ImportCSVResponse, error)); ok {
+		return rf(ctx, userID, accountID, typeDefinitionRule, csvData)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int, int, domain.ImportDecimalSeparatorValue, domain.ImportTypeDefinitionRule, []byte) *domain.ImportCSVResponse); ok {
-		r0 = rf(ctx, userID, accountID, decimalSeparator, typeDefinitionRule, csvData)
+	if rf, ok := ret.Get(0).(func(context.Context, int, int, domain.ImportTypeDefinitionRule, []byte) *domain.ImportCSVResponse); ok {
+		r0 = rf(ctx, userID, accountID, typeDefinitionRule, csvData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*domain.ImportCSVResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int, int, domain.ImportDecimalSeparatorValue, domain.ImportTypeDefinitionRule, []byte) error); ok {
-		r1 = rf(ctx, userID, accountID, decimalSeparator, typeDefinitionRule, csvData)
+	if rf, ok := ret.Get(1).(func(context.Context, int, int, domain.ImportTypeDefinitionRule, []byte) error); ok {
+		r1 = rf(ctx, userID, accountID, typeDefinitionRule, csvData)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -291,16 +291,15 @@ type MockTransactionService_ParseImportCSV_Call struct {
 //   - ctx context.Context
 //   - userID int
 //   - accountID int
-//   - decimalSeparator domain.ImportDecimalSeparatorValue
 //   - typeDefinitionRule domain.ImportTypeDefinitionRule
 //   - csvData []byte
-func (_e *MockTransactionService_Expecter) ParseImportCSV(ctx interface{}, userID interface{}, accountID interface{}, decimalSeparator interface{}, typeDefinitionRule interface{}, csvData interface{}) *MockTransactionService_ParseImportCSV_Call {
-	return &MockTransactionService_ParseImportCSV_Call{Call: _e.mock.On("ParseImportCSV", ctx, userID, accountID, decimalSeparator, typeDefinitionRule, csvData)}
+func (_e *MockTransactionService_Expecter) ParseImportCSV(ctx interface{}, userID interface{}, accountID interface{}, typeDefinitionRule interface{}, csvData interface{}) *MockTransactionService_ParseImportCSV_Call {
+	return &MockTransactionService_ParseImportCSV_Call{Call: _e.mock.On("ParseImportCSV", ctx, userID, accountID, typeDefinitionRule, csvData)}
 }
 
-func (_c *MockTransactionService_ParseImportCSV_Call) Run(run func(ctx context.Context, userID int, accountID int, decimalSeparator domain.ImportDecimalSeparatorValue, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte)) *MockTransactionService_ParseImportCSV_Call {
+func (_c *MockTransactionService_ParseImportCSV_Call) Run(run func(ctx context.Context, userID int, accountID int, typeDefinitionRule domain.ImportTypeDefinitionRule, csvData []byte)) *MockTransactionService_ParseImportCSV_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int), args[2].(int), args[3].(domain.ImportDecimalSeparatorValue), args[4].(domain.ImportTypeDefinitionRule), args[5].([]byte))
+		run(args[0].(context.Context), args[1].(int), args[2].(int), args[3].(domain.ImportTypeDefinitionRule), args[4].([]byte))
 	})
 	return _c
 }
@@ -310,7 +309,7 @@ func (_c *MockTransactionService_ParseImportCSV_Call) Return(_a0 *domain.ImportC
 	return _c
 }
 
-func (_c *MockTransactionService_ParseImportCSV_Call) RunAndReturn(run func(context.Context, int, int, domain.ImportDecimalSeparatorValue, domain.ImportTypeDefinitionRule, []byte) (*domain.ImportCSVResponse, error)) *MockTransactionService_ParseImportCSV_Call {
+func (_c *MockTransactionService_ParseImportCSV_Call) RunAndReturn(run func(context.Context, int, int, domain.ImportTypeDefinitionRule, []byte) (*domain.ImportCSVResponse, error)) *MockTransactionService_ParseImportCSV_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -118,13 +118,11 @@ export async function updateTransaction(id: number, payload: Transactions.Update
 export async function parseImportCSV(
   file: File,
   accountId: number,
-  decimalSeparator: Transactions.DecimalSeparatorValue,
   typeDefinitionRule: Transactions.TypeDefinitionRule,
 ): Promise<Transactions.ImportCSVResponse> {
   const form = new FormData();
   form.append("file", file);
   form.append("account_id", String(accountId));
-  form.append("decimal_separator", decimalSeparator);
   form.append("type_definition_rule", typeDefinitionRule);
   // Do NOT set Content-Type header — browser sets it automatically with the boundary.
   const res = await fetch(`${apiUrl}/api/transactions/import-csv`, {

--- a/frontend/src/components/transactions/import/UploadStep.tsx
+++ b/frontend/src/components/transactions/import/UploadStep.tsx
@@ -23,7 +23,7 @@ import { Transactions } from '@/types/transactions'
 import { parseApiError } from '@/utils/apiErrors'
 import { renderDrawer } from '@/utils/renderDrawer'
 import { CSV_COLUMNS } from './importPayload'
-import { ImportTestIds, type ImportDecimalSeparator, type ImportTypeRule } from '@/testIds'
+import { ImportTestIds, type ImportTypeRule } from '@/testIds'
 
 type Props = {
   onParsed: (rows: Transactions.ParsedImportRow[], accountId: number) => void
@@ -31,7 +31,6 @@ type Props = {
 }
 
 export function UploadStep({ onParsed, onBack }: Props) {
-  const [decimalSeparator, setDecimalSeparator] = useState<Transactions.DecimalSeparatorValue>('comma')
   const [typeDefinitionRule, setTypeDefinitionRule] = useState<Transactions.TypeDefinitionRule>('positive_as_income')
   const [accountId, setAccountId] = useState<number | null>(null)
   const [file, setFile] = useState<File | null>(null)
@@ -58,7 +57,7 @@ export function UploadStep({ onParsed, onBack }: Props) {
     }
 
     mutation.mutate(
-      { file, accountId, decimalSeparator, typeDefinitionRule },
+      { file, accountId, typeDefinitionRule },
       {
         onSuccess: (result) => onParsed(result.rows, accountId),
         onError: async (err: unknown) => {
@@ -117,24 +116,6 @@ export function UploadStep({ onParsed, onBack }: Props) {
           <IconPlus size={16} />
         </ActionIcon>
 
-        <Select
-          label="Formato da coluna 'Valor'"
-          required
-          data={[
-            { label: '1.234,56', value: 'comma' },
-            { label: '1,243.56', value: 'dot' },
-          ]}
-          value={decimalSeparator}
-          onChange={(val) => setDecimalSeparator((val as Transactions.DecimalSeparatorValue | null) ?? 'comma')}
-          renderOption={({ option }) => (
-            <span
-              data-testid={ImportTestIds.OptionDecimalSeparator(option.value as ImportDecimalSeparator)}
-            >
-              {option.label}
-            </span>
-          )}
-          data-testid={ImportTestIds.SelectDecimalSeparator}
-        />
         <Select
           label="Regra de definição do tipo"
           required

--- a/frontend/src/hooks/useParseImportCSV.ts
+++ b/frontend/src/hooks/useParseImportCSV.ts
@@ -7,14 +7,12 @@ export function useParseImportCSV() {
     mutationFn: ({
       file,
       accountId,
-      decimalSeparator,
       typeDefinitionRule,
     }: {
       file: File;
       accountId: number;
-      decimalSeparator: Transactions.DecimalSeparatorValue;
       typeDefinitionRule: Transactions.TypeDefinitionRule;
-    }) => parseImportCSV(file, accountId, decimalSeparator, typeDefinitionRule),
+    }) => parseImportCSV(file, accountId, typeDefinitionRule),
   });
   return { mutation };
 }

--- a/frontend/src/testIds/import.ts
+++ b/frontend/src/testIds/import.ts
@@ -1,6 +1,5 @@
 export type ImportRowAction = 'import' | 'skip' | 'duplicate'
 export type ImportRowTransactionType = 'expense' | 'income' | 'transfer'
-export type ImportDecimalSeparator = 'comma' | 'dot'
 export type ImportTypeRule = 'positive_as_income' | 'positive_as_expense'
 
 export const ImportTestIds = {
@@ -12,15 +11,12 @@ export const ImportTestIds = {
   // Upload-step controls
   BtnProcessCSV: 'btn_process_csv',
   SelectAccount: 'select_import_account',
-  SelectDecimalSeparator: 'select_decimal_separator',
   SelectTypeRule: 'select_type_rule',
   InputCsvFile: 'input_csv_file',
   BtnCreateAccountHeader: 'btn_create_account_header',
 
   // Upload-step option testids
   OptionAccount: (accountId: number | string) => `option_import_account_${accountId}` as const,
-  OptionDecimalSeparator: (value: ImportDecimalSeparator) =>
-    `option_decimal_separator_${value}` as const,
   OptionTypeRule: (value: ImportTypeRule) => `option_type_rule_${value}` as const,
 
   // Review-step controls

--- a/frontend/src/testIds/index.ts
+++ b/frontend/src/testIds/index.ts
@@ -29,7 +29,6 @@ export {
   ImportTestIds,
   type ImportRowAction,
   type ImportRowTransactionType,
-  type ImportDecimalSeparator,
   type ImportTypeRule,
 } from "./import";
 export { RecurrenceTestIds, type RecurrenceType } from "./recurrence";

--- a/frontend/src/types/transactions.ts
+++ b/frontend/src/types/transactions.ts
@@ -227,7 +227,6 @@ export namespace Transactions {
     parse_errors?: string[];
   }
 
-  export type DecimalSeparatorValue = "comma" | "dot";
   export type TypeDefinitionRule = "positive_as_income" | "positive_as_expense";
 
   export interface ImportCSVResponse {


### PR DESCRIPTION
## Summary
This PR removes the manual decimal separator selection from the CSV import flow and replaces it with automatic format detection. The system now intelligently infers whether numbers use comma or dot as decimal separators based on the actual content of each amount field.

## Key Changes

### Backend
- **Removed `ImportDecimalSeparatorValue` type** from domain and service packages
- **Refactored `parseAmountSigned()` function** to auto-detect number formats:
  - Handles integers ("150")
  - Detects pt-BR format ("1.234,56" with dot as thousands separator, comma as decimal)
  - Detects US/international format ("1,234.56" with comma as thousands separator, dot as decimal)
  - Resolves ambiguous cases ("1.234" or "1,234") by treating single separators followed by 3 digits as thousands separators
  - When both separators present, uses the last occurrence as decimal separator
- **Updated `ParseImportCSV()` signature** to remove `decimalSeparator` parameter
- **Updated all test cases** to reflect new auto-detection logic with comprehensive test coverage for various number formats
- **Updated handler** to remove decimal separator form value processing

### Frontend
- **Removed decimal separator selector** from the UploadStep component
- **Removed `DecimalSeparatorValue` type** from transactions types
- **Updated API call** to remove decimal separator parameter
- **Cleaned up test IDs** related to decimal separator selection
- **Updated hook** to remove decimal separator from mutation payload

## Implementation Details
The new `parseAmountSigned()` function uses a sophisticated heuristic approach:
1. Counts occurrences of dots and commas
2. Identifies the position of the last occurrence of each separator
3. Applies rules based on separator count and position to determine which is the decimal separator
4. Normalizes the string to a standard format before parsing with `strconv.ParseFloat()`

This eliminates the need for users to manually specify their number format while maintaining support for both common conventions (Brazilian and US/International).

https://claude.ai/code/session_01MtEUvMdEGiRceD733Bt2va