### PR TITLE
Fix settlement filtering in transaction totals and rendering

### DIFF
--- a/frontend/src/components/transactions/TransactionGroup.tsx
+++ b/frontend/src/components/transactions/TransactionGroup.tsx
@@ -179,10 +179,7 @@ export function TransactionGroup({
               tx.user_id === currentUserId);
 
           if (isSynthetic) {
-            // Render synthetic entries (orphan settlements surfaced by the
-            // backend or inline settlements promoted into their own date
-            // group) with the same SettlementRow styling used for inline
-            // settlements.
+            if (hideSettlements) return null;
             const settlementId = tx.origin_settlement_id!;
             const sourceTxId = tx.source_transaction_id;
             const syntheticSettlement: Transactions.Settlement = {

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -26,6 +26,9 @@ function groupNetTotal(
   const filterSet = hasAccountFilter ? new Set(accountFilter) : null;
 
   return group.transactions.reduce((sum, tx) => {
+    if (hideSettlements && tx.origin_settlement_id !== undefined) {
+      return sum;
+    }
     const txAmount = tx.operation_type === "credit" ? tx.amount : -tx.amount;
     const settlementsAmount = hideSettlements
       ? 0


### PR DESCRIPTION
## Summary
Fixes a bug where synthetic settlements were not being properly excluded from transaction group net totals when the `hideSettlements` flag was enabled, and removes outdated comments in the settlement rendering logic.

## Changes
- **TransactionList.tsx**: Added a check in `groupNetTotal()` to skip transactions with `origin_settlement_id` when `hideSettlements` is true, ensuring settlement amounts don't contribute to group totals
- **TransactionGroup.tsx**: Replaced outdated multi-line comment with the actual settlement filtering logic (`if (hideSettlements) return null;`), making the intent clearer and consistent with the filtering applied elsewhere

## Implementation Details
The fix ensures that when settlements are hidden from the UI, they are also excluded from the calculated net totals for transaction groups. This prevents discrepancies between displayed transactions and their aggregated amounts. The filtering logic checks for the presence of `origin_settlement_id` to identify synthetic settlement entries that should be excluded.

https://claude.ai/code/session_01V9Va1s5LQWByPLUgDsZy2e