### PR TITLE
Pass hideSettlements filter to opening balance query

### DIFF
--- a/frontend/src/components/transactions/OpeningBalanceRow.tsx
+++ b/frontend/src/components/transactions/OpeningBalanceRow.tsx
@@ -12,6 +12,7 @@ export function OpeningBalanceRow() {
     month: search.month,
     year: search.year,
     accumulated: search.accumulated,
+    hideSettlements: search.hideSettlements,
   })
 
   const balance = balanceQuery.data?.balance ?? 0


### PR DESCRIPTION
## Summary
Updates the `OpeningBalanceRow` component to pass the `hideSettlements` search parameter to the balance query, ensuring the opening balance respects the user's settlement visibility preference.

## Changes
- Added `hideSettlements: search.hideSettlements` to the balance query parameters in `OpeningBalanceRow`

## Details
The opening balance calculation now includes the `hideSettlements` filter, allowing it to be consistent with other balance displays when the user toggles settlement visibility. This ensures the opening balance shown to the user accurately reflects their current filter preferences.

https://claude.ai/code/session_01Q575eMQh9sSeKJ5Wy2VTNR