### PR TITLE
fix(transactions): keep altered-date settlements off private account filter

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint src",
-    "test:unit": "node --import tsx --test ./src/utils/splitMath.test.ts",
+    "test:unit": "node --import tsx --test ./src/utils/splitMath.test.ts ./src/utils/groupTransactions.test.ts",
     "test:component": "vitest run",
     "e2e": "PLAYWRIGHT_BASE_URL=http://localhost:3100 PLAYWRIGHT_BACKEND_URL=http://localhost:8090 playwright test",
     "e2e:debug": "PLAYWRIGHT_BASE_URL=http://localhost:3100 PLAYWRIGHT_BACKEND_URL=http://localhost:8090 playwright test --debug",

--- a/frontend/src/hooks/useGroupedTransactions.ts
+++ b/frontend/src/hooks/useGroupedTransactions.ts
@@ -36,8 +36,8 @@ export function useGroupedTransactions<T = Transactions.TransactionGroup[]>(
   }, [transactions, search.query]);
 
   const groups = useMemo(
-    () => groupTransactions(filtered, search.groupBy, accounts, categories),
-    [filtered, search.groupBy, accounts, categories],
+    () => groupTransactions(filtered, search.groupBy, accounts, categories, filters.accountIds),
+    [filtered, search.groupBy, accounts, categories, filters.accountIds],
   );
 
   const selected = useMemo(

--- a/frontend/src/utils/groupTransactions.test.ts
+++ b/frontend/src/utils/groupTransactions.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { groupTransactions } from "./groupTransactions";
+import type { Transactions } from "../types/transactions";
+
+const PRIVATE_ACCOUNT = 1;
+const CONNECTION_ACCOUNT = 99;
+
+function settlement(date: string): Transactions.Settlement {
+  return {
+    id: 500,
+    user_id: 1,
+    amount: 5000,
+    type: "credit",
+    account_id: CONNECTION_ACCOUNT,
+    source_transaction_id: 10,
+    parent_transaction_id: 0,
+    date,
+  };
+}
+
+function sourceTransaction(
+  settlements: Transactions.Settlement[],
+): Transactions.Transaction {
+  return {
+    id: 10,
+    user_id: 1,
+    type: "expense",
+    account_id: PRIVATE_ACCOUNT,
+    amount: 10000,
+    operation_type: "debit",
+    date: "2026-05-10",
+    description: "split expense",
+    settlements_from_source: settlements,
+  };
+}
+
+function flatten(groups: Transactions.TransactionGroup[]): Transactions.Transaction[] {
+  return groups.flatMap((g) => g.transactions);
+}
+
+function syntheticSettlementRows(
+  groups: Transactions.TransactionGroup[],
+): Transactions.Transaction[] {
+  return flatten(groups).filter((tx) => tx.origin_settlement_id !== undefined);
+}
+
+test("altered-date settlement is promoted to its own row when no account filter is active", () => {
+  const groups = groupTransactions(
+    [sourceTransaction([settlement("2026-05-20")])],
+    "date",
+    [],
+    [],
+    [],
+  );
+  assert.equal(syntheticSettlementRows(groups).length, 1);
+});
+
+test("altered-date settlement is NOT promoted when filtering by the private source account", () => {
+  // The settlement belongs to the connection account; filtering by the
+  // private account where the source expense lives must not surface it.
+  const groups = groupTransactions(
+    [sourceTransaction([settlement("2026-05-20")])],
+    "date",
+    [],
+    [],
+    [PRIVATE_ACCOUNT],
+  );
+  assert.equal(syntheticSettlementRows(groups).length, 0);
+
+  // It stays inline under the source, where the per-account render/total
+  // filters exclude it.
+  const source = flatten(groups).find((tx) => tx.id === 10);
+  assert.ok(source);
+  assert.equal((source.settlements_from_source ?? []).length, 1);
+});
+
+test("altered-date settlement is promoted when the filter includes its connection account", () => {
+  const groups = groupTransactions(
+    [sourceTransaction([settlement("2026-05-20")])],
+    "date",
+    [],
+    [],
+    [PRIVATE_ACCOUNT, CONNECTION_ACCOUNT],
+  );
+  assert.equal(syntheticSettlementRows(groups).length, 1);
+});
+
+test("same-date settlement is never promoted regardless of the account filter", () => {
+  for (const filter of [[], [PRIVATE_ACCOUNT], [CONNECTION_ACCOUNT]]) {
+    const groups = groupTransactions(
+      [sourceTransaction([settlement("2026-05-10")])],
+      "date",
+      [],
+      [],
+      filter,
+    );
+    assert.equal(syntheticSettlementRows(groups).length, 0);
+  }
+});

--- a/frontend/src/utils/groupTransactions.ts
+++ b/frontend/src/utils/groupTransactions.ts
@@ -19,18 +19,28 @@ function dateKey(iso: string | undefined | null): string {
  * (mirroring the orphan-settlement shape produced by the backend) for each
  * such settlement and remove it from the source's `settlements_from_source`
  * so it isn't rendered twice.
+ *
+ * A settlement belongs to its connection account. When an account filter is
+ * active, a settlement whose account is outside the filter must NOT be
+ * promoted to a standalone row — that row bypasses the per-account filter in
+ * TransactionGroup / groupNetTotal and would leak the settlement into a
+ * filtered (e.g. private) account view. Such a settlement is left inline,
+ * where those filters already exclude it from render and totals.
  */
 function expandInlineSettlementsForDateGrouping(
   txs: Transactions.Transaction[],
+  accountFilter: number[],
 ): Transactions.Transaction[] {
   const result: Transactions.Transaction[] = []
   for (const tx of txs) {
     const sameDate: Transactions.Settlement[] = []
     const promoted: Transactions.Settlement[] = []
     for (const s of tx.settlements_from_source ?? []) {
+      const inScope =
+        accountFilter.length === 0 || accountFilter.includes(s.account_id)
       const sKey = dateKey(s.date ?? s.created_at)
       const tKey = dateKey(tx.date)
-      if (sKey && tKey && sKey !== tKey) {
+      if (inScope && sKey && tKey && sKey !== tKey) {
         promoted.push(s)
       } else {
         sameDate.push(s)
@@ -70,11 +80,14 @@ export function groupTransactions(
   groupBy: Transactions.GroupBy,
   accounts: Transactions.Account[],
   categories: Transactions.Category[],
+  accountFilter: number[],
 ): Transactions.TransactionGroup[] {
   const groups = new Map<string, Transactions.TransactionGroup>()
 
   const input =
-    groupBy === 'date' ? expandInlineSettlementsForDateGrouping(transactions) : transactions
+    groupBy === 'date'
+      ? expandInlineSettlementsForDateGrouping(transactions, accountFilter)
+      : transactions
 
   for (const tx of input) {
     let label: string


### PR DESCRIPTION
Settlements with a customized date are promoted to standalone synthetic
rows by expandInlineSettlementsForDateGrouping when grouping by date. The
#136 fix only filtered inline settlements by the active account filter —
promoted rows bypassed it, so a connection-account settlement leaked into
a private-account-filtered view.

Only promote a settlement when its account is within the active filter;
out-of-scope settlements stay inline, where the existing render and total
filters already exclude them.

https://claude.ai/code/session_01Bs1ujT2FphXbqh3mDp2HVs