### PR TITLE
Fix iOS PWA bottom nav overflowing the safe area

### DIFF
--- a/frontend/src/components/MobileTabBar.module.css
+++ b/frontend/src/components/MobileTabBar.module.css
@@ -9,7 +9,7 @@
   border-top: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
   padding-bottom: env(safe-area-inset-bottom);
   height: calc(56px + env(safe-area-inset-bottom));
-  box-sizing: content-box;
+  box-sizing: border-box;
 }
 
 .tab {


### PR DESCRIPTION
MobileTabBar used box-sizing: content-box, so its explicit height
(56px + safe-area-inset) plus padding-bottom (safe-area-inset) stacked,
double-counting the inset and making the bar ~34px too tall on iPhone.
Switching to border-box makes the inset padding part of the declared
height, leaving 56px for the tab content.

https://claude.ai/code/session_01WoUoLmRn7XMnveRfjTgpgJ