### PR TITLE
Improve import type rule select labels

### DIFF
--- a/frontend/src/components/transactions/import/UploadStep.tsx
+++ b/frontend/src/components/transactions/import/UploadStep.tsx
@@ -120,11 +120,11 @@ export function UploadStep({ onParsed, onBack }: Props) {
         </ActionIcon>
 
         <Select
-          label="Regra de definição do tipo"
+          label="Considerar valores positivos como:"
           required
           data={[
-            { label: "Valor positivo considerado 'receita'", value: 'positive_as_income' },
-            { label: "Valor positivo considerado 'despesa'", value: 'positive_as_expense' },
+            { label: 'Receitas', value: 'positive_as_income' },
+            { label: 'Despesas', value: 'positive_as_expense' },
           ]}
           value={typeDefinitionRule}
           onChange={(val) =>


### PR DESCRIPTION
Rephrase the type definition rule select to a clearer question-style
label with concise "Receitas"/"Despesas" options.

https://claude.ai/code/session_01BLwjFBTnhtiPLHcUfc3XL1