### PR TITLE
feat(import): allow selecting shared accounts in transaction import

### DIFF
--- a/frontend/e2e/tests/import-shared-account.spec.ts
+++ b/frontend/e2e/tests/import-shared-account.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+import { ImportPage } from "../pages/ImportPage";
+import { createUserAndPartner, type UserAndPartnerResult } from "../helpers/createUserAndPartner";
+import { apiFetchAs, apiListTransactions, openAuthedPage } from "../helpers/api";
+import { buildCsvContent } from "../helpers/csv";
+import { ImportTestIds } from "@/testIds";
+
+/**
+ * Import to shared account E2E tests.
+ *
+ * Expenses/incomes can be posted directly to a shared (connection) account,
+ * so the import flow must allow picking one. Splits, however, are not allowed
+ * on shared accounts — the split option must disappear for those rows.
+ */
+
+const now = new Date();
+const MONTH = now.getMonth() + 1;
+const YEAR = now.getFullYear();
+const importDate = `15/${String(MONTH).padStart(2, "0")}/${YEAR}`;
+
+test.describe("Import to shared account", () => {
+  let setup: UserAndPartnerResult;
+  let categoryId: number;
+
+  test.beforeAll(async () => {
+    setup = await createUserAndPartner("e2e-import-shared");
+
+    const catRes = await apiFetchAs(setup.userToken, "/api/categories", {
+      method: "POST",
+      body: JSON.stringify({ name: `Cat Import Shared ${Date.now()}` }),
+    });
+    const cat = (await catRes.json()) as { id: number };
+    categoryId = cat.id;
+  });
+
+  test("imports an expense onto a shared account and partner sees inverted income", async ({
+    browser,
+  }) => {
+    const page = await openAuthedPage(browser, setup.userToken);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
+    const description = `Imported shared expense ${Date.now()}`;
+    const csv = buildCsvContent([[importDate, description, "-100,00"]]);
+
+    // Selecting the shared account is the behavior under test.
+    await importPage.uploadCSV(csv, setup.userConnAccountId);
+    await importPage.setRowCategory(0, categoryId);
+
+    // Splits are not allowed on shared accounts — the popover must be gone.
+    await expect(
+      importPage.reviewStep.getByTestId(ImportTestIds.RowBtnSplitPopover(0)),
+    ).not.toBeVisible();
+
+    await importPage.confirmImport();
+    await expect(page.getByText("Importação concluída com sucesso")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Primary user sees the expense on the shared account.
+    const userTxs = await apiListTransactions(MONTH, YEAR, { token: setup.userToken });
+    const userExpense = userTxs.find((t) => t.description === description);
+    expect(userExpense).toBeDefined();
+    expect(userExpense!.type).toBe("expense");
+    expect(userExpense!.operation_type).toBe("debit");
+    expect(userExpense!.account_id).toBe(setup.userConnAccountId);
+
+    // Partner sees the inverted income on their side of the connection.
+    const partnerTxs = await apiListTransactions(MONTH, YEAR, { token: setup.partnerToken });
+    const partnerIncome = partnerTxs.find((t) => t.description === description);
+    expect(partnerIncome).toBeDefined();
+    expect(partnerIncome!.type).toBe("income");
+    expect(partnerIncome!.operation_type).toBe("credit");
+    expect(partnerIncome!.account_id).toBe(setup.partnerConnAccountId);
+
+    await page.close();
+  });
+});

--- a/frontend/src/components/transactions/import/ImportCSVBulkToolbar.tsx
+++ b/frontend/src/components/transactions/import/ImportCSVBulkToolbar.tsx
@@ -44,6 +44,8 @@ type LocalFormType = {
 
 interface Props {
   selectedCount: number;
+  /** Splits aren't allowed on shared accounts — hide the bulk split action. */
+  canSplit: boolean;
   onRemove: () => void;
   onBulkSetAction: (action: Transactions.ImportRowAction) => void;
   onBulkSetDate: (date: string) => void;
@@ -66,6 +68,7 @@ const propsByType: Record<AvailableAction, { icon: React.ReactNode; label: strin
 
 export function ImportCSVBulkToolbar({
   selectedCount,
+  canSplit,
   onRemove,
   onBulkSetAction,
   onBulkSetDate,
@@ -198,7 +201,9 @@ export function ImportCSVBulkToolbar({
             </Button>
           </Menu.Target>
           <Menu.Dropdown>
-            {Object.entries(propsByType).map(([k, v]) => {
+            {Object.entries(propsByType)
+              .filter(([k]) => k !== "split" || canSplit)
+              .map(([k, v]) => {
               return (
                 <MenuItem
                   key={k}

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -92,6 +92,10 @@ export const ImportReviewRow = memo(
 
     const isSkipped = action !== "import";
     const isTransfer = transactionType === "transfer";
+    // Splits create a settlement on a connection account, so the main
+    // transaction must live on a private account. When the row already
+    // targets a shared account, the split option is not applicable.
+    const isSharedAccount = sharedAccounts.some((a) => a.id === sourceAccountId);
 
     function rowClass() {
       if (action === "duplicate") return classes.rowDuplicate;
@@ -391,7 +395,7 @@ export const ImportReviewRow = memo(
 
         {/* Split */}
         <Table.Td miw={140}>
-          {!isTransfer && sharedAccounts.length > 0 ? (
+          {!isTransfer && !isSharedAccount && sharedAccounts.length > 0 ? (
             <SplitPopover
               namePrefix={namePrefix}
               summary={splitSummary}

--- a/frontend/src/components/transactions/import/UploadStep.tsx
+++ b/frontend/src/components/transactions/import/UploadStep.tsx
@@ -18,12 +18,15 @@ import {
 import { IconAlertCircle, IconArrowLeft, IconFileTypeCsv, IconPlus } from '@tabler/icons-react'
 import { AccountDrawer } from '@/components/accounts/AccountDrawer'
 import { useAccounts } from '@/hooks/useAccounts'
+import { useGroupedAccountOptions } from '@/hooks/useGroupedAccountOptions'
 import { useParseImportCSV } from '@/hooks/useParseImportCSV'
 import { Transactions } from '@/types/transactions'
 import { parseApiError } from '@/utils/apiErrors'
 import { renderDrawer } from '@/utils/renderDrawer'
 import { CSV_COLUMNS } from './importPayload'
 import { ImportTestIds, type ImportTypeRule } from '@/testIds'
+
+const EMPTY_ACCOUNTS: Transactions.Account[] = []
 
 type Props = {
   onParsed: (rows: Transactions.ParsedImportRow[], accountId: number) => void
@@ -36,12 +39,12 @@ export function UploadStep({ onParsed, onBack }: Props) {
   const [file, setFile] = useState<File | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const { query: ownAccountsQuery } = useAccounts((accounts) =>
-    accounts
-      .filter((a) => !a.user_connection && a.is_active)
-      .map((a) => ({ value: String(a.id), label: a.name })),
+  const { query: accountsQuery } = useAccounts((accounts) =>
+    accounts.filter(
+      (a) => a.is_active && (!a.user_connection || a.user_connection.connection_status === 'accepted'),
+    ),
   )
-  const ownAccountOptions = ownAccountsQuery.data ?? []
+  const accountOptions = useGroupedAccountOptions(accountsQuery.data ?? EMPTY_ACCOUNTS)
 
   const { mutation } = useParseImportCSV()
 
@@ -91,7 +94,7 @@ export function UploadStep({ onParsed, onBack }: Props) {
           label="Conta"
           placeholder="Selecione uma conta"
           required
-          data={ownAccountOptions}
+          data={accountOptions}
           value={accountId ? String(accountId) : null}
           onChange={(val) => setAccountId(val ? Number(val) : null)}
           renderOption={({ option }) => (

--- a/frontend/src/pages/ImportTransactionsPage.tsx
+++ b/frontend/src/pages/ImportTransactionsPage.tsx
@@ -20,6 +20,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useQueryClient } from '@tanstack/react-query'
 import { createTransaction } from '@/api/transactions'
 import { useRedirectOnImportSuccess } from '@/hooks/import/useRedirectOnImportSuccess'
+import { useSharedAccounts } from '@/hooks/import/useImportOptions'
 import { Transactions } from '@/types/transactions'
 import { parseApiError } from '@/utils/apiErrors'
 import { QueryKeys } from '@/utils/queryKeys'
@@ -73,6 +74,11 @@ export function ImportTransactionsPage() {
     control: form.control,
     name: 'rows',
   })
+
+  // The import targets a single account; splits aren't allowed on shared accounts.
+  const importAccountId = useWatch({ control: form.control, name: 'accountId' })
+  const sharedAccounts = useSharedAccounts()
+  const importingToSharedAccount = sharedAccounts.some((a) => a.id === importAccountId)
 
   // Stable per-index ref callbacks so React.memo on ImportReviewRow can bail out
   // when only one row's selection slot changes; an inline arrow would invalidate
@@ -333,6 +339,7 @@ export function ImportTransactionsPage() {
             <Paper p="xs" withBorder style={{ visibility: someSelected && !importing ? 'visible' : 'hidden' }}>
               <ImportCSVBulkToolbar
                 selectedCount={totalSelected}
+                canSplit={!importingToSharedAccount}
                 onRemove={handleRemoveSelected}
                 onBulkSetAction={handleBulkSetAction}
                 onBulkSetDate={handleBulkSetDate}


### PR DESCRIPTION
## Summary

Expenses and incomes can now be posted directly to shared (connection) accounts. The transaction import flow previously filtered shared accounts out of its account picker, so this PR brings import in line with the regular transaction form.

- **Upload step** — the account selector now lists shared accounts in a grouped dropdown (`Minhas contas` / `Contas Compartilhadas`), reusing `useGroupedAccountOptions` like the regular form. Only active accounts and accepted connections are offered.
- **Review rows** — the per-row split popover is hidden when the row targets a shared account (splits create a settlement on a connection account, so the main transaction must stay on a private account).
- **Bulk toolbar** — the bulk "Divisão" action is hidden when the import targets a shared account, via a new `canSplit` prop.

No backend changes were needed: `ParseImportCSV` only validates account ownership, and `Create` already accepts shared accounts for expenses/incomes (and still rejects transfers/splits on them).

## Test plan

- [x] `tsc --noEmit` (app + e2e) passes
- [x] `npm run lint` passes
- [ ] New e2e test `import-shared-account.spec.ts`: imports an expense onto a shared account, asserts the split popover is hidden, and verifies the partner receives the inverted income
- [ ] Manual: import a CSV of expenses/incomes targeting a shared account; confirm rows post correctly and no split UI appears

https://claude.ai/code/session_01CReXZ1poNRTtpipABANGJN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CReXZ1poNRTtpipABANGJN)_