### PR TITLE
feat(frontend): add dark mode with light/dark/auto toggle

### DIFF
--- a/frontend/e2e/tests/theme-toggle.spec.ts
+++ b/frontend/e2e/tests/theme-toggle.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test'
+import { CommonTestIds } from '@/testIds'
+
+test.describe('Theme toggle', () => {
+  test('cycles color scheme and persists across reload', async ({ page }) => {
+    await page.goto('/accounts')
+
+    const toggle = page.getByTestId(CommonTestIds.ThemeToggle)
+    const html = page.locator('html')
+
+    await expect(toggle).toBeVisible()
+
+    // Toggle cycles light -> dark -> auto. Click until we land on dark.
+    while ((await toggle.getAttribute('data-color-scheme')) !== 'dark') {
+      await toggle.click()
+    }
+    await expect(html).toHaveAttribute('data-mantine-color-scheme', 'dark')
+
+    // Preference persists across a full reload (localStorage).
+    await page.reload()
+    await expect(html).toHaveAttribute('data-mantine-color-scheme', 'dark')
+    await expect(toggle).toHaveAttribute('data-color-scheme', 'dark')
+
+    // Continue cycling until light.
+    while ((await toggle.getAttribute('data-color-scheme')) !== 'light') {
+      await toggle.click()
+    }
+    await expect(html).toHaveAttribute('data-mantine-color-scheme', 'light')
+  })
+})

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -9,6 +9,7 @@ import { InviteDrawer } from "@/components/InviteDrawer";
 import { MobileTabBar } from "@/components/MobileTabBar";
 import { PWAInstallBanner } from "@/components/PWAInstallBanner";
 import { UserAvatar } from "@/components/UserAvatar";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { renderDrawer } from "@/utils/renderDrawer";
 import { CommonTestIds } from '@/testIds'
 
@@ -57,36 +58,39 @@ export function AppLayout() {
             </Group>
           </Link>
 
-          {user && (
-            <Menu shadow="md" position="bottom-end">
-              <Menu.Target>
-                <Group gap={4} wrap="nowrap" align="center" style={{ cursor: "pointer" }}>
-                  <UserAvatar name={user?.name ?? "?"} avatarUrl={user?.avatar_url} size="sm" />
-                  <Text size="sm" fw={500} visibleFrom="sm">
-                    {user.name.split(" ")[0]}
-                  </Text>
-                  <IconChevronDown size={14} />
-                </Group>
-              </Menu.Target>
-              <Menu.Dropdown>
-                <Menu.Label>{user.email}</Menu.Label>
-                {!isMobile && (
-                  <>
-                    <Menu.Item
-                      leftSection={<IconUsers size={16} />}
-                      onClick={() => void renderDrawer(() => <InviteDrawer />).catch(() => {})}
-                    >
-                      Criar Conexão
-                    </Menu.Item>
-                    <Menu.Divider />
-                  </>
-                )}
-                <Menu.Item onClick={() => logoutMutation.mutate()} disabled={logoutMutation.isPending}>
-                  Sair
-                </Menu.Item>
-              </Menu.Dropdown>
-            </Menu>
-          )}
+          <Group gap="xs" wrap="nowrap">
+            <ThemeToggle />
+            {user && (
+              <Menu shadow="md" position="bottom-end">
+                <Menu.Target>
+                  <Group gap={4} wrap="nowrap" align="center" style={{ cursor: "pointer" }}>
+                    <UserAvatar name={user?.name ?? "?"} avatarUrl={user?.avatar_url} size="sm" />
+                    <Text size="sm" fw={500} visibleFrom="sm">
+                      {user.name.split(" ")[0]}
+                    </Text>
+                    <IconChevronDown size={14} />
+                  </Group>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  <Menu.Label>{user.email}</Menu.Label>
+                  {!isMobile && (
+                    <>
+                      <Menu.Item
+                        leftSection={<IconUsers size={16} />}
+                        onClick={() => void renderDrawer(() => <InviteDrawer />).catch(() => {})}
+                      >
+                        Criar Conexão
+                      </Menu.Item>
+                      <Menu.Divider />
+                    </>
+                  )}
+                  <Menu.Item onClick={() => logoutMutation.mutate()} disabled={logoutMutation.isPending}>
+                    Sair
+                  </Menu.Item>
+                </Menu.Dropdown>
+              </Menu>
+            )}
+          </Group>
         </Group>
       </AppShell.Header>
 

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+import { ActionIcon, useMantineColorScheme, type MantineColorScheme } from '@mantine/core'
+import { IconDeviceDesktop, IconMoon, IconSun } from '@tabler/icons-react'
+import { CommonTestIds } from '@/testIds'
+
+const order: MantineColorScheme[] = ['light', 'dark', 'auto']
+
+const config: Record<MantineColorScheme, { icon: typeof IconSun; label: string }> = {
+  light: { icon: IconSun, label: 'Tema: claro' },
+  dark: { icon: IconMoon, label: 'Tema: escuro' },
+  auto: { icon: IconDeviceDesktop, label: 'Tema: automático' },
+}
+
+export function ThemeToggle() {
+  const { colorScheme, setColorScheme } = useMantineColorScheme()
+  const { icon: Icon, label } = config[colorScheme]
+
+  const cycle = () => {
+    const next = order[(order.indexOf(colorScheme) + 1) % order.length]
+    setColorScheme(next)
+  }
+
+  return (
+    <ActionIcon
+      variant="default"
+      size="lg"
+      onClick={cycle}
+      aria-label={label}
+      title={label}
+      data-testid={CommonTestIds.ThemeToggle}
+      data-color-scheme={colorScheme}
+    >
+      <Icon size={18} />
+    </ActionIcon>
+  )
+}

--- a/frontend/src/components/accounts/ColorSwatchPicker.tsx
+++ b/frontend/src/components/accounts/ColorSwatchPicker.tsx
@@ -41,7 +41,10 @@ export function ColorSwatchPicker({ value, onChange, label }: ColorSwatchPickerP
             data-selected={value === color ? "true" : undefined}
             style={{
               cursor: "pointer",
-              boxShadow: value === color ? "0 0 0 2px white, 0 0 0 4px var(--mantine-color-dark-4)" : "none",
+              boxShadow:
+                value === color
+                  ? "0 0 0 2px light-dark(var(--mantine-color-white), var(--mantine-color-dark-7)), 0 0 0 4px var(--mantine-color-dark-4)"
+                  : "none",
             }}
           />
         ))}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
-import { MantineProvider } from '@mantine/core'
+import { ColorSchemeScript, MantineProvider } from '@mantine/core'
 import { Notifications } from '@mantine/notifications'
 import '@mantine/core/styles.css'
 import '@mantine/notifications/styles.css'
@@ -13,7 +13,8 @@ import { queryClient } from './queryClient'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <MantineProvider theme={theme}>
+      <ColorSchemeScript defaultColorScheme="auto" />
+      <MantineProvider theme={theme} defaultColorScheme="auto">
         <Notifications position="top-right" autoClose={3000} />
         <App />
       </MantineProvider>

--- a/frontend/src/testIds/common.ts
+++ b/frontend/src/testIds/common.ts
@@ -13,6 +13,7 @@ export const CommonTestIds = {
   AvatarUser: 'avatar_user',
   AvatarAccount: 'avatar_account',
   AvatarAccountEmpty: 'avatar_account_empty',
+  ThemeToggle: 'btn_theme_toggle',
   /**
    * NavLink badge, keyed by the route's path without the leading slash
    * (e.g. `nav_badge_charges` for `/charges`).

--- a/frontend/src/utils/renderDrawer.tsx
+++ b/frontend/src/utils/renderDrawer.tsx
@@ -78,7 +78,9 @@ export function renderDrawer<T>(factory: () => ReactElement): Promise<T> {
           }}
         >
           <QueryClientProvider client={queryClient}>
-            <MantineProvider theme={theme}>{factory()}</MantineProvider>
+            <MantineProvider theme={theme} defaultColorScheme="auto">
+              {factory()}
+            </MantineProvider>
           </QueryClientProvider>
         </DrawerContext.Provider>
       );


### PR DESCRIPTION
Enable Mantine color scheme support with a header toggle that cycles
through light, dark, and auto (system) modes. The preference persists
across reloads via Mantine's localStorage color scheme manager, and the
isolated drawer roots inherit the active scheme.

https://claude.ai/code/session_01Kjf4G12GsmAGtxbpdroNLQ