### PR TITLE
fix(transactions): keep split settlements off the source account balance

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -315,6 +315,8 @@ User A create a shared expense with the amount of R$ 100,00, splitting it in 50%
 When User A filter transactions by account_id = 10 it will see only a settlement of R$ 50,00 being credited and the balance for that account in that MM/YYYY will be +R$50,00
 When User B filter transactions by account_id = 20 it will see only an expense of R$ 50,00 being debited and the balance for that account in that MM/YYYY will be -R$50,00
 
+A settlement contributes **only** to the balance of its own account (the connection account it was created on). When User A filters by the **private** account where the R$ 100,00 expense lives, the balance shows the full -R$100,00 — the settlement does NOT leak into it, so the private account reconciles with the real bank statement. `GetBalance`'s settlements leg is filtered by `settlements.account_id` alone, never by the source transaction's `account_id`.
+
 #### Shared incomes
 
 It's the same as expenses but with operation type flipped

--- a/backend/internal/repository/transaction_repository.go
+++ b/backend/internal/repository/transaction_repository.go
@@ -99,15 +99,14 @@ func (r *transactionRepository) Search(ctx context.Context, filter domain.Transa
 
 	if filter.WithSettlements {
 		// Preload ALL settlements attached to returned source transactions,
-		// regardless of the settlement's own account_id. The listing view
-		// displays settlements inline under their source transaction even
-		// when the active filter doesn't target the settlement's account —
-		// it provides context about the split. The frontend is responsible
-		// for excluding out-of-scope settlements from the group net total so
-		// the displayed sum stays consistent with GetBalance (whose settlements
-		// leg is filtered by s.account_id). Double-counting in the combined-
-		// filter case is still prevented by FindOrphanedSettlementTransactions
-		// via its `t.account_id NOT IN filter` guard.
+		// regardless of the settlement's own account_id. The frontend filters
+		// them per the active account filter: with no filter (or a filter
+		// that includes the settlement's account) they render inline under
+		// the source transaction; otherwise they are hidden, keeping the
+		// displayed group total consistent with GetBalance, whose settlements
+		// leg is filtered by s.account_id. The combined-filter case is still
+		// handled by FindOrphanedSettlementTransactions via its
+		// `t.account_id NOT IN filter` guard.
 		query = query.Preload("SettlementsFromSource")
 	}
 
@@ -393,8 +392,12 @@ func (r *transactionRepository) GetBalance(ctx context.Context, filter domain.Ba
 		}
 
 		if len(filter.AccountIDs) > 0 {
-			settlementSQL += " AND (s.account_id IN ? OR t.account_id IN ?)"
-			args = append(args, filter.AccountIDs, filter.AccountIDs)
+			// A settlement contributes only to the balance of its own account
+			// (the author's connection account). It must NOT leak into the
+			// source transaction's private account balance, so the private
+			// account reconciles with the real bank statement.
+			settlementSQL += " AND s.account_id IN ?"
+			args = append(args, filter.AccountIDs)
 		}
 
 		if filter.Accumulated {

--- a/backend/internal/service/transaction_balance_test.go
+++ b/backend/internal/service/transaction_balance_test.go
@@ -106,6 +106,59 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_IncludesSettlemen
 	suite.Assert().Equal(int64(-500), result.Balance)
 }
 
+func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_SettlementDoesNotLeakIntoPrivateAccount() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, user1)
+	suite.Require().NoError(err)
+
+	personal1, err := suite.createTestAccount(ctx, user1)
+	suite.Require().NoError(err)
+
+	date := now()
+	period := domain.Period{Month: int(date.Month()), Year: date.Year()}
+
+	// user1 pays 1000 from the private account, splits 50% with user2
+	// → expense -1000 on personal1, settlement credit +500 on conn.FromAccountID
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		TransactionType: domain.TransactionTypeExpense,
+		AccountID:       personal1.ID,
+		CategoryID:      category.ID,
+		Amount:          1000,
+		Date:            domain.Date{Time: date},
+		Description:     "split expense",
+		SplitSettings:   []domain.SplitSettings{{ConnectionID: conn.ID, Percentage: lo.ToPtr(50)}},
+	})
+	suite.Require().NoError(err)
+
+	// private account: full expense -1000 — the settlement does NOT leak in,
+	// so the balance reconciles with the real bank statement
+	resultPrivate, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
+		AccountIDs: []int{personal1.ID},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(-1000), resultPrivate.Balance)
+
+	// connection account: only the settlement credit +500
+	resultConn, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
+		AccountIDs: []int{conn.FromAccountID},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(500), resultConn.Balance)
+
+	// no filter: the user total still nets to -500
+	resultTotal, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(-500), resultTotal.Balance)
+}
+
 func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_AccountIDFilter() {
 	ctx := context.Background()
 	user, err := suite.createTestUser(ctx)
@@ -421,12 +474,13 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_UpdateSplitExpens
 	})
 	suite.Require().NoError(err)
 
-	// personal1 filter: expense -6000 + settlement credit +3000 (source tx on personal1) = -3000
+	// personal1 filter: expense -6000 only — the settlement belongs to the
+	// connection account and does not leak into the private account balance
 	resultAccount1, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
 		AccountIDs: []int{personal1.ID},
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(-3000), resultAccount1.Balance)
+	suite.Assert().Equal(int64(-6000), resultAccount1.Balance)
 
 	// after update, conn account: fromTx removed by update (splitHasChanged=true) + 3000 (settlement credit) = 3000
 	resultConn, err = suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
@@ -488,12 +542,13 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_SplitExpense_ByTo
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(-500), result1.Balance)
 
-	// user2 personal account: expense -1000 + settlement credit +500 (source tx on personal2 is included in balance) = -500
+	// user2 personal account: expense -1000 only — the settlement belongs to
+	// the connection account and does not leak into the private account balance
 	result2Personal, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{
 		AccountIDs: []int{personal2.ID},
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(-500), result2Personal.Balance)
+	suite.Assert().Equal(int64(-1000), result2Personal.Balance)
 
 	// user2 connection account (ToAccountID): +500 (settlement, no fromTx for shared expenses)
 	result2Conn, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{
@@ -625,12 +680,13 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_SplitExpense_ByTo
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(-2000), result1.Balance)
 
-	// user2 personal: expense -4000 + settlement credit +2000 (source tx on personal2) = -2000
+	// user2 personal: expense -4000 only — the settlement belongs to the
+	// connection account and does not leak into the private account balance
 	result2Personal, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{
 		AccountIDs: []int{personal2.ID},
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(-2000), result2Personal.Balance)
+	suite.Assert().Equal(int64(-4000), result2Personal.Balance)
 
 	// user2 connection account: fromTx removed by update + 2000 (settlement credit) = 2000
 	result2Conn, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{

--- a/backend/internal/service/transaction_create_test.go
+++ b/backend/internal/service/transaction_create_test.go
@@ -1277,13 +1277,12 @@ func (suite *TransactionCreateWithDBTestSuite) TestSearchSharedExpenseByFromAcco
 	suite.Assert().Equal(sourceTxID, *synthetic.SourceTransactionID, "source_transaction_id must point at the real source transaction backing the settlement")
 
 	// Case 2: user1 filters ONLY by the personal account — the real source
-	// transaction is returned, and its settlement MUST be preloaded inline
-	// so the UI can display it as context beneath the source row (the user
-	// sees "I spent 100, of which 50 is coming back to me"). The settlement's
-	// own account is the shared account, NOT the personal one, so the
-	// frontend is expected to exclude it from the group net total; this
-	// backend test only verifies that the data is there for display and
-	// that no synthetic duplicate is appended.
+	// transaction is returned with its settlement preloaded inline. The
+	// settlement's own account is the shared account, NOT the personal one;
+	// the backend always preloads it, and the frontend hides it (and excludes
+	// it from the group total) when the settlement's account is not in the
+	// active filter. This backend test only verifies that the data is there
+	// and that no synthetic duplicate is appended.
 	personalOnly, err := suite.Services.Transaction.Search(ctx, user1.ID, period, domain.TransactionFilter{
 		UserID:          &user1.ID,
 		AccountIDs:      []int{account.ID},
@@ -1307,15 +1306,14 @@ func (suite *TransactionCreateWithDBTestSuite) TestSearchSharedExpenseByFromAcco
 	suite.Assert().Equal(userConnection.FromAccountID, toSettlement.AccountID, "preloaded settlement keeps its own account_id so the frontend can decide to exclude it from the group sum")
 
 	// Case 2b (balance consistency): GetBalance filtered by the personal
-	// account returns the source transaction plus the settlement whose source
-	// tx lives on that account — this matches the frontend's group-total
-	// behavior, which includes nested settlements when the source tx is in
-	// the filter.
+	// account returns ONLY the source transaction — the settlement counts
+	// solely toward its own connection account and does not leak into the
+	// private account balance, so it reconciles with the bank statement.
 	balancePersonal, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
 		AccountIDs: []int{account.ID},
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(-amount+amount/2, balancePersonal.Balance, "personal-only balance equals source tx amount plus in-scope settlement credit")
+	suite.Assert().Equal(-amount, balancePersonal.Balance, "personal-only balance equals the full source tx amount; the settlement belongs to the connection account and does not leak in")
 
 	// Case 3: user1 filters by BOTH personal AND shared accounts — the source
 	// transaction is in the filter AND the settlement's account is in the

--- a/frontend/e2e/tests/settlement-bulk-date.spec.ts
+++ b/frontend/e2e/tests/settlement-bulk-date.spec.ts
@@ -194,10 +194,11 @@ test.describe("Bulk settlement date change", () => {
     const page = await openAuthedPage(browser, setup.userToken);
     const txPage = new TransactionsPage(page);
 
-    // Filter by the private account so the source tx is rendered with its
-    // inline settlement child — both rows side by side, both selectable.
+    // Filter by both the private and the connection account so the source tx
+    // is rendered with its inline settlement child — the inline settlement is
+    // shown only when its own connection account is in the active filter.
     await page.goto(
-      `/transactions?month=${MONTH}&year=${YEAR}&account_id[]=${setup.userAccountId}`,
+      `/transactions?month=${MONTH}&year=${YEAR}&account_id[]=${setup.userAccountId}&account_id[]=${setup.userConnAccountId}`,
     );
     await page.waitForLoadState("networkidle");
 

--- a/frontend/src/components/transactions/TransactionGroup.tsx
+++ b/frontend/src/components/transactions/TransactionGroup.tsx
@@ -44,6 +44,7 @@ interface TransactionGroupProps {
   accounts: Transactions.Account[];
   categories: Transactions.Category[];
   currentUserId: number;
+  accountFilter?: number[];
   groupTotal?: number;
   runningBalance?: number;
   isFirst?: boolean;
@@ -61,6 +62,7 @@ export function TransactionGroup({
   accounts,
   categories,
   currentUserId,
+  accountFilter,
   groupTotal,
   runningBalance,
   isFirst = false,
@@ -230,23 +232,34 @@ export function TransactionGroup({
                 }
                 onDelete={!isSelectionActive && isOwner ? onDeleteTransaction : undefined}
               />
-              {!hideSettlements && (tx.settlements_from_source ?? []).map((s) => (
-                <SettlementRow
-                  key={`settlement-${s.id}`}
-                  settlement={s}
-                  groupBy={groupBy}
-                  accounts={accounts}
-                  description={tx.description}
-                  isSelected={selectedSettlementIds?.has(s.id)}
-                  isSelectionMode={isSelectionActive}
-                  onSelect={onSelectSettlement}
-                  onEdit={
-                    !isSelectionActive && isOwner
-                      ? () => openEditDrawer(tx, "split_settings.0.amount")
-                      : undefined
-                  }
-                />
-              ))}
+              {!hideSettlements &&
+                (tx.settlements_from_source ?? [])
+                  // A settlement belongs to its connection account. When an
+                  // account filter is active, only show it under the source
+                  // transaction if that connection account is in the filter;
+                  // otherwise it would appear without counting toward the total.
+                  .filter(
+                    (s) =>
+                      !accountFilter?.length ||
+                      accountFilter.includes(s.account_id)
+                  )
+                  .map((s) => (
+                    <SettlementRow
+                      key={`settlement-${s.id}`}
+                      settlement={s}
+                      groupBy={groupBy}
+                      accounts={accounts}
+                      description={tx.description}
+                      isSelected={selectedSettlementIds?.has(s.id)}
+                      isSelectionMode={isSelectionActive}
+                      onSelect={onSelectSettlement}
+                      onEdit={
+                        !isSelectionActive && isOwner
+                          ? () => openEditDrawer(tx, "split_settings.0.amount")
+                          : undefined
+                      }
+                    />
+                  ))}
             </Fragment>
           );
         })}

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -33,8 +33,10 @@ function groupNetTotal(
     const settlementsAmount = hideSettlements
       ? 0
       : (tx.settlements_from_source ?? []).reduce((s, settlement) => {
-          // Include settlement if: no account filter, OR source tx account matches, OR settlement account matches
-          if (filterSet && !filterSet.has(tx.account_id) && !filterSet.has(settlement.account_id)) {
+          // A settlement counts only toward its own (connection) account, never
+          // the source transaction's private account — keeps the displayed total
+          // consistent with GetBalance and lets the private account reconcile.
+          if (filterSet && !filterSet.has(settlement.account_id)) {
             return s;
           }
           return s + (settlement.type === "credit" ? settlement.amount : -settlement.amount);
@@ -102,6 +104,7 @@ export function TransactionList({
           groupTotal={groupTotals[i]}
           runningBalance={runningBalances[i]}
           isFirst={i === 0}
+          accountFilter={filters.accountIds}
           selectedIds={selectedIds}
           selectedSettlementIds={selectedSettlementIds}
           onSelectTransaction={onSelectTransaction && ((id, shiftKey) => onSelectTransaction(id, shiftKey, group.key))}


### PR DESCRIPTION
The GetBalance settlements leg matched `s.account_id IN ? OR t.account_id
IN ?`, so a split settlement leaked into the balance of the source
transaction's private account — the private account no longer reconciled
with the real bank statement. Filter the settlements leg by
`s.account_id` alone so a settlement contributes only to its connection
account. The frontend group total and inline settlement rows follow the
same rule: a settlement is shown/counted only when its connection account
is in the active filter.

https://claude.ai/code/session_01WChtvLvq2scVcBhuHgu4Lw