### PR TITLE
fix: barra de salvar do drawer de transaction sobreposta pelo SegmentedControl

### DIFF
--- a/frontend/src/components/transactions/form/TransactionForm.tsx
+++ b/frontend/src/components/transactions/form/TransactionForm.tsx
@@ -385,6 +385,7 @@ export const TransactionForm = ({
         style={{
           position: "sticky",
           bottom: 0,
+          zIndex: 3,
           background: "var(--mantine-color-body)",
           borderTop: "1px solid var(--mantine-color-default-border)",
           paddingTop: "var(--mantine-spacing-md)",


### PR DESCRIPTION
A barra sticky do botão Salvar não tinha z-index, então os itens do
SegmentedControl (z-index: 2 do Mantine) ficavam por cima ao rolar o
conteúdo do drawer. Adiciona z-index: 3 à barra para mantê-la no topo.

https://claude.ai/code/session_01T2C5QZCUV38Db2QfewWTFA