### PR TITLE
Fix MobileMoreDrawer height to prevent overflow

### DIFF
--- a/frontend/src/components/MobileMoreDrawer.tsx
+++ b/frontend/src/components/MobileMoreDrawer.tsx
@@ -59,7 +59,7 @@ export function MobileMoreDrawer() {
     <ResponsiveDrawer
       opened={opened}
       onClose={() => close()}
-      size="auto"
+      styles={{ content: { height: 'auto', maxHeight: '85dvh' } }}
       title=""
       closeButtonProps={
         {


### PR DESCRIPTION
## Summary
Updated the `MobileMoreDrawer` component to use a more robust height configuration that prevents content overflow on mobile devices while maintaining responsive behavior.

## Changes
- Replaced the `size="auto"` prop with a `styles` prop that explicitly sets the drawer's content height to `auto` with a maximum height constraint of `85dvh` (85% of the dynamic viewport height)

## Implementation Details
This change ensures the drawer:
- Adapts to its content size naturally (`height: 'auto'`)
- Never exceeds 85% of the viewport height, preventing it from covering critical UI elements or extending beyond the screen
- Uses dynamic viewport height (`dvh`) units for better mobile compatibility across different device orientations and browser UI states

https://claude.ai/code/session_017pWv64jdKTxKoRqUd187Kc