### PR TITLE
Prevent suggestions from overwriting user-edited fields

### DIFF
--- a/frontend/e2e/helpers/formFields.ts
+++ b/frontend/e2e/helpers/formFields.ts
@@ -137,6 +137,24 @@ export class SelectField extends FieldBase {
   }
 }
 
+// ─── Autocomplete (Mantine combobox with free text) ──────────────────────────
+
+/**
+ * Wraps a Mantine `Autocomplete`. The component must instrument its options
+ * via `renderOption` with a matching `data-testid`. Like `SelectField`, this
+ * class does not fall back to `getByRole('option')`.
+ */
+export class AutocompleteField extends FieldBase {
+  /** Type `query`, then click the suggestion option whose testid matches. */
+  async pickSuggestion(query: string, optionTestId: string): Promise<void> {
+    const input = this.locator()
+    await input.click()
+    await input.fill(query)
+    // Mantine renders Autocomplete options in a portal attached to <body>.
+    await this.page().getByTestId(optionTestId).click()
+  }
+}
+
 // ─── TagsInput (multi) ────────────────────────────────────────────────────────
 
 /**

--- a/frontend/e2e/pages/TransactionsPage.ts
+++ b/frontend/e2e/pages/TransactionsPage.ts
@@ -1,6 +1,7 @@
 import { type Page, type Locator, expect } from "@playwright/test";
 import { TransactionsTestIds, type PropagationOption, type TransactionType } from '@/testIds'
 import {
+  AutocompleteField,
   CurrencyField,
   SegmentedField,
   SelectField,
@@ -121,6 +122,18 @@ export class TransactionsPage {
 
   async fillDescription(description: string) {
     await new TextField(this.formDrawer, TransactionsTestIds.InputDescription).fill(description);
+  }
+
+  /**
+   * Type a description and pick the autocomplete suggestion whose text equals
+   * it, triggering the suggestion-fill behaviour. Defaults to the create drawer.
+   */
+  async pickDescriptionSuggestion(description: string, drawer?: Locator) {
+    const container = drawer ?? this.formDrawer;
+    await new AutocompleteField(container, TransactionsTestIds.InputDescription).pickSuggestion(
+      description,
+      TransactionsTestIds.OptionDescriptionSuggestion(description),
+    );
   }
 
   async selectAccount(accountId: number) {

--- a/frontend/e2e/tests/description-autocomplete.spec.ts
+++ b/frontend/e2e/tests/description-autocomplete.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect } from '@playwright/test'
+import { TransactionsPage } from '../pages/TransactionsPage'
+import {
+  apiCreateAccount,
+  apiCreateCategory,
+  apiCreateTransaction,
+  getAuthTokenForUser,
+  openAuthedPage,
+} from '../helpers/api'
+import { TransactionsTestIds } from '@/testIds'
+
+const today = new Date().toISOString().slice(0, 10)
+
+/**
+ * Issue #151 — selecting a description suggestion must not overwrite fields the
+ * user has already edited manually. Each test creates a fresh user with its own
+ * source transaction (the row the autocomplete suggests).
+ */
+test.describe('Description autocomplete — dirty-field preservation', () => {
+  // ── AC1: manually-entered amount is preserved ──────────────────────────────
+  test('preserves the amount typed before selecting a suggestion', async ({ browser }) => {
+    const token = await getAuthTokenForUser(`e2e-autocomplete-amount-${Date.now()}@financeapp.local`)
+    const account = await apiCreateAccount({ name: 'Conta Auto', initial_balance: 0 }, { token })
+    const sourceCategory = await apiCreateCategory({ name: 'Categoria Fonte' }, { token })
+    const sourceDesc = `Fonte Amount ${Date.now()}`
+    await apiCreateTransaction(
+      {
+        transaction_type: 'expense',
+        account_id: account.id,
+        category_id: sourceCategory.id,
+        amount: 12345,
+        date: today,
+        description: sourceDesc,
+      },
+      { token },
+    )
+
+    const page = await openAuthedPage(browser, token)
+    const txPage = new TransactionsPage(page)
+    await txPage.goto()
+    await txPage.openCreateForm()
+
+    // User sets the amount manually, then picks a suggestion.
+    await txPage.fillAmount(99999)
+    await txPage.pickDescriptionSuggestion(sourceDesc)
+
+    // Amount is preserved; the untouched category is filled from the suggestion.
+    await expect(txPage.formDrawer.getByTestId(TransactionsTestIds.InputAmount)).toHaveValue('999,99')
+    await expect(txPage.formDrawer.getByTestId(TransactionsTestIds.SelectCategory)).toHaveValue(
+      'Categoria Fonte',
+    )
+
+    await page.close()
+  })
+
+  // ── AC2: manually-selected category is preserved ───────────────────────────
+  test('preserves the category selected before choosing a suggestion', async ({ browser }) => {
+    const token = await getAuthTokenForUser(`e2e-autocomplete-category-${Date.now()}@financeapp.local`)
+    const account = await apiCreateAccount({ name: 'Conta Auto', initial_balance: 0 }, { token })
+    const sourceCategory = await apiCreateCategory({ name: 'Categoria Fonte' }, { token })
+    const userCategory = await apiCreateCategory({ name: 'Categoria Escolhida' }, { token })
+    const sourceDesc = `Fonte Category ${Date.now()}`
+    await apiCreateTransaction(
+      {
+        transaction_type: 'expense',
+        account_id: account.id,
+        category_id: sourceCategory.id,
+        amount: 12345,
+        date: today,
+        description: sourceDesc,
+      },
+      { token },
+    )
+
+    const page = await openAuthedPage(browser, token)
+    const txPage = new TransactionsPage(page)
+    await txPage.goto()
+    await txPage.openCreateForm()
+
+    // User picks a category manually, then picks a suggestion.
+    await txPage.selectCategory(userCategory.id)
+    await txPage.pickDescriptionSuggestion(sourceDesc)
+
+    // Category is preserved; the untouched amount is filled from the suggestion.
+    await expect(txPage.formDrawer.getByTestId(TransactionsTestIds.SelectCategory)).toHaveValue(
+      'Categoria Escolhida',
+    )
+    await expect(txPage.formDrawer.getByTestId(TransactionsTestIds.InputAmount)).toHaveValue('123,45')
+
+    await page.close()
+  })
+
+  // ── AC3: untouched fields are still filled by the suggestion ───────────────
+  test('fills every untouched field from the suggestion', async ({ browser }) => {
+    const token = await getAuthTokenForUser(`e2e-autocomplete-untouched-${Date.now()}@financeapp.local`)
+    const account = await apiCreateAccount({ name: 'Conta Auto', initial_balance: 0 }, { token })
+    const sourceCategory = await apiCreateCategory({ name: 'Categoria Fonte' }, { token })
+    const sourceDesc = `Fonte Untouched ${Date.now()}`
+    // Source is an income so the transaction type also visibly changes.
+    await apiCreateTransaction(
+      {
+        transaction_type: 'income',
+        account_id: account.id,
+        category_id: sourceCategory.id,
+        amount: 12345,
+        date: today,
+        description: sourceDesc,
+      },
+      { token },
+    )
+
+    const page = await openAuthedPage(browser, token)
+    const txPage = new TransactionsPage(page)
+    await txPage.goto()
+    await txPage.openCreateForm()
+
+    // Only the description is touched; everything else is picked from the suggestion.
+    await txPage.pickDescriptionSuggestion(sourceDesc)
+
+    await expect(txPage.formDrawer.getByTestId(TransactionsTestIds.InputAmount)).toHaveValue('123,45')
+    await expect(txPage.formDrawer.getByTestId(TransactionsTestIds.SelectCategory)).toHaveValue(
+      'Categoria Fonte',
+    )
+    await expect(txPage.formDrawer.getByTestId(TransactionsTestIds.SelectAccount)).toHaveValue(
+      'Conta Auto',
+    )
+    const segmented = txPage.formDrawer.getByTestId(TransactionsTestIds.SegmentedTransactionType)
+    await expect(segmented.locator('[data-active]').first()).toContainText('Receita')
+
+    await page.close()
+  })
+
+  // ── AC4: the same rule holds while editing an existing transaction ─────────
+  test('preserves a manually-edited field when editing a transaction', async ({ browser }) => {
+    const token = await getAuthTokenForUser(`e2e-autocomplete-edit-${Date.now()}@financeapp.local`)
+    const account = await apiCreateAccount({ name: 'Conta Auto', initial_balance: 0 }, { token })
+    const sourceCategory = await apiCreateCategory({ name: 'Categoria Fonte' }, { token })
+    const targetCategory = await apiCreateCategory({ name: 'Categoria Alvo' }, { token })
+
+    const sourceDesc = `Fonte Edit ${Date.now()}`
+    await apiCreateTransaction(
+      {
+        transaction_type: 'expense',
+        account_id: account.id,
+        category_id: sourceCategory.id,
+        amount: 22200,
+        date: today,
+        description: sourceDesc,
+      },
+      { token },
+    )
+
+    const targetTx = await apiCreateTransaction(
+      {
+        transaction_type: 'expense',
+        account_id: account.id,
+        category_id: targetCategory.id,
+        amount: 11100,
+        date: today,
+        description: `Alvo Edit ${Date.now()}`,
+      },
+      { token },
+    )
+
+    const page = await openAuthedPage(browser, token)
+    const txPage = new TransactionsPage(page)
+    await txPage.goto()
+    await txPage.clickTransactionRow(targetTx.id)
+
+    // User edits the amount, then picks a suggestion in the update drawer.
+    await txPage.clearAndFillAmount(55500)
+    await txPage.pickDescriptionSuggestion(sourceDesc, txPage.updateDrawer)
+
+    // Edited amount is preserved; the untouched category takes the suggestion value.
+    await expect(txPage.updateDrawer.getByTestId(TransactionsTestIds.InputAmount)).toHaveValue(
+      '555,00',
+    )
+    await expect(txPage.updateDrawer.getByTestId(TransactionsTestIds.SelectCategory)).toHaveValue(
+      'Categoria Fonte',
+    )
+
+    await page.close()
+  })
+})

--- a/frontend/src/components/transactions/form/DescriptionAutocomplete.tsx
+++ b/frontend/src/components/transactions/form/DescriptionAutocomplete.tsx
@@ -48,6 +48,11 @@ export const DescriptionAutocomplete = forwardRef<HTMLInputElement, Props>(funct
       error={error}
       data-testid={TransactionsTestIds.InputDescription}
       defaultDropdownOpened={false}
+      renderOption={({ option }) => (
+        <span data-testid={TransactionsTestIds.OptionDescriptionSuggestion(option.value)}>
+          {option.value}
+        </span>
+      )}
     />
   );
 });

--- a/frontend/src/components/transactions/form/TransactionForm.tsx
+++ b/frontend/src/components/transactions/form/TransactionForm.tsx
@@ -71,7 +71,7 @@ export const TransactionForm = ({
     setValue,
     setFocus,
     getValues,
-    formState: { errors, isSubmitting },
+    formState: { errors, isSubmitting, dirtyFields },
   } = useFormContext<TransactionFormValues>();
 
   useFocusFieldOnMount(setFocus, focusField);
@@ -113,11 +113,13 @@ export const TransactionForm = ({
   };
 
   function handleSuggestionSelect(suggestion: Transactions.TransactionSuggestion) {
-    setValue("transaction_type", suggestion.type);
-    setValue("amount", suggestion.amount);
-    if (suggestion.account_id) setValue("account_id", suggestion.account_id);
-    if (suggestion.category_id) setValue("category_id", suggestion.category_id);
-    if (suggestion.tags)
+    // Only fill fields the user hasn't manually edited, so a suggestion never
+    // overwrites a value the user already set on purpose.
+    if (!dirtyFields.transaction_type) setValue("transaction_type", suggestion.type);
+    if (!dirtyFields.amount) setValue("amount", suggestion.amount);
+    if (!dirtyFields.account_id && suggestion.account_id) setValue("account_id", suggestion.account_id);
+    if (!dirtyFields.category_id && suggestion.category_id) setValue("category_id", suggestion.category_id);
+    if (!dirtyFields.tags && suggestion.tags)
       setValue(
         "tags",
         suggestion.tags.map((t) => t.name),

--- a/frontend/src/testIds/transactions.ts
+++ b/frontend/src/testIds/transactions.ts
@@ -36,6 +36,8 @@ export const TransactionsTestIds = {
   OptionDestinationAccount: (accountId: number | string) =>
     `option_destination_account_${accountId}` as const,
   OptionCategory: (categoryId: number | string) => `option_category_${categoryId}` as const,
+  OptionDescriptionSuggestion: (description: string) =>
+    `option_description_suggestion_${description}` as const,
 
   // SegmentedControl items
   SegmentTransactionType: (type: TransactionType) => `segment_transaction_type_${type}` as const,


### PR DESCRIPTION
## Summary
Modified the transaction suggestion handler to respect user input by only populating fields that haven't been manually edited. This prevents suggestions from overwriting values the user intentionally set.

## Changes
- Added `dirtyFields` to the form state destructuring to track which fields have been modified by the user
- Updated `handleSuggestionSelect()` to check `dirtyFields` before applying suggestion values:
  - `transaction_type`, `amount`, `account_id`, `category_id`, and `tags` are now only set if the user hasn't already edited them
  - This ensures suggestions enhance the form without clobbering intentional user input

## Implementation Details
The fix leverages React Hook Form's built-in `dirtyFields` tracking to distinguish between:
- Fields the user has manually changed (which should be preserved)
- Fields that are still at their initial state (which can be populated from suggestions)

This provides a better UX where suggestions act as helpful defaults rather than overwriting user choices.

https://claude.ai/code/session_0125tAfofAmvZQcmQwwSnMQ5