### PR TITLE
Add dark mode support to LoginPage styles

### DIFF
--- a/frontend/src/pages/LoginPage.module.css
+++ b/frontend/src/pages/LoginPage.module.css
@@ -4,7 +4,11 @@
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
-  background: linear-gradient(160deg, var(--mantine-color-blue-0) 0%, var(--mantine-color-white) 60%);
+  background: linear-gradient(
+    160deg,
+    light-dark(var(--mantine-color-blue-0), var(--mantine-color-dark-8)) 0%,
+    light-dark(var(--mantine-color-white), var(--mantine-color-dark-7)) 60%
+  );
 }
 
 .content {
@@ -20,12 +24,12 @@
 .title {
   font-size: 2rem;
   font-weight: 800;
-  color: var(--mantine-color-blue-8);
+  color: light-dark(var(--mantine-color-blue-8), var(--mantine-color-blue-2));
   text-align: center;
 }
 
 .subtitle {
-  color: var(--mantine-color-grey-6);
+  color: var(--mantine-color-dimmed);
   text-align: center;
   font-size: 1rem;
   line-height: 1.5;
@@ -36,18 +40,18 @@
   gap: 0.5rem;
   width: 100%;
   padding: 1.25rem 1.5rem;
-  background: var(--mantine-color-white);
+  background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
   border-radius: var(--mantine-radius-md);
-  border: 1px solid var(--mantine-color-grey-1);
+  border: 1px solid light-dark(var(--mantine-color-grey-1), var(--mantine-color-dark-4));
 }
 
 .googleButton {
   min-height: 3rem;
   font-size: 1rem;
   font-weight: 500;
-  border-color: var(--mantine-color-grey-2);
+  border-color: light-dark(var(--mantine-color-grey-2), var(--mantine-color-dark-4));
 }
 
 .googleButton:hover {
-  background-color: var(--mantine-color-grey-0);
+  background-color: light-dark(var(--mantine-color-grey-0), var(--mantine-color-dark-5));
 }


### PR DESCRIPTION
## Summary
Updated the LoginPage stylesheet to support dark mode by replacing hardcoded light color values with `light-dark()` utility functions and using semantic color tokens where appropriate.

## Changes
- **Background gradient**: Updated to use `light-dark()` for both gradient stops, switching between light blues/whites in light mode and dark grays in dark mode
- **Title color**: Changed from fixed blue-8 to `light-dark(blue-8, blue-2)` for better contrast in dark mode
- **Subtitle color**: Replaced grey-6 with the semantic `--mantine-color-dimmed` token for consistency
- **Form container**: Updated background and border colors to adapt to light/dark modes using `light-dark()`
- **Google button**: Updated border and hover state colors to use `light-dark()` for proper visibility in both modes

## Implementation Details
All color changes use Mantine's `light-dark()` CSS function to conditionally apply colors based on the current color scheme. This ensures the login page maintains proper contrast and visual hierarchy in both light and dark modes without requiring JavaScript theme detection.

https://claude.ai/code/session_01KdymVjZUKP7S5ubVNnh4UA