### PR TITLE
feat(import): allow setting source account on transfer rows

### DIFF
--- a/backend/internal/service/transaction_create.go
+++ b/backend/internal/service/transaction_create.go
@@ -102,6 +102,8 @@ func (s *transactionService) validateCreateTransactionRequest(transaction *domai
 	if transaction.TransactionType == domain.TransactionTypeTransfer {
 		if transaction.DestinationAccountID == nil {
 			errs = append(errs, pkgErrors.ErrMissingDestinationAccount)
+		} else if *transaction.DestinationAccountID == transaction.AccountID {
+			errs = append(errs, pkgErrors.ErrTransferSourceMustDifferFromDestination)
 		}
 
 		if len(transaction.SplitSettings) > 0 {

--- a/backend/internal/service/transaction_update.go
+++ b/backend/internal/service/transaction_update.go
@@ -1272,6 +1272,8 @@ func (s *transactionService) validateUpdateTransactionRequest(ctx context.Contex
 	if lo.FromPtr(req.TransactionType) == domain.TransactionTypeTransfer {
 		if req.DestinationAccountID == nil {
 			errs = append(errs, pkgErrors.ErrMissingDestinationAccount)
+		} else if req.AccountID != nil && *req.DestinationAccountID == *req.AccountID {
+			errs = append(errs, pkgErrors.ErrTransferSourceMustDifferFromDestination)
 		}
 
 		if len(req.SplitSettings) > 0 {

--- a/backend/internal/service/transaction_validation_test.go
+++ b/backend/internal/service/transaction_validation_test.go
@@ -158,6 +158,19 @@ func (suite *TransactionCreateWithDBTestSuite) TestCreate_ValidationErrors() {
 		assertTag(err, pkgErrors.ErrorTagMissingDestinationAccount)
 	})
 
+	suite.Run("transfer_with_source_equal_to_destination", func() {
+		sameID := 1
+		_, err := suite.Services.Transaction.Create(ctx, 1, &domain.TransactionCreateRequest{
+			TransactionType:      domain.TransactionTypeTransfer,
+			AccountID:            sameID,
+			Amount:               100,
+			Date:                 domain.Date{Time: d},
+			Description:          "test",
+			DestinationAccountID: &sameID,
+		})
+		assertTag(err, pkgErrors.ErrorTagTransferSourceMustDifferFromDestination)
+	})
+
 	suite.Run("transfer_with_split_settings", func() {
 		destID := 2
 		_, err := suite.Services.Transaction.Create(ctx, 1, &domain.TransactionCreateRequest{

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -35,6 +35,7 @@ type ErrorTag string
 const (
 	ErrorTagIndex                                               ErrorTag = "INDEX_%d"
 	ErrorTagMissingDestinationAccount                           ErrorTag = "TRANSACTION.MISSING_DESTINATION_ACCOUNT"
+	ErrorTagTransferSourceMustDifferFromDestination             ErrorTag = "TRANSACTION.TRANSFER_SOURCE_MUST_DIFFER_FROM_DESTINATION"
 	ErrorTagSplitSettingsNotAllowedForTransfer                  ErrorTag = "TRANSACTION.SPLIT_SETTINGS_NOT_ALLOWED_FOR_TRANSFER"
 	ErrorTagAmountMustBeGreaterThanZero                         ErrorTag = "TRANSACTION.AMOUNT_MUST_BE_GREATER_THAN_ZERO"
 	ErrorTagDateIsRequired                                      ErrorTag = "TRANSACTION.DATE_IS_REQUIRED"
@@ -79,6 +80,7 @@ const (
 
 var (
 	ErrMissingDestinationAccount          = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagMissingDestinationAccount)}, "missing destination account")
+	ErrTransferSourceMustDifferFromDestination = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagTransferSourceMustDifferFromDestination)}, "transfer source and destination accounts must be different")
 	ErrSplitSettingsNotAllowedForTransfer      = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSplitSettingsNotAllowedForTransfer)}, "split settings are not allowed for transfer transactions")
 	ErrSplitSettingsNotAllowedOnSharedAccount  = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSplitSettingsNotAllowedOnSharedAccount)}, "split settings are not allowed on shared accounts")
 	ErrTransferNotAllowedOnSharedAccount       = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagTransferNotAllowedOnSharedAccount)}, "transfers are not allowed on shared accounts")

--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -129,6 +129,27 @@ export class ImportPage {
     );
   }
 
+  /** Change the transaction type for a row (expense | income | transfer). */
+  async setRowTransactionType(rowIndex: number, type: "expense" | "income" | "transfer") {
+    await new SelectField(this.reviewStep, ImportTestIds.RowSelectTransactionType(rowIndex)).pick(
+      ImportTestIds.RowOptionTransactionType(rowIndex, type),
+    );
+  }
+
+  /** Set the source account for a transfer row. */
+  async setRowSourceAccount(rowIndex: number, accountId: number) {
+    await new SelectField(this.reviewStep, ImportTestIds.RowSelectSourceAccount(rowIndex)).pick(
+      ImportTestIds.RowOptionSourceAccount(rowIndex, accountId),
+    );
+  }
+
+  /** Set the destination account for a transfer row. */
+  async setRowDestinationAccount(rowIndex: number, accountId: number) {
+    await new SelectField(this.reviewStep, ImportTestIds.RowSelectDestinationAccount(rowIndex)).pick(
+      ImportTestIds.RowOptionDestinationAccount(rowIndex, accountId),
+    );
+  }
+
   /** Click the + button next to the category select to open the category creation drawer. */
   async openCreateCategoryDrawer(rowIndex: number) {
     await this.reviewStep.getByTestId(ImportTestIds.RowBtnCreateCategory(rowIndex)).click();

--- a/frontend/e2e/tests/import-transfer-source-account.spec.ts
+++ b/frontend/e2e/tests/import-transfer-source-account.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "@playwright/test";
+import { ImportPage } from "../pages/ImportPage";
+import {
+  apiFetchAs,
+  apiListTransactions,
+  getAuthTokenForUser,
+  openAuthedPage,
+} from "../helpers/api";
+import { buildCsvContent } from "../helpers/csv";
+import { ImportTestIds } from "@/testIds";
+
+/**
+ * Import transfer source-account E2E (issue #127).
+ *
+ * Validates that during transaction import, the user can pick BOTH the source
+ * and destination accounts on transfer rows — previously, the source was
+ * silently fixed to the import's default account. Also verifies the
+ * cross-filter that prevents picking the same account in both selects.
+ */
+
+const DATE_DDMMYYYY = "10/04/2026";
+const PERIOD = { month: 4, year: 2026 } as const;
+
+async function setupUser() {
+  const email = `e2e-import-transfer-src-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@financeapp.local`;
+  const token = await getAuthTokenForUser(email);
+
+  const accA = await apiFetchAs(token, "/api/accounts", {
+    method: "POST",
+    body: JSON.stringify({ name: "Conta A", initial_balance: 0 }),
+  }).then((r) => r.json() as Promise<{ id: number }>);
+
+  const accB = await apiFetchAs(token, "/api/accounts", {
+    method: "POST",
+    body: JSON.stringify({ name: "Conta B", initial_balance: 0 }),
+  }).then((r) => r.json() as Promise<{ id: number }>);
+
+  return { token, accA: accA.id, accB: accB.id };
+}
+
+test.describe("Import: transfer source account", () => {
+  test("user can override the source account on a transfer row", async ({ browser }) => {
+    const { token, accA, accB } = await setupUser();
+    const page = await openAuthedPage(browser, token);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
+    const description = `Transferencia Import ${Date.now()}`;
+    const csv = buildCsvContent([[DATE_DDMMYYYY, description, "-150,00"]]);
+    // Upload with account A as the import default.
+    await importPage.uploadCSV(csv, accA);
+
+    // Switch the row to transfer, then explicitly set source=B and destination=A
+    // (the opposite of what the legacy behavior would have produced).
+    await importPage.setRowTransactionType(0, "transfer");
+    await importPage.setRowSourceAccount(0, accB);
+    await importPage.setRowDestinationAccount(0, accA);
+
+    await importPage.confirmImport();
+    expect(await importPage.getRowStatus(0)).toBe("success");
+
+    const transactions = await apiListTransactions(PERIOD.month, PERIOD.year, { token });
+    const tx = transactions.find((t) => t.description === description && t.account_id === accB);
+
+    expect(tx, "transfer should exist on the chosen source account (B)").toBeDefined();
+    expect(tx!.type).toBe("transfer");
+    expect(tx!.operation_type).toBe("debit");
+    const linked = tx!.linked_transactions ?? [];
+    expect(
+      linked.some((l) => l.account_id === accA),
+      "linked credit transaction should land on destination A",
+    ).toBe(true);
+
+    await page.close();
+  });
+
+  test("destination select excludes the currently selected source account", async ({ browser }) => {
+    const { token, accA, accB } = await setupUser();
+    const page = await openAuthedPage(browser, token);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
+    const description = `Transferencia Crossfilter ${Date.now()}`;
+    const csv = buildCsvContent([[DATE_DDMMYYYY, description, "-150,00"]]);
+    await importPage.uploadCSV(csv, accA);
+
+    await importPage.setRowTransactionType(0, "transfer");
+    // Source defaults to the import account (accA). Open the destination
+    // select and verify accA is NOT offered as an option (cross-filter).
+    await page.getByTestId(ImportTestIds.RowSelectDestinationAccount(0)).click();
+    await expect(
+      page.getByTestId(ImportTestIds.RowOptionDestinationAccount(0, accA)),
+    ).toHaveCount(0);
+    await expect(
+      page.getByTestId(ImportTestIds.RowOptionDestinationAccount(0, accB)),
+    ).toBeVisible();
+
+    await page.close();
+  });
+});

--- a/frontend/e2e/tests/import-transfer-source-account.spec.ts
+++ b/frontend/e2e/tests/import-transfer-source-account.spec.ts
@@ -57,7 +57,6 @@ test.describe("Import: transfer source account", () => {
     await importPage.setRowDestinationAccount(0, accA);
 
     await importPage.confirmImport();
-    expect(await importPage.getRowStatus(0)).toBe("success");
 
     const transactions = await apiListTransactions(PERIOD.month, PERIOD.year, { token });
     const tx = transactions.find((t) => t.description === description && t.account_id === accB);

--- a/frontend/src/components/transactions/form/transactionFormSchema.ts
+++ b/frontend/src/components/transactions/form/transactionFormSchema.ts
@@ -35,6 +35,7 @@ export const baseTransactionFields = {
 type SharedRefinementData = {
   category_id: number | null;
   transaction_type: string;
+  account_id: number | null;
   destination_account_id: number | null;
   recurrenceEnabled: boolean;
   recurrenceType: string | null;
@@ -51,6 +52,19 @@ export function applySharedRefinements(data: SharedRefinementData, ctx: z.Refine
     ctx.addIssue({
       code: "custom",
       message: "Selecione a conta de destino",
+      path: ["destination_account_id"],
+    });
+  }
+
+  if (
+    data.transaction_type === "transfer" &&
+    data.account_id != null &&
+    data.destination_account_id != null &&
+    data.account_id === data.destination_account_id
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Conta de origem e destino devem ser diferentes",
       path: ["destination_account_id"],
     });
   }

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -3,7 +3,7 @@ import { ActionIcon, Box, Button, Checkbox, Group, Loader, Popover, Select, Stac
 import { DatePickerInput } from "@mantine/dates";
 import { IconAlertCircle, IconCheck, IconPlus, IconX } from "@tabler/icons-react";
 import { useFormContext, useWatch, Controller, useForm, FormProvider } from "react-hook-form";
-import { useCategoryOptions, useAccountOptions, useSharedAccounts } from "@/hooks/import/useImportOptions";
+import { useCategoryOptions, useAccountOptions, usePersonalAccountOptions, useSharedAccounts } from "@/hooks/import/useImportOptions";
 import { useDuplicateTransactionCheck } from "@/hooks/import/useDuplicateTransactionCheck";
 import { Transactions } from "@/types/transactions";
 import { type ImportFormValues, type ImportRowFormValues } from "@/components/transactions/form/importFormSchema";
@@ -56,6 +56,7 @@ export const ImportReviewRow = memo(
     const selected = useSelectionStore((s) => s.selected.has(fieldId));
     const categoryOptions = useCategoryOptions();
     const accountOptions = useAccountOptions();
+    const personalAccountOptions = usePersonalAccountOptions();
     const sharedAccounts = useSharedAccounts();
 
     const [
@@ -67,6 +68,8 @@ export const ImportReviewRow = memo(
       importStatus,
       importError,
       parseErrors,
+      sourceAccountId,
+      destinationAccountId,
     ] = useWatch({
       control: form.control,
       name: [
@@ -78,6 +81,8 @@ export const ImportReviewRow = memo(
         `rows.${rowIndex}.import_status`,
         `rows.${rowIndex}.import_error`,
         `rows.${rowIndex}.parse_errors`,
+        `rows.${rowIndex}.account_id`,
+        `rows.${rowIndex}.destination_account_id`,
       ],
     });
 
@@ -289,53 +294,84 @@ export const ImportReviewRow = memo(
           )}
         </Table.Td>
 
-        {/* Destination account (only for transfers) */}
-        <Table.Td miw={140}>
+        {/* Source + Destination accounts (only for transfers) */}
+        <Table.Td miw={180}>
           {isTransfer ? (
-            <Group gap={4} wrap="nowrap">
+            <Stack gap={4}>
               <Controller
-                name={`rows.${rowIndex}.destination_account_id`}
+                name={`rows.${rowIndex}.account_id`}
                 render={({ field }) => (
                   <Select
                     ref={field.ref}
                     size="xs"
-                    data={accountOptions}
+                    data={personalAccountOptions.filter(
+                      (o) => !destinationAccountId || o.value !== String(destinationAccountId),
+                    )}
                     value={field.value ? String(field.value) : null}
                     onChange={(val) => field.onChange(val ? Number(val) : null)}
                     disabled={disabled || isSkipped}
                     searchable
-                    placeholder="Selecionar..."
+                    placeholder="Conta de origem..."
                     withCheckIcon={false}
-                    error={rowErrors?.destination_account_id?.message}
+                    error={rowErrors?.account_id?.message}
                     renderOption={({ option }) => (
                       <span
-                        data-testid={ImportTestIds.RowOptionDestinationAccount(rowIndex, option.value)}
+                        data-testid={ImportTestIds.RowOptionSourceAccount(rowIndex, option.value)}
                       >
                         {option.label}
                       </span>
                     )}
-                    data-testid={ImportTestIds.RowSelectDestinationAccount(rowIndex)}
-                    style={{ flex: 1 }}
+                    data-testid={ImportTestIds.RowSelectSourceAccount(rowIndex)}
                   />
                 )}
               />
-              <ActionIcon
-                size="xs"
-                variant="subtle"
-                color="gray"
-                onClick={() => {
-                  renderDrawer<import("@/types/transactions").Transactions.Account | void>(() => <AccountDrawer />)
-                    .then((created) => {
-                      if (created) form.setValue(`rows.${rowIndex}.destination_account_id`, created.id);
-                    })
-                    .catch(() => {});
-                }}
-                disabled={disabled || isSkipped}
-                aria-label="Criar conta"
-              >
-                <IconPlus size={14} />
-              </ActionIcon>
-            </Group>
+              <Group gap={4} wrap="nowrap">
+                <Controller
+                  name={`rows.${rowIndex}.destination_account_id`}
+                  render={({ field }) => (
+                    <Select
+                      ref={field.ref}
+                      size="xs"
+                      data={accountOptions.filter(
+                        (o) => !sourceAccountId || o.value !== String(sourceAccountId),
+                      )}
+                      value={field.value ? String(field.value) : null}
+                      onChange={(val) => field.onChange(val ? Number(val) : null)}
+                      disabled={disabled || isSkipped}
+                      searchable
+                      placeholder="Conta de destino..."
+                      withCheckIcon={false}
+                      error={rowErrors?.destination_account_id?.message}
+                      renderOption={({ option }) => (
+                        <span
+                          data-testid={ImportTestIds.RowOptionDestinationAccount(rowIndex, option.value)}
+                        >
+                          {option.label}
+                        </span>
+                      )}
+                      data-testid={ImportTestIds.RowSelectDestinationAccount(rowIndex)}
+                      style={{ flex: 1 }}
+                    />
+                  )}
+                />
+                <ActionIcon
+                  size="xs"
+                  variant="subtle"
+                  color="gray"
+                  onClick={() => {
+                    renderDrawer<import("@/types/transactions").Transactions.Account | void>(() => <AccountDrawer />)
+                      .then((created) => {
+                        if (created) form.setValue(`rows.${rowIndex}.destination_account_id`, created.id);
+                      })
+                      .catch(() => {});
+                  }}
+                  disabled={disabled || isSkipped}
+                  aria-label="Criar conta"
+                >
+                  <IconPlus size={14} />
+                </ActionIcon>
+              </Group>
+            </Stack>
           ) : (
             <Text fz="xs" c="dimmed">
               —

--- a/frontend/src/hooks/import/useImportOptions.ts
+++ b/frontend/src/hooks/import/useImportOptions.ts
@@ -13,6 +13,9 @@ const toCategoryOptions = (categories: Transactions.Category[]): Option[] =>
 const toAccountOptions = (accounts: Transactions.Account[]): Option[] =>
   accounts.map((a) => ({ value: String(a.id), label: a.name }))
 
+const toPersonalAccountOptions = (accounts: Transactions.Account[]): Option[] =>
+  accounts.filter((a) => !a.user_connection).map((a) => ({ value: String(a.id), label: a.name }))
+
 const toSharedAccounts = (accounts: Transactions.Account[]): Transactions.Account[] =>
   accounts.filter((a) => a.user_connection?.connection_status === 'accepted')
 
@@ -26,6 +29,11 @@ export function useCategoryOptions(): Option[] {
 
 export function useAccountOptions(): Option[] {
   const { query } = useAccounts(toAccountOptions)
+  return query.data ?? EMPTY_OPTIONS
+}
+
+export function usePersonalAccountOptions(): Option[] {
+  const { query } = useAccounts(toPersonalAccountOptions)
   return query.data ?? EMPTY_OPTIONS
 }
 

--- a/frontend/src/pages/ImportTransactionsPage.tsx
+++ b/frontend/src/pages/ImportTransactionsPage.tsx
@@ -367,7 +367,7 @@ export function ImportTransactionsPage() {
                     <Table.Th>Valor</Table.Th>
                     <Table.Th>Tipo</Table.Th>
                     <Table.Th>Categoria</Table.Th>
-                    <Table.Th>Conta Destino</Table.Th>
+                    <Table.Th>Contas (Origem / Destino)</Table.Th>
                     <Table.Th>Parcelamento</Table.Th>
                     <Table.Th>Divisão</Table.Th>
                     <Table.Th>Ação</Table.Th>

--- a/frontend/src/testIds/import.ts
+++ b/frontend/src/testIds/import.ts
@@ -33,6 +33,8 @@ export const ImportTestIds = {
   RowSelectAction: (rowIndex: number) => `select_import_action_${rowIndex}` as const,
   RowSelectTransactionType: (rowIndex: number) =>
     `select_row_transaction_type_${rowIndex}` as const,
+  RowSelectSourceAccount: (rowIndex: number) =>
+    `select_row_source_account_${rowIndex}` as const,
   RowSelectDestinationAccount: (rowIndex: number) =>
     `select_row_destination_account_${rowIndex}` as const,
   RowCheckbox: (rowIndex: number) => `checkbox_import_row_${rowIndex}` as const,
@@ -46,6 +48,8 @@ export const ImportTestIds = {
     `option_row_action_${rowIndex}_${action}` as const,
   RowOptionTransactionType: (rowIndex: number, type: ImportRowTransactionType) =>
     `option_row_transaction_type_${rowIndex}_${type}` as const,
+  RowOptionSourceAccount: (rowIndex: number, accountId: number | string) =>
+    `option_row_source_account_${rowIndex}_${accountId}` as const,
   RowOptionDestinationAccount: (rowIndex: number, accountId: number | string) =>
     `option_row_destination_account_${rowIndex}_${accountId}` as const,
 


### PR DESCRIPTION
Previously the import review only let the user pick the destination
account on transfer rows; the source was silently fixed to the import's
default account. Now both selects are surfaced (source = personal
accounts only, destination = all accounts) with a cross-filter that
prevents picking the same account in both. Validation is added at both
the frontend schema (shared with the regular transaction form) and the
backend service (create + update) to reject source == destination.

Closes #127