### PR TITLE
Show opening balance row when there are no transactions

### DIFF
--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -5,7 +5,9 @@ import { useActiveFilters } from "@/hooks/useActiveFilters";
 import { useGroupedTransactions } from "@/hooks/useGroupedTransactions";
 import { useOpeningBalance } from "@/hooks/useOpeningBalance";
 import { Transactions } from "@/types/transactions";
+import { OpeningBalanceRow } from "./OpeningBalanceRow";
 import { TransactionGroup } from "./TransactionGroup";
+import classes from "./TransactionGroup.module.css";
 import { TransactionListSkeleton } from "./TransactionListSkeleton";
 
 interface TransactionListProps {
@@ -85,9 +87,14 @@ export function TransactionList({
 
   if (groups.length === 0) {
     return (
-      <Text ta="center" c="dimmed" py="xl">
-        Nenhuma transação encontrada
-      </Text>
+      <Stack gap="sm">
+        <div className={classes.rows}>
+          <OpeningBalanceRow />
+        </div>
+        <Text ta="center" c="dimmed" py="xl">
+          Nenhuma transação encontrada
+        </Text>
+      </Stack>
     );
   }
 


### PR DESCRIPTION
The opening balance row only rendered inside the first transaction
group, so an empty transactions screen hid it entirely — leaving the
user without the balance up to that period. Render it in the empty
state too.

https://claude.ai/code/session_01M5WCZDyV7d6T5Zz6cJFt45