### PR TITLE
Add settlement-aware duplicate detection during import

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2755,6 +2755,14 @@ const docTemplate = `{
                 "parent_transaction_id": {
                     "type": "integer"
                 },
+                "source_transaction": {
+                    "description": "SourceTransaction is populated when the caller requests\nWithSourceTransaction on the filter. nil otherwise.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.Transaction"
+                        }
+                    ]
+                },
                 "source_transaction_id": {
                     "type": "integer"
                 },

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1475,7 +1475,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Runs the duplicate check for one or more rows in a single request and returns the matches per row_index. Matching considers the whole calendar month, an amount range of ±2 cents, and fuzzy description similarity.",
+                "description": "Runs the duplicate check for one or more rows in a single request and returns the transaction and settlement matches per row_index. Matching considers the whole calendar month, an amount range of ±2 cents, and fuzzy description similarity. Income rows are also compared against credit settlements; expense rows against debit settlements.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2434,6 +2434,9 @@ const docTemplate = `{
                 },
                 "row_index": {
                     "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/domain.TransactionType"
                 }
             }
         },
@@ -2448,6 +2451,12 @@ const docTemplate = `{
                 },
                 "row_index": {
                     "type": "integer"
+                },
+                "settlement_matches": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.SettlementMatch"
+                    }
                 }
             }
         },
@@ -2681,6 +2690,12 @@ const docTemplate = `{
                 "row_index": {
                     "type": "integer"
                 },
+                "settlement_matches": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.SettlementMatch"
+                    }
+                },
                 "status": {
                     "$ref": "#/definitions/domain.ImportRowStatus"
                 },
@@ -2751,6 +2766,33 @@ const docTemplate = `{
                 },
                 "user_id": {
                     "type": "integer"
+                }
+            }
+        },
+        "domain.SettlementMatch": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "integer"
+                },
+                "amount": {
+                    "description": "cents",
+                    "type": "integer"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "source_transaction_id": {
+                    "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/domain.SettlementType"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1469,7 +1469,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Runs the duplicate check for one or more rows in a single request and returns the matches per row_index. Matching considers the whole calendar month, an amount range of ±2 cents, and fuzzy description similarity.",
+                "description": "Runs the duplicate check for one or more rows in a single request and returns the transaction and settlement matches per row_index. Matching considers the whole calendar month, an amount range of ±2 cents, and fuzzy description similarity. Income rows are also compared against credit settlements; expense rows against debit settlements.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2428,6 +2428,9 @@
                 },
                 "row_index": {
                     "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/domain.TransactionType"
                 }
             }
         },
@@ -2442,6 +2445,12 @@
                 },
                 "row_index": {
                     "type": "integer"
+                },
+                "settlement_matches": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.SettlementMatch"
+                    }
                 }
             }
         },
@@ -2675,6 +2684,12 @@
                 "row_index": {
                     "type": "integer"
                 },
+                "settlement_matches": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.SettlementMatch"
+                    }
+                },
                 "status": {
                     "$ref": "#/definitions/domain.ImportRowStatus"
                 },
@@ -2745,6 +2760,33 @@
                 },
                 "user_id": {
                     "type": "integer"
+                }
+            }
+        },
+        "domain.SettlementMatch": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "integer"
+                },
+                "amount": {
+                    "description": "cents",
+                    "type": "integer"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "source_transaction_id": {
+                    "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/domain.SettlementType"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2749,6 +2749,14 @@
                 "parent_transaction_id": {
                     "type": "integer"
                 },
+                "source_transaction": {
+                    "description": "SourceTransaction is populated when the caller requests\nWithSourceTransaction on the filter. nil otherwise.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.Transaction"
+                        }
+                    ]
+                },
                 "source_transaction_id": {
                     "type": "integer"
                 },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -334,6 +334,12 @@ definitions:
         type: integer
       parent_transaction_id:
         type: integer
+      source_transaction:
+        allOf:
+        - $ref: '#/definitions/domain.Transaction'
+        description: |-
+          SourceTransaction is populated when the caller requests
+          WithSourceTransaction on the filter. nil otherwise.
       source_transaction_id:
         type: integer
       type:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -122,6 +122,8 @@ definitions:
         type: string
       row_index:
         type: integer
+      type:
+        $ref: '#/definitions/domain.TransactionType'
     type: object
   domain.CheckDuplicateRowResult:
     properties:
@@ -131,6 +133,10 @@ definitions:
         type: array
       row_index:
         type: integer
+      settlement_matches:
+        items:
+          $ref: '#/definitions/domain.SettlementMatch'
+        type: array
     type: object
   domain.CheckDuplicatesBulkRequest:
     properties:
@@ -283,6 +289,10 @@ definitions:
         $ref: '#/definitions/domain.RecurrenceType'
       row_index:
         type: integer
+      settlement_matches:
+        items:
+          $ref: '#/definitions/domain.SettlementMatch'
+        type: array
       status:
         $ref: '#/definitions/domain.ImportRowStatus'
       type:
@@ -332,6 +342,24 @@ definitions:
         type: string
       user_id:
         type: integer
+    type: object
+  domain.SettlementMatch:
+    properties:
+      account_id:
+        type: integer
+      amount:
+        description: cents
+        type: integer
+      date:
+        type: string
+      description:
+        type: string
+      id:
+        type: integer
+      source_transaction_id:
+        type: integer
+      type:
+        $ref: '#/definitions/domain.SettlementType'
     type: object
   domain.SettlementType:
     enum:
@@ -1634,8 +1662,10 @@ paths:
       consumes:
       - application/json
       description: Runs the duplicate check for one or more rows in a single request
-        and returns the matches per row_index. Matching considers the whole calendar
-        month, an amount range of ±2 cents, and fuzzy description similarity.
+        and returns the transaction and settlement matches per row_index. Matching
+        considers the whole calendar month, an amount range of ±2 cents, and fuzzy
+        description similarity. Income rows are also compared against credit settlements;
+        expense rows against debit settlements.
       parameters:
       - description: Bulk duplicate check params
         in: body

--- a/backend/internal/domain/settlement.go
+++ b/backend/internal/domain/settlement.go
@@ -14,16 +14,19 @@ func (s SettlementType) IsValid() bool {
 }
 
 type Settlement struct {
-	ID                   int            `json:"id"`
-	UserID               int            `json:"user_id"`
-	Amount               int64          `json:"amount"` // Amount in cents
-	Type                 SettlementType `json:"type"`
-	AccountID            int            `json:"account_id"`
-	SourceTransactionID  int            `json:"source_transaction_id"`
-	ParentTransactionID  int            `json:"parent_transaction_id"`
-	Date                 time.Time      `json:"date"`
-	CreatedAt            *time.Time     `json:"created_at"`
-	UpdatedAt            *time.Time     `json:"updated_at"`
+	ID                  int            `json:"id"`
+	UserID              int            `json:"user_id"`
+	Amount              int64          `json:"amount"` // Amount in cents
+	Type                SettlementType `json:"type"`
+	AccountID           int            `json:"account_id"`
+	SourceTransactionID int            `json:"source_transaction_id"`
+	ParentTransactionID int            `json:"parent_transaction_id"`
+	Date                time.Time      `json:"date"`
+	CreatedAt           *time.Time     `json:"created_at"`
+	UpdatedAt           *time.Time     `json:"updated_at"`
+	// SourceTransaction is populated when the caller requests
+	// WithSourceTransaction on the filter. nil otherwise.
+	SourceTransaction *Transaction `json:"source_transaction,omitempty"`
 }
 
 type SettlementUpdateRequest struct {
@@ -39,6 +42,9 @@ type SettlementFilter struct {
 	Types                []SettlementType             `query:"type[]"`
 	StartDate            *ComparableSearch[time.Time] `query:"start_date,omitempty"`
 	EndDate              *ComparableSearch[time.Time] `query:"end_date,omitempty"`
-	Limit                *int                         `query:"limit,omitempty"`
-	Offset               *int                         `query:"offset,omitempty"`
+	// WithSourceTransaction preloads each settlement's source transaction.
+	// Opt-in so default settlement queries stay lean.
+	WithSourceTransaction bool `query:"with_source_transaction,omitempty"`
+	Limit                 *int `query:"limit,omitempty"`
+	Offset                *int `query:"offset,omitempty"`
 }

--- a/backend/internal/domain/settlement.go
+++ b/backend/internal/domain/settlement.go
@@ -31,11 +31,14 @@ type SettlementUpdateRequest struct {
 }
 
 type SettlementFilter struct {
-	IDs                   []int `query:"id[]"`
-	UserIDs               []int `query:"user_id[]"`
-	AccountIDs            []int `query:"account_id[]"`
-	SourceTransactionIDs  []int `query:"source_transaction_id[]"`
-	ParentTransactionIDs  []int `query:"parent_transaction_id[]"`
-	Limit                 *int  `query:"limit,omitempty"`
-	Offset                *int  `query:"offset,omitempty"`
+	IDs                  []int                        `query:"id[]"`
+	UserIDs              []int                        `query:"user_id[]"`
+	AccountIDs           []int                        `query:"account_id[]"`
+	SourceTransactionIDs []int                        `query:"source_transaction_id[]"`
+	ParentTransactionIDs []int                        `query:"parent_transaction_id[]"`
+	Types                []SettlementType             `query:"type[]"`
+	StartDate            *ComparableSearch[time.Time] `query:"start_date,omitempty"`
+	EndDate              *ComparableSearch[time.Time] `query:"end_date,omitempty"`
+	Limit                *int                         `query:"limit,omitempty"`
+	Offset               *int                         `query:"offset,omitempty"`
 }

--- a/backend/internal/domain/transaction_import.go
+++ b/backend/internal/domain/transaction_import.go
@@ -19,22 +19,37 @@ const (
 
 // ParsedImportRow represents a single row from a parsed CSV import file.
 // It includes inferred values (e.g. category from transaction history) and
-// any transactions detected as possible duplicates of this row.
+// any transactions or settlements detected as possible duplicates of this row.
 type ParsedImportRow struct {
-	RowIndex                     int             `json:"row_index"`
-	Status                       ImportRowStatus `json:"status"`
-	Date                         *time.Time      `json:"date,omitempty"`
-	Description                  string          `json:"description"`
-	Type                         TransactionType `json:"type"`
-	Amount                       int64           `json:"amount"` // cents
-	CategoryID                   *int            `json:"category_id,omitempty"`
-	CategoryInferred             bool            `json:"category_inferred"`
-	DestinationAccountID         *int            `json:"destination_account_id,omitempty"`
-	RecurrenceType               *RecurrenceType `json:"recurrence_type,omitempty"`
-	RecurrenceCount              *int            `json:"recurrence_count,omitempty"`
-	RecurrenceCurrentInstallment *int            `json:"recurrence_current_installment,omitempty"`
-	ParseErrors                  []string        `json:"parse_errors,omitempty"`
-	DuplicateMatches             []Transaction   `json:"duplicate_matches,omitempty"`
+	RowIndex                     int                `json:"row_index"`
+	Status                       ImportRowStatus    `json:"status"`
+	Date                         *time.Time         `json:"date,omitempty"`
+	Description                  string             `json:"description"`
+	Type                         TransactionType    `json:"type"`
+	Amount                       int64              `json:"amount"` // cents
+	CategoryID                   *int               `json:"category_id,omitempty"`
+	CategoryInferred             bool               `json:"category_inferred"`
+	DestinationAccountID         *int               `json:"destination_account_id,omitempty"`
+	RecurrenceType               *RecurrenceType    `json:"recurrence_type,omitempty"`
+	RecurrenceCount              *int               `json:"recurrence_count,omitempty"`
+	RecurrenceCurrentInstallment *int               `json:"recurrence_current_installment,omitempty"`
+	ParseErrors                  []string           `json:"parse_errors,omitempty"`
+	DuplicateMatches             []Transaction      `json:"duplicate_matches,omitempty"`
+	SettlementMatches            []SettlementMatch  `json:"settlement_matches,omitempty"`
+}
+
+// SettlementMatch is a settlement flagged as a possible duplicate of an
+// imported income/expense row. Description is hydrated from the settlement's
+// source transaction so the UI can show meaningful text — settlements
+// themselves have no description column.
+type SettlementMatch struct {
+	ID                  int            `json:"id"`
+	AccountID           int            `json:"account_id"`
+	Amount              int64          `json:"amount"` // cents
+	Type                SettlementType `json:"type"`
+	Date                time.Time      `json:"date"`
+	SourceTransactionID int            `json:"source_transaction_id"`
+	Description         string         `json:"description"`
 }
 
 // DuplicateCriteria describes the thresholds used to flag a row as a possible
@@ -55,11 +70,15 @@ type ImportCSVResponse struct {
 }
 
 // CheckDuplicateRowInput is a single row submitted to the bulk duplicate check.
+// Type drives the settlement comparison: income matches against credit
+// settlements, expense matches against debit settlements, transfer skips
+// settlement matching entirely.
 type CheckDuplicateRowInput struct {
-	RowIndex    int    `json:"row_index"`
-	Date        Date   `json:"date"`
-	Amount      int64  `json:"amount"` // cents
-	Description string `json:"description"`
+	RowIndex    int             `json:"row_index"`
+	Date        Date            `json:"date"`
+	Amount      int64           `json:"amount"` // cents
+	Description string          `json:"description"`
+	Type        TransactionType `json:"type,omitempty"`
 }
 
 // CheckDuplicatesBulkRequest is the request body for the bulk duplicate check.
@@ -69,9 +88,13 @@ type CheckDuplicatesBulkRequest struct {
 }
 
 // CheckDuplicateRowResult holds the duplicate matches for one bulk-checked row.
+// Matches lists existing transactions; SettlementMatches lists existing
+// settlements (income rows match credit settlements, expense rows match
+// debit settlements). Both share the same amount/description thresholds.
 type CheckDuplicateRowResult struct {
-	RowIndex int           `json:"row_index"`
-	Matches  []Transaction `json:"matches"`
+	RowIndex          int                `json:"row_index"`
+	Matches           []Transaction      `json:"matches"`
+	SettlementMatches []SettlementMatch  `json:"settlement_matches,omitempty"`
 }
 
 // CheckDuplicatesBulkResponse is the response of the bulk duplicate check.

--- a/backend/internal/entity/settlement.go
+++ b/backend/internal/entity/settlement.go
@@ -8,16 +8,17 @@ import (
 )
 
 type Settlement struct {
-	ID                  int                    `gorm:"primaryKey;autoIncrement"`
-	UserID              int                    `gorm:"not null"`
-	Amount              int64                  `gorm:"not null"`
-	Type                domain.SettlementType  `gorm:"not null"`
-	AccountID           int                    `gorm:"not null"`
-	SourceTransactionID int                    `gorm:"not null"`
-	ParentTransactionID int                    `gorm:"not null"`
-	Date                time.Time              `gorm:"type:date;not null"`
+	ID                  int                   `gorm:"primaryKey;autoIncrement"`
+	UserID              int                   `gorm:"not null"`
+	Amount              int64                 `gorm:"not null"`
+	Type                domain.SettlementType `gorm:"not null"`
+	AccountID           int                   `gorm:"not null"`
+	SourceTransactionID int                   `gorm:"not null"`
+	ParentTransactionID int                   `gorm:"not null"`
+	Date                time.Time             `gorm:"type:date;not null"`
 	CreatedAt           *time.Time
 	UpdatedAt           *time.Time
+	SourceTransaction   *Transaction `gorm:"foreignKey:SourceTransactionID;<-:false"`
 }
 
 func (Settlement) BeforeCreate(tx *gorm.DB) error {
@@ -33,6 +34,10 @@ func (s *Settlement) BeforeUpdate(tx *gorm.DB) error {
 }
 
 func (s *Settlement) ToDomain() *domain.Settlement {
+	var sourceTx *domain.Transaction
+	if s.SourceTransaction != nil {
+		sourceTx = s.SourceTransaction.ToDomain()
+	}
 	return &domain.Settlement{
 		ID:                  s.ID,
 		UserID:              s.UserID,
@@ -44,6 +49,7 @@ func (s *Settlement) ToDomain() *domain.Settlement {
 		Date:                s.Date,
 		CreatedAt:           s.CreatedAt,
 		UpdatedAt:           s.UpdatedAt,
+		SourceTransaction:   sourceTx,
 	}
 }
 

--- a/backend/internal/handler/transaction_handler.go
+++ b/backend/internal/handler/transaction_handler.go
@@ -320,7 +320,7 @@ func (h *TransactionHandler) Delete(c echo.Context) error {
 
 // CheckDuplicatesBulk godoc
 // @Summary      Check rows for possible duplicates
-// @Description  Runs the duplicate check for one or more rows in a single request and returns the matches per row_index. Matching considers the whole calendar month, an amount range of ±2 cents, and fuzzy description similarity.
+// @Description  Runs the duplicate check for one or more rows in a single request and returns the transaction and settlement matches per row_index. Matching considers the whole calendar month, an amount range of ±2 cents, and fuzzy description similarity. Income rows are also compared against credit settlements; expense rows against debit settlements.
 // @Tags         transactions
 // @Accept       json
 // @Produce      json

--- a/backend/internal/repository/settlement_repository.go
+++ b/backend/internal/repository/settlement_repository.go
@@ -37,6 +37,10 @@ func (r *settlementRepository) Search(ctx context.Context, filter domain.Settlem
 	var ents []entity.Settlement
 	query := GetTxFromContext(ctx, r.db)
 
+	if filter.WithSourceTransaction {
+		query = query.Preload("SourceTransaction")
+	}
+
 	if len(filter.IDs) > 0 {
 		query = query.Where("id IN ?", filter.IDs)
 	}

--- a/backend/internal/repository/settlement_repository.go
+++ b/backend/internal/repository/settlement_repository.go
@@ -52,6 +52,15 @@ func (r *settlementRepository) Search(ctx context.Context, filter domain.Settlem
 	if len(filter.ParentTransactionIDs) > 0 {
 		query = query.Where("parent_transaction_id IN ?", filter.ParentTransactionIDs)
 	}
+	if len(filter.Types) > 0 {
+		query = query.Where("type IN ?", filter.Types)
+	}
+	if filter.StartDate != nil && filter.StartDate.IsValid() {
+		query = query.Where(filter.StartDate.ToSQL("date"))
+	}
+	if filter.EndDate != nil && filter.EndDate.IsValid() {
+		query = query.Where(filter.EndDate.ToSQL("date"))
+	}
 	if filter.Limit != nil {
 		query = query.Limit(*filter.Limit)
 	}

--- a/backend/internal/service/transaction_check_duplicate.go
+++ b/backend/internal/service/transaction_check_duplicate.go
@@ -39,7 +39,7 @@ func checkDuplicatesByWindow(ctx context.Context, s *transactionService, userID 
 		month time.Month
 	}
 	txWindows := make(map[monthKey][]*domain.Transaction)
-	settlementWindows := make(map[monthKey][]hydratedSettlement)
+	settlementWindows := make(map[monthKey][]*domain.Settlement)
 	settlementWindowLoaded := make(map[monthKey]bool)
 	txResult := make(map[int][]domain.Transaction, len(rows))
 	settlementResult := make(map[int][]domain.SettlementMatch, len(rows))

--- a/backend/internal/service/transaction_check_duplicate.go
+++ b/backend/internal/service/transaction_check_duplicate.go
@@ -9,9 +9,10 @@ import (
 
 // CheckDuplicatesBulk runs the duplicate check for many rows at once. Rows are
 // grouped by calendar month so each (account, month) window is fetched from
-// the database only once.
+// the database only once. Returns both transaction and settlement matches
+// per row.
 func (s *transactionService) CheckDuplicatesBulk(ctx context.Context, userID int, accountID *int, rows []domain.CheckDuplicateRowInput) ([]domain.CheckDuplicateRowResult, error) {
-	matches, err := checkDuplicatesByWindow(ctx, s, userID, accountID, rows)
+	txMatches, settlementMatches, err := checkDuplicatesByWindow(ctx, s, userID, accountID, rows)
 	if err != nil {
 		return nil, err
 	}
@@ -19,8 +20,9 @@ func (s *transactionService) CheckDuplicatesBulk(ctx context.Context, userID int
 	results := make([]domain.CheckDuplicateRowResult, 0, len(rows))
 	for _, row := range rows {
 		results = append(results, domain.CheckDuplicateRowResult{
-			RowIndex: row.RowIndex,
-			Matches:  matches[row.RowIndex],
+			RowIndex:          row.RowIndex,
+			Matches:           txMatches[row.RowIndex],
+			SettlementMatches: settlementMatches[row.RowIndex],
 		})
 	}
 	return results, nil
@@ -28,27 +30,49 @@ func (s *transactionService) CheckDuplicatesBulk(ctx context.Context, userID int
 
 // checkDuplicatesByWindow resolves possible duplicates for many rows while
 // fetching each (account, calendar-month) window from the database only once.
-// The result maps each row's RowIndex to its matched transactions.
-func checkDuplicatesByWindow(ctx context.Context, s *transactionService, userID int, accountID *int, rows []domain.CheckDuplicateRowInput) (map[int][]domain.Transaction, error) {
+// Returns two maps keyed by RowIndex: matched transactions and matched
+// settlements. Settlement lookups are skipped for windows whose rows are all
+// transfers (settlement matching only makes sense for income/expense).
+func checkDuplicatesByWindow(ctx context.Context, s *transactionService, userID int, accountID *int, rows []domain.CheckDuplicateRowInput) (map[int][]domain.Transaction, map[int][]domain.SettlementMatch, error) {
 	type monthKey struct {
 		year  int
 		month time.Month
 	}
-	windows := make(map[monthKey][]*domain.Transaction)
-	result := make(map[int][]domain.Transaction, len(rows))
+	txWindows := make(map[monthKey][]*domain.Transaction)
+	settlementWindows := make(map[monthKey][]hydratedSettlement)
+	settlementWindowLoaded := make(map[monthKey]bool)
+	txResult := make(map[int][]domain.Transaction, len(rows))
+	settlementResult := make(map[int][]domain.SettlementMatch, len(rows))
 
 	for _, row := range rows {
 		key := monthKey{year: row.Date.Year(), month: row.Date.Month()}
-		txs, cached := windows[key]
+
+		txs, cached := txWindows[key]
 		if !cached {
 			var err error
 			txs, err = searchMonthWindow(ctx, s, userID, row.Date.Time, accountID)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			windows[key] = txs
+			txWindows[key] = txs
 		}
-		result[row.RowIndex] = filterDuplicateMatches(txs, row.Amount, row.Description)
+		txResult[row.RowIndex] = filterDuplicateMatches(txs, row.Amount, row.Description)
+
+		// Settlement lookup only when the row type can plausibly match one.
+		if _, ok := allowedSettlementTypeFor(row.Type); !ok {
+			continue
+		}
+		if !settlementWindowLoaded[key] {
+			settlements, err := searchSettlementMonthWindow(ctx, s, userID, row.Date.Time, accountID)
+			if err != nil {
+				return nil, nil, err
+			}
+			settlementWindows[key] = settlements
+			settlementWindowLoaded[key] = true
+		}
+		if matches := filterSettlementDuplicateMatches(settlementWindows[key], row.Amount, row.Description, row.Type); len(matches) > 0 {
+			settlementResult[row.RowIndex] = matches
+		}
 	}
-	return result, nil
+	return txResult, settlementResult, nil
 }

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -377,6 +377,129 @@ func searchMonthWindow(ctx context.Context, s *transactionService, userID int, d
 	return s.transactionRepo.Search(ctx, filter)
 }
 
+// hydratedSettlement carries a settlement together with the description of its
+// source transaction, which is required for trigram similarity matching.
+type hydratedSettlement struct {
+	Settlement  *domain.Settlement
+	Description string
+}
+
+// searchSettlementMonthWindow fetches every settlement for the user in the
+// calendar month of date, optionally scoped to a single account, and hydrates
+// each one with the description of its source transaction. The description is
+// what fuzzy matching needs — settlements themselves have no description.
+func searchSettlementMonthWindow(ctx context.Context, s *transactionService, userID int, date time.Time, accountID *int) ([]hydratedSettlement, error) {
+	period := domain.Period{Month: int(date.Month()), Year: date.Year()}
+	start := period.StartDate()
+	end := period.EndDate()
+
+	filter := domain.SettlementFilter{
+		UserIDs:   []int{userID},
+		StartDate: &domain.ComparableSearch[time.Time]{GreaterThanOrEqual: &start},
+		EndDate:   &domain.ComparableSearch[time.Time]{LessThanOrEqual: &end},
+	}
+	if accountID != nil {
+		filter.AccountIDs = []int{*accountID}
+	}
+	settlements, err := s.settlementRepo.Search(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	if len(settlements) == 0 {
+		return nil, nil
+	}
+
+	sourceIDs := make([]int, 0, len(settlements))
+	seen := make(map[int]struct{}, len(settlements))
+	for _, st := range settlements {
+		if st == nil || st.SourceTransactionID == 0 {
+			continue
+		}
+		if _, ok := seen[st.SourceTransactionID]; ok {
+			continue
+		}
+		seen[st.SourceTransactionID] = struct{}{}
+		sourceIDs = append(sourceIDs, st.SourceTransactionID)
+	}
+
+	descByID := make(map[int]string, len(sourceIDs))
+	if len(sourceIDs) > 0 {
+		sources, err := s.transactionRepo.Search(ctx, domain.TransactionFilter{IDs: sourceIDs})
+		if err != nil {
+			return nil, err
+		}
+		for _, tx := range sources {
+			if tx == nil {
+				continue
+			}
+			descByID[tx.ID] = tx.Description
+		}
+	}
+
+	out := make([]hydratedSettlement, 0, len(settlements))
+	for _, st := range settlements {
+		if st == nil {
+			continue
+		}
+		out = append(out, hydratedSettlement{
+			Settlement:  st,
+			Description: descByID[st.SourceTransactionID],
+		})
+	}
+	return out, nil
+}
+
+// allowedSettlementTypeFor returns which settlement type can duplicate an
+// imported row of the given transaction type. Returns ("", false) when
+// settlement matching should be skipped (e.g. transfer rows).
+func allowedSettlementTypeFor(t domain.TransactionType) (domain.SettlementType, bool) {
+	switch t {
+	case domain.TransactionTypeIncome:
+		return domain.SettlementTypeCredit, true
+	case domain.TransactionTypeExpense:
+		return domain.SettlementTypeDebit, true
+	default:
+		return "", false
+	}
+}
+
+// filterSettlementDuplicateMatches mirrors filterDuplicateMatches but for
+// settlements: amount within ±duplicateAmountThreshold, description trigram
+// similarity ≥ descriptionSimilarityThreshold (against the source transaction
+// description), and the settlement type aligned with the row type.
+func filterSettlementDuplicateMatches(candidates []hydratedSettlement, amount int64, description string, rowType domain.TransactionType) []domain.SettlementMatch {
+	allowedType, ok := allowedSettlementTypeFor(rowType)
+	if !ok {
+		return nil
+	}
+	matches := make([]domain.SettlementMatch, 0)
+	for _, h := range candidates {
+		st := h.Settlement
+		if st == nil {
+			continue
+		}
+		if st.Type != allowedType {
+			continue
+		}
+		if diff := st.Amount - amount; diff < -duplicateAmountThreshold || diff > duplicateAmountThreshold {
+			continue
+		}
+		if description != "" && trigramSimilarity(h.Description, description) < descriptionSimilarityThreshold {
+			continue
+		}
+		matches = append(matches, domain.SettlementMatch{
+			ID:                  st.ID,
+			AccountID:           st.AccountID,
+			Amount:              st.Amount,
+			Type:                st.Type,
+			Date:                st.Date,
+			SourceTransactionID: st.SourceTransactionID,
+			Description:         h.Description,
+		})
+	}
+	return matches
+}
+
 // filterDuplicateMatches keeps only the candidates that are possible
 // duplicates of (amount, description): amount within ±2 cents and, when a
 // description is supplied, trigram similarity >= descriptionSimilarityThreshold.
@@ -397,9 +520,10 @@ func filterDuplicateMatches(candidates []*domain.Transaction, amount int64, desc
 	return matches
 }
 
-// detectDuplicateRows fills DuplicateMatches on every parsed row that has a
-// valid date and amount, querying the database once per (account, month)
-// window rather than once per row. It returns the count of flagged rows.
+// detectDuplicateRows fills DuplicateMatches and SettlementMatches on every
+// parsed row that has a valid date and amount, querying the database once per
+// (account, month) window rather than once per row. It returns the count of
+// rows flagged by at least one of the two checks.
 func detectDuplicateRows(ctx context.Context, s *transactionService, userID, accountID int, rows []domain.ParsedImportRow) int {
 	inputs := make([]domain.CheckDuplicateRowInput, 0, len(rows))
 	for i, row := range rows {
@@ -409,6 +533,7 @@ func detectDuplicateRows(ctx context.Context, s *transactionService, userID, acc
 				Date:        domain.Date{Time: *row.Date},
 				Amount:      row.Amount,
 				Description: row.Description,
+				Type:        row.Type,
 			})
 		}
 	}
@@ -416,15 +541,23 @@ func detectDuplicateRows(ctx context.Context, s *transactionService, userID, acc
 		return 0
 	}
 
-	matches, err := checkDuplicatesByWindow(ctx, s, userID, &accountID, inputs)
+	txMatches, settlementMatches, err := checkDuplicatesByWindow(ctx, s, userID, &accountID, inputs)
 	if err != nil {
 		return 0
 	}
 
 	count := 0
 	for i := range rows {
-		if m := matches[i]; len(m) > 0 {
+		flagged := false
+		if m := txMatches[i]; len(m) > 0 {
 			rows[i].DuplicateMatches = m
+			flagged = true
+		}
+		if m := settlementMatches[i]; len(m) > 0 {
+			rows[i].SettlementMatches = m
+			flagged = true
+		}
+		if flagged {
 			count++
 		}
 	}

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -377,76 +377,25 @@ func searchMonthWindow(ctx context.Context, s *transactionService, userID int, d
 	return s.transactionRepo.Search(ctx, filter)
 }
 
-// hydratedSettlement carries a settlement together with the description of its
-// source transaction, which is required for trigram similarity matching.
-type hydratedSettlement struct {
-	Settlement  *domain.Settlement
-	Description string
-}
-
 // searchSettlementMonthWindow fetches every settlement for the user in the
-// calendar month of date, optionally scoped to a single account, and hydrates
-// each one with the description of its source transaction. The description is
-// what fuzzy matching needs — settlements themselves have no description.
-func searchSettlementMonthWindow(ctx context.Context, s *transactionService, userID int, date time.Time, accountID *int) ([]hydratedSettlement, error) {
+// calendar month of date, optionally scoped to a single account, and preloads
+// the source transaction on each one. The source transaction supplies the
+// description used by trigram similarity — settlements themselves have none.
+func searchSettlementMonthWindow(ctx context.Context, s *transactionService, userID int, date time.Time, accountID *int) ([]*domain.Settlement, error) {
 	period := domain.Period{Month: int(date.Month()), Year: date.Year()}
 	start := period.StartDate()
 	end := period.EndDate()
 
 	filter := domain.SettlementFilter{
-		UserIDs:   []int{userID},
-		StartDate: &domain.ComparableSearch[time.Time]{GreaterThanOrEqual: &start},
-		EndDate:   &domain.ComparableSearch[time.Time]{LessThanOrEqual: &end},
+		UserIDs:               []int{userID},
+		StartDate:             &domain.ComparableSearch[time.Time]{GreaterThanOrEqual: &start},
+		EndDate:               &domain.ComparableSearch[time.Time]{LessThanOrEqual: &end},
+		WithSourceTransaction: true,
 	}
 	if accountID != nil {
 		filter.AccountIDs = []int{*accountID}
 	}
-	settlements, err := s.settlementRepo.Search(ctx, filter)
-	if err != nil {
-		return nil, err
-	}
-	if len(settlements) == 0 {
-		return nil, nil
-	}
-
-	sourceIDs := make([]int, 0, len(settlements))
-	seen := make(map[int]struct{}, len(settlements))
-	for _, st := range settlements {
-		if st == nil || st.SourceTransactionID == 0 {
-			continue
-		}
-		if _, ok := seen[st.SourceTransactionID]; ok {
-			continue
-		}
-		seen[st.SourceTransactionID] = struct{}{}
-		sourceIDs = append(sourceIDs, st.SourceTransactionID)
-	}
-
-	descByID := make(map[int]string, len(sourceIDs))
-	if len(sourceIDs) > 0 {
-		sources, err := s.transactionRepo.Search(ctx, domain.TransactionFilter{IDs: sourceIDs})
-		if err != nil {
-			return nil, err
-		}
-		for _, tx := range sources {
-			if tx == nil {
-				continue
-			}
-			descByID[tx.ID] = tx.Description
-		}
-	}
-
-	out := make([]hydratedSettlement, 0, len(settlements))
-	for _, st := range settlements {
-		if st == nil {
-			continue
-		}
-		out = append(out, hydratedSettlement{
-			Settlement:  st,
-			Description: descByID[st.SourceTransactionID],
-		})
-	}
-	return out, nil
+	return s.settlementRepo.Search(ctx, filter)
 }
 
 // allowedSettlementTypeFor returns which settlement type can duplicate an
@@ -465,16 +414,17 @@ func allowedSettlementTypeFor(t domain.TransactionType) (domain.SettlementType, 
 
 // filterSettlementDuplicateMatches mirrors filterDuplicateMatches but for
 // settlements: amount within ±duplicateAmountThreshold, description trigram
-// similarity ≥ descriptionSimilarityThreshold (against the source transaction
-// description), and the settlement type aligned with the row type.
-func filterSettlementDuplicateMatches(candidates []hydratedSettlement, amount int64, description string, rowType domain.TransactionType) []domain.SettlementMatch {
+// similarity ≥ descriptionSimilarityThreshold (against the preloaded source
+// transaction description), and the settlement type aligned with the row type.
+// Settlements without a preloaded SourceTransaction contribute an empty
+// description — they only match when the row description is also empty.
+func filterSettlementDuplicateMatches(candidates []*domain.Settlement, amount int64, description string, rowType domain.TransactionType) []domain.SettlementMatch {
 	allowedType, ok := allowedSettlementTypeFor(rowType)
 	if !ok {
 		return nil
 	}
 	matches := make([]domain.SettlementMatch, 0)
-	for _, h := range candidates {
-		st := h.Settlement
+	for _, st := range candidates {
 		if st == nil {
 			continue
 		}
@@ -484,7 +434,11 @@ func filterSettlementDuplicateMatches(candidates []hydratedSettlement, amount in
 		if diff := st.Amount - amount; diff < -duplicateAmountThreshold || diff > duplicateAmountThreshold {
 			continue
 		}
-		if description != "" && trigramSimilarity(h.Description, description) < descriptionSimilarityThreshold {
+		var sourceDesc string
+		if st.SourceTransaction != nil {
+			sourceDesc = st.SourceTransaction.Description
+		}
+		if description != "" && trigramSimilarity(sourceDesc, description) < descriptionSimilarityThreshold {
 			continue
 		}
 		matches = append(matches, domain.SettlementMatch{
@@ -494,7 +448,7 @@ func filterSettlementDuplicateMatches(candidates []hydratedSettlement, amount in
 			Type:                st.Type,
 			Date:                st.Date,
 			SourceTransactionID: st.SourceTransactionID,
-			Description:         h.Description,
+			Description:         sourceDesc,
 		})
 	}
 	return matches

--- a/backend/internal/service/transaction_import_test.go
+++ b/backend/internal/service/transaction_import_test.go
@@ -109,27 +109,26 @@ func TestAllowedSettlementTypeFor(t *testing.T) {
 }
 
 func TestFilterSettlementDuplicateMatches(t *testing.T) {
-	credit := func(id int, amount int64, desc string) hydratedSettlement {
-		return hydratedSettlement{
-			Settlement: &domain.Settlement{
-				ID: id, Amount: amount, Type: domain.SettlementTypeCredit,
-				AccountID: 10, SourceTransactionID: id + 100, Date: time.Now(),
-			},
-			Description: desc,
+	settlement := func(id int, amount int64, t domain.SettlementType, desc string) *domain.Settlement {
+		return &domain.Settlement{
+			ID:                  id,
+			Amount:              amount,
+			Type:                t,
+			AccountID:           10,
+			SourceTransactionID: id + 100,
+			Date:                time.Now(),
+			SourceTransaction:   &domain.Transaction{ID: id + 100, Description: desc},
 		}
 	}
-	debit := func(id int, amount int64, desc string) hydratedSettlement {
-		return hydratedSettlement{
-			Settlement: &domain.Settlement{
-				ID: id, Amount: amount, Type: domain.SettlementTypeDebit,
-				AccountID: 10, SourceTransactionID: id + 100, Date: time.Now(),
-			},
-			Description: desc,
-		}
+	credit := func(id int, amount int64, desc string) *domain.Settlement {
+		return settlement(id, amount, domain.SettlementTypeCredit, desc)
+	}
+	debit := func(id int, amount int64, desc string) *domain.Settlement {
+		return settlement(id, amount, domain.SettlementTypeDebit, desc)
 	}
 
 	t.Run("income matches credit settlement only", func(t *testing.T) {
-		candidates := []hydratedSettlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
+		candidates := []*domain.Settlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
 		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
 		require.Len(t, got, 1)
 		assert.Equal(t, 1, got[0].ID)
@@ -138,7 +137,7 @@ func TestFilterSettlementDuplicateMatches(t *testing.T) {
 	})
 
 	t.Run("expense matches debit settlement only", func(t *testing.T) {
-		candidates := []hydratedSettlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
+		candidates := []*domain.Settlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
 		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeExpense)
 		require.Len(t, got, 1)
 		assert.Equal(t, 2, got[0].ID)
@@ -146,32 +145,46 @@ func TestFilterSettlementDuplicateMatches(t *testing.T) {
 	})
 
 	t.Run("transfer skips settlement matching entirely", func(t *testing.T) {
-		candidates := []hydratedSettlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
+		candidates := []*domain.Settlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
 		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeTransfer)
 		assert.Nil(t, got)
 	})
 
 	t.Run("amount within tolerance matches, outside does not", func(t *testing.T) {
-		candidates := []hydratedSettlement{credit(1, 5002, "Petz"), credit(2, 5003, "Petz")}
+		candidates := []*domain.Settlement{credit(1, 5002, "Petz"), credit(2, 5003, "Petz")}
 		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
 		require.Len(t, got, 1)
 		assert.Equal(t, 1, got[0].ID)
 	})
 
 	t.Run("description mismatch is filtered out", func(t *testing.T) {
-		candidates := []hydratedSettlement{credit(1, 5000, "Imec")}
+		candidates := []*domain.Settlement{credit(1, 5000, "Imec")}
 		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
 		assert.Empty(t, got)
 	})
 
 	t.Run("empty description skips similarity check", func(t *testing.T) {
-		candidates := []hydratedSettlement{credit(1, 5000, "Whatever")}
+		candidates := []*domain.Settlement{credit(1, 5000, "Whatever")}
 		got := filterSettlementDuplicateMatches(candidates, 5000, "", domain.TransactionTypeIncome)
 		require.Len(t, got, 1)
 	})
 
+	t.Run("settlement missing preloaded source transaction is treated as empty description", func(t *testing.T) {
+		bare := &domain.Settlement{
+			ID: 1, Amount: 5000, Type: domain.SettlementTypeCredit, AccountID: 10,
+			SourceTransactionID: 101, Date: time.Now(),
+		}
+		candidates := []*domain.Settlement{bare}
+		// With a non-empty description, the bare settlement fails the
+		// similarity check (empty source description) and is filtered out.
+		assert.Empty(t, filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome))
+		// With an empty description, the similarity check is skipped and the
+		// settlement matches on amount + type alone.
+		require.Len(t, filterSettlementDuplicateMatches(candidates, 5000, "", domain.TransactionTypeIncome), 1)
+	})
+
 	t.Run("nil settlement is skipped without panic", func(t *testing.T) {
-		candidates := []hydratedSettlement{{Settlement: nil, Description: ""}, credit(1, 5000, "Petz")}
+		candidates := []*domain.Settlement{nil, credit(1, 5000, "Petz")}
 		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
 		require.Len(t, got, 1)
 		assert.Equal(t, 1, got[0].ID)

--- a/backend/internal/service/transaction_import_test.go
+++ b/backend/internal/service/transaction_import_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/finance_app/backend/internal/domain"
 	pkgErrors "github.com/finance_app/backend/pkg/errors"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -82,6 +83,98 @@ func TestTrigramSimilarity(t *testing.T) {
 
 	t.Run("empty string has zero similarity", func(t *testing.T) {
 		assert.Equal(t, 0.0, trigramSimilarity("", "Petz"))
+	})
+}
+
+func TestAllowedSettlementTypeFor(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    domain.TransactionType
+		wantType domain.SettlementType
+		wantOK   bool
+	}{
+		{"income → credit", domain.TransactionTypeIncome, domain.SettlementTypeCredit, true},
+		{"expense → debit", domain.TransactionTypeExpense, domain.SettlementTypeDebit, true},
+		{"transfer → skip", domain.TransactionTypeTransfer, "", false},
+		{"empty → skip", domain.TransactionType(""), "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := allowedSettlementTypeFor(tc.input)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantType, got)
+		})
+	}
+}
+
+func TestFilterSettlementDuplicateMatches(t *testing.T) {
+	credit := func(id int, amount int64, desc string) hydratedSettlement {
+		return hydratedSettlement{
+			Settlement: &domain.Settlement{
+				ID: id, Amount: amount, Type: domain.SettlementTypeCredit,
+				AccountID: 10, SourceTransactionID: id + 100, Date: time.Now(),
+			},
+			Description: desc,
+		}
+	}
+	debit := func(id int, amount int64, desc string) hydratedSettlement {
+		return hydratedSettlement{
+			Settlement: &domain.Settlement{
+				ID: id, Amount: amount, Type: domain.SettlementTypeDebit,
+				AccountID: 10, SourceTransactionID: id + 100, Date: time.Now(),
+			},
+			Description: desc,
+		}
+	}
+
+	t.Run("income matches credit settlement only", func(t *testing.T) {
+		candidates := []hydratedSettlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
+		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
+		require.Len(t, got, 1)
+		assert.Equal(t, 1, got[0].ID)
+		assert.Equal(t, domain.SettlementTypeCredit, got[0].Type)
+		assert.Equal(t, "Petz", got[0].Description)
+	})
+
+	t.Run("expense matches debit settlement only", func(t *testing.T) {
+		candidates := []hydratedSettlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
+		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeExpense)
+		require.Len(t, got, 1)
+		assert.Equal(t, 2, got[0].ID)
+		assert.Equal(t, domain.SettlementTypeDebit, got[0].Type)
+	})
+
+	t.Run("transfer skips settlement matching entirely", func(t *testing.T) {
+		candidates := []hydratedSettlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
+		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeTransfer)
+		assert.Nil(t, got)
+	})
+
+	t.Run("amount within tolerance matches, outside does not", func(t *testing.T) {
+		candidates := []hydratedSettlement{credit(1, 5002, "Petz"), credit(2, 5003, "Petz")}
+		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
+		require.Len(t, got, 1)
+		assert.Equal(t, 1, got[0].ID)
+	})
+
+	t.Run("description mismatch is filtered out", func(t *testing.T) {
+		candidates := []hydratedSettlement{credit(1, 5000, "Imec")}
+		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty description skips similarity check", func(t *testing.T) {
+		candidates := []hydratedSettlement{credit(1, 5000, "Whatever")}
+		got := filterSettlementDuplicateMatches(candidates, 5000, "", domain.TransactionTypeIncome)
+		require.Len(t, got, 1)
+	})
+
+	t.Run("nil settlement is skipped without panic", func(t *testing.T) {
+		candidates := []hydratedSettlement{{Settlement: nil, Description: ""}, credit(1, 5000, "Petz")}
+		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
+		require.Len(t, got, 1)
+		assert.Equal(t, 1, got[0].ID)
 	})
 }
 
@@ -429,6 +522,88 @@ func (suite *TransactionImportWithDBTestSuite) TestCheckDuplicatesBulk() {
 	suite.NotEmpty(byIndex[0].Matches)
 	suite.Empty(byIndex[1].Matches)
 	suite.Empty(byIndex[2].Matches)
+}
+
+// TestCheckDuplicatesBulkAgainstSettlements verifies that an imported income
+// row matches a credit settlement on the same connection account when amount,
+// description, and month align — and that an unrelated row does not.
+func (suite *TransactionImportWithDBTestSuite) TestCheckDuplicatesBulkAgainstSettlements() {
+	ctx := context.Background()
+
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	privateAccount, err := suite.createTestAccount(ctx, user1)
+	suite.Require().NoError(err)
+
+	connection, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	category, err := suite.createTestCategory(ctx, user1)
+	suite.Require().NoError(err)
+
+	sharedDate := time.Date(2026, 11, 12, 0, 0, 0, 0, time.UTC)
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		AccountID:       privateAccount.ID,
+		CategoryID:      category.ID,
+		Amount:          10000,
+		Date:            domain.Date{Time: sharedDate},
+		Description:     "Jantar restaurante",
+		TransactionType: domain.TransactionTypeExpense,
+		SplitSettings: []domain.SplitSettings{
+			{ConnectionID: connection.ID, Percentage: lo.ToPtr(50)},
+		},
+	})
+	suite.Require().NoError(err)
+
+	// Sanity check: a credit settlement of 5000 must exist on user1's side of the connection.
+	settlements, err := suite.Repos.Settlement.Search(ctx, domain.SettlementFilter{
+		UserIDs:    []int{user1.ID},
+		AccountIDs: []int{connection.FromAccountID},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(settlements, 1)
+	suite.Require().Equal(int64(5000), settlements[0].Amount)
+	suite.Require().Equal(domain.SettlementTypeCredit, settlements[0].Type)
+
+	connAccountID := connection.FromAccountID
+
+	rows := []domain.CheckDuplicateRowInput{
+		// Match: income on same connection account, same month, amount within tolerance, similar description.
+		{RowIndex: 0, Date: domain.Date{Time: time.Date(2026, 11, 15, 0, 0, 0, 0, time.UTC)}, Amount: 5001, Description: "Jantar restaurante", Type: domain.TransactionTypeIncome},
+		// No match: expense looks at debit settlements, but the existing settlement is credit.
+		{RowIndex: 1, Date: domain.Date{Time: sharedDate}, Amount: 5000, Description: "Jantar restaurante", Type: domain.TransactionTypeExpense},
+		// No match: transfer skips settlement matching entirely.
+		{RowIndex: 2, Date: domain.Date{Time: sharedDate}, Amount: 5000, Description: "Jantar restaurante", Type: domain.TransactionTypeTransfer},
+		// No match: different month.
+		{RowIndex: 3, Date: domain.Date{Time: time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)}, Amount: 5000, Description: "Jantar restaurante", Type: domain.TransactionTypeIncome},
+		// No match: amount too far.
+		{RowIndex: 4, Date: domain.Date{Time: sharedDate}, Amount: 9999, Description: "Jantar restaurante", Type: domain.TransactionTypeIncome},
+		// No match: description mismatch.
+		{RowIndex: 5, Date: domain.Date{Time: sharedDate}, Amount: 5000, Description: "Aluguel mensal apto", Type: domain.TransactionTypeIncome},
+	}
+
+	results, err := suite.Services.Transaction.CheckDuplicatesBulk(ctx, user1.ID, &connAccountID, rows)
+	suite.Require().NoError(err)
+	suite.Require().Len(results, len(rows))
+
+	byIndex := make(map[int]domain.CheckDuplicateRowResult, len(results))
+	for _, r := range results {
+		byIndex[r.RowIndex] = r
+	}
+	suite.Require().Len(byIndex[0].SettlementMatches, 1, "income should match the credit settlement")
+	suite.Equal(settlements[0].ID, byIndex[0].SettlementMatches[0].ID)
+	suite.Equal(int64(5000), byIndex[0].SettlementMatches[0].Amount)
+	suite.Equal(domain.SettlementTypeCredit, byIndex[0].SettlementMatches[0].Type)
+	suite.Equal("Jantar restaurante", byIndex[0].SettlementMatches[0].Description)
+
+	suite.Empty(byIndex[1].SettlementMatches, "expense should not match a credit settlement")
+	suite.Empty(byIndex[2].SettlementMatches, "transfer should skip settlement matching")
+	suite.Empty(byIndex[3].SettlementMatches, "different month should not match")
+	suite.Empty(byIndex[4].SettlementMatches, "amount outside tolerance should not match")
+	suite.Empty(byIndex[5].SettlementMatches, "description mismatch should not match")
 }
 
 func TestInferInstallment(t *testing.T) {

--- a/backend/internal/service/transaction_service.go
+++ b/backend/internal/service/transaction_service.go
@@ -15,6 +15,7 @@ type transactionService struct {
 	transactionRepo      repository.TransactionRepository
 	transactionRecurRepo repository.TransactionRecurrenceRepository
 	tagRepo              repository.TagRepository
+	settlementRepo       repository.SettlementRepository
 	services             *Services
 }
 
@@ -24,6 +25,7 @@ func NewTransactionService(repos *repository.Repositories, services *Services) T
 		transactionRepo:      repos.Transaction,
 		transactionRecurRepo: repos.TransactionRecurrence,
 		tagRepo:              repos.Tag,
+		settlementRepo:       repos.Settlement,
 		services:             services,
 	}
 }

--- a/frontend/e2e/tests/import-settlement-duplicates.spec.ts
+++ b/frontend/e2e/tests/import-settlement-duplicates.spec.ts
@@ -110,7 +110,9 @@ test.describe("Import: settlement-aware duplicate detection", () => {
 
     // 5. "Marcar como não importar" must still work for settlement-only matches.
     await importPage.markNotImportFromDrawer();
-    await expect(await importPage.getRowActionLabel(0)).toBe("Não importar");
+    await expect(
+      importPage.reviewStep.getByTestId(ImportTestIds.RowSelectAction(0)),
+    ).toHaveValue("Não importar", { timeout: 5000 });
 
     await page.close();
   });

--- a/frontend/e2e/tests/import-settlement-duplicates.spec.ts
+++ b/frontend/e2e/tests/import-settlement-duplicates.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Settlement-aware duplicate detection during import
+ *
+ * When a shared expense is recorded, a credit settlement is created on the
+ * author's side of the connection account. When the author later imports an
+ * income row on that same connection account whose amount/description align
+ * with the settlement, the import drawer must surface the settlement under a
+ * dedicated section — distinct from the existing-transactions list.
+ *
+ * Mirror scenario for shared incomes / debit settlements is not covered here:
+ * the credit case exercises the same code path on both sides.
+ */
+
+import { test, expect } from "@playwright/test";
+import { ImportPage } from "../pages/ImportPage";
+import { apiFetchAs, openAuthedPage } from "../helpers/api";
+import { createUserAndPartner } from "../helpers/createUserAndPartner";
+import { buildCsvContent } from "../helpers/csv";
+import { ImportTestIds } from "@/testIds";
+import type { Transactions } from "@/types/transactions";
+
+function formatDateBR(d: Date): string {
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}/${mm}/${d.getFullYear()}`;
+}
+
+function ymd(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+test.describe("Import: settlement-aware duplicate detection", () => {
+  test("income on the connection account flags the existing credit settlement", async ({ browser }) => {
+    const setup = await createUserAndPartner("e2e-set-dup");
+
+    const catRes = await apiFetchAs(setup.userToken, "/api/categories", {
+      method: "POST",
+      body: JSON.stringify({ name: `Cat ${Date.now()}` }),
+    });
+    const category = (await catRes.json()) as { id: number };
+
+    const sharedDate = new Date(2026, 6, 15); // July 15 2026
+    const description = `Jantar restaurante ${Date.now()}`;
+
+    // 1. Author creates a shared expense → produces a credit settlement of 5000
+    //    on the user's side of the connection account.
+    await apiFetchAs(setup.userToken, "/api/transactions", {
+      method: "POST",
+      body: JSON.stringify({
+        transaction_type: "expense",
+        account_id: setup.userAccountId,
+        category_id: category.id,
+        amount: 10000,
+        date: ymd(sharedDate),
+        description,
+        split_settings: [{ connection_id: setup.connectionId, percentage: 50 }],
+      }),
+    });
+
+    // 2. Fetch the settlement so we know its id (for the per-card testid).
+    const txsRes = await apiFetchAs(
+      setup.userToken,
+      `/api/transactions?month=${sharedDate.getMonth() + 1}&year=${sharedDate.getFullYear()}&account_id[]=${setup.userAccountId}&with_settlements=true`,
+    );
+    const txs = (await txsRes.json()) as Transactions.Transaction[];
+    const sourceTx = txs.find((t) => t.description === description);
+    expect(sourceTx).toBeDefined();
+    const settlement = sourceTx?.settlements_from_source?.[0];
+    expect(settlement).toBeDefined();
+    expect(settlement?.amount).toBe(5000);
+    expect(settlement?.type).toBe("credit");
+
+    // 3. Import an income row on the connection account that aligns with the
+    //    settlement on amount, description, and month.
+    const page = await openAuthedPage(browser, setup.userToken);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
+    const importDate = new Date(2026, 6, 20); // July 20 2026 — same month
+    const csv = buildCsvContent([
+      [formatDateBR(importDate), description, "50,00"],
+    ]);
+    await importPage.uploadCSV(csv, setup.userConnAccountId);
+
+    await expect(importPage.reviewStep.getByTestId(ImportTestIds.Row(0))).toBeVisible();
+    await expect(importPage.duplicateWarning(0)).toBeVisible({ timeout: 5000 });
+
+    // 4. Open the drawer and confirm both sections behave as expected.
+    await importPage.openDuplicatesDrawer(0);
+
+    const settlementsSection = importPage.duplicatesDrawer.getByTestId(
+      ImportTestIds.DrawerDuplicatesSettlementsSection,
+    );
+    await expect(settlementsSection).toBeVisible();
+
+    const card = importPage.duplicatesDrawer.getByTestId(
+      ImportTestIds.DrawerDuplicatesSettlementCard(settlement!.id),
+    );
+    await expect(card).toBeVisible();
+    await expect(card).toContainText(description);
+
+    // The transactions section must NOT render — there is no existing
+    // transaction on the connection account itself, just the settlement.
+    await expect(
+      importPage.duplicatesDrawer.getByTestId(ImportTestIds.DrawerDuplicatesTransactionsSection),
+    ).not.toBeVisible();
+
+    // 5. "Marcar como não importar" must still work for settlement-only matches.
+    await importPage.markNotImportFromDrawer();
+    await expect(await importPage.getRowActionLabel(0)).toBe("Não importar");
+
+    await page.close();
+  });
+
+  test("transfer row never matches against settlements", async ({ browser }) => {
+    const setup = await createUserAndPartner("e2e-set-dup-xfer");
+
+    const catRes = await apiFetchAs(setup.userToken, "/api/categories", {
+      method: "POST",
+      body: JSON.stringify({ name: `Cat ${Date.now()}` }),
+    });
+    const category = (await catRes.json()) as { id: number };
+
+    const sharedDate = new Date(2026, 7, 10);
+    const description = `Compra mercado ${Date.now()}`;
+
+    await apiFetchAs(setup.userToken, "/api/transactions", {
+      method: "POST",
+      body: JSON.stringify({
+        transaction_type: "expense",
+        account_id: setup.userAccountId,
+        category_id: category.id,
+        amount: 20000,
+        date: ymd(sharedDate),
+        description,
+        split_settings: [{ connection_id: setup.connectionId, percentage: 50 }],
+      }),
+    });
+
+    const page = await openAuthedPage(browser, setup.userToken);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
+    // Import an income row first so it parses, then flip the row to transfer
+    // — settlement matching must drop away.
+    const csv = buildCsvContent([
+      [formatDateBR(sharedDate), description, "100,00"],
+    ]);
+    await importPage.uploadCSV(csv, setup.userConnAccountId);
+
+    await expect(importPage.duplicateWarning(0)).toBeVisible({ timeout: 5000 });
+
+    // Switch the row type to transfer and confirm the warning disappears.
+    await importPage.setRowTransactionType(0, "transfer");
+    await expect(importPage.duplicateWarning(0)).not.toBeVisible({ timeout: 5000 });
+
+    await page.close();
+  });
+});

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -136,7 +136,13 @@ export async function parseImportCSV(
 
 export async function checkDuplicatesBulk(params: {
   account_id: number;
-  rows: { row_index: number; date: string; amount: number; description: string }[];
+  rows: {
+    row_index: number;
+    date: string;
+    amount: number;
+    description: string;
+    type?: Transactions.TransactionType;
+  }[];
 }): Promise<{ rows: Transactions.CheckDuplicateRowResult[] }> {
   const res = await fetch(`${apiUrl}/api/transactions/check-duplicates-bulk`, {
     method: "POST",

--- a/frontend/src/components/transactions/form/importFormSchema.ts
+++ b/frontend/src/components/transactions/form/importFormSchema.ts
@@ -18,6 +18,9 @@ export const importRowFormSchema = z
     // Transient: existing transactions flagged as possible duplicates of this
     // row. Recomputed on every date/amount/description edit; never persisted.
     duplicate_matches: z.array(z.custom<Transactions.Transaction>()),
+    // Transient: existing settlements flagged as possible duplicates of this
+    // row (income vs credit, expense vs debit). Recomputed on every edit.
+    settlement_matches: z.array(z.custom<Transactions.SettlementMatch>()),
   })
   .superRefine((data, ctx) => {
     // Validação só se aplica a linhas marcadas para importar

--- a/frontend/src/components/transactions/import/DuplicateTransactionsDrawer.tsx
+++ b/frontend/src/components/transactions/import/DuplicateTransactionsDrawer.tsx
@@ -1,5 +1,5 @@
 import { Alert, Badge, Button, Card, Group, List, Stack, Text } from '@mantine/core'
-import { IconAlertTriangle, IconInfoCircle } from '@tabler/icons-react'
+import { IconAlertTriangle, IconArrowsExchange, IconInfoCircle } from '@tabler/icons-react'
 import { ResponsiveDrawer } from '@/components/ResponsiveDrawer'
 import { useDrawerContext } from '@/utils/renderDrawer'
 import { useAccountOptions } from '@/hooks/import/useImportOptions'
@@ -16,6 +16,7 @@ interface ImportingRow {
 interface Props {
   row: ImportingRow
   matches: Transactions.Transaction[]
+  settlementMatches: Transactions.SettlementMatch[]
   /** Detection thresholds from the parse endpoint; drives the criteria text. */
   criteria?: Transactions.DuplicateCriteria
 }
@@ -28,11 +29,12 @@ function formatDate(iso: string): string {
 }
 
 /**
- * Inspection drawer for a row flagged as a possible duplicate. Lists the
- * existing transactions that matched and lets the user mark the row as "not
- * imported" — resolved via `close('skip')` so the caller flips the row action.
+ * Inspection drawer for a row flagged as a possible duplicate. Surfaces two
+ * independent sections — existing transactions and existing settlements that
+ * matched — and lets the user mark the row as "not imported" via
+ * `close('skip')` so the caller flips the row action.
  */
-export function DuplicateTransactionsDrawer({ row, matches, criteria }: Props) {
+export function DuplicateTransactionsDrawer({ row, matches, settlementMatches, criteria }: Props) {
   const { opened, close, reject } = useDrawerContext<'skip' | void>()
   const accountOptions = useAccountOptions()
 
@@ -45,6 +47,9 @@ export function DuplicateTransactionsDrawer({ row, matches, criteria }: Props) {
   const amountLabel = criteria
     ? `Valor a até ${criteria.amount_tolerance_cents} ${criteria.amount_tolerance_cents === 1 ? 'centavo' : 'centavos'} de diferença`
     : 'Valor próximo'
+
+  const hasTransactions = matches.length > 0
+  const hasSettlements = settlementMatches.length > 0
 
   return (
     <ResponsiveDrawer
@@ -82,47 +87,100 @@ export function DuplicateTransactionsDrawer({ row, matches, criteria }: Props) {
           title="Como detectamos duplicidades"
         >
           <Text fz="xs" mb={4}>
-            Uma linha é sinalizada quando existe uma transação que atende aos 3 critérios:
+            Uma linha é sinalizada quando existe uma transação ou liquidação que atende aos 3 critérios:
           </Text>
           <List size="xs" spacing={2}>
             <List.Item>{similarityLabel}</List.Item>
             <List.Item>{amountLabel}</List.Item>
             <List.Item>No mesmo mês da data da transação</List.Item>
           </List>
+          <Text fz="xs" mt={6}>
+            Receitas também são comparadas com liquidações de crédito; despesas com liquidações de débito da mesma conta.
+          </Text>
         </Alert>
 
-        <Stack gap={4}>
-          <Group gap={6}>
-            <IconAlertTriangle size={16} color="var(--mantine-color-orange-6)" />
-            <Text fz="xs" c="dimmed" tt="uppercase" fw={600}>
-              {matches.length === 1
-                ? '1 transação possivelmente duplicada'
-                : `${matches.length} transações possivelmente duplicadas`}
-            </Text>
-          </Group>
-          {matches.map((tx) => (
-            <Card key={tx.id} withBorder padding="sm">
-              <Group justify="space-between" wrap="nowrap">
-                <Stack gap={2}>
-                  <Text fw={500} fz="sm">
-                    {tx.description}
-                  </Text>
-                  <Group gap={6}>
-                    <Text fz="xs" c="dimmed">
-                      {formatDate(tx.date)}
+        {hasTransactions && (
+          <Stack gap={4} data-testid={ImportTestIds.DrawerDuplicatesTransactionsSection}>
+            <Group gap={6}>
+              <IconAlertTriangle size={16} color="var(--mantine-color-orange-6)" />
+              <Text fz="xs" c="dimmed" tt="uppercase" fw={600}>
+                {matches.length === 1
+                  ? '1 transação possivelmente duplicada'
+                  : `${matches.length} transações possivelmente duplicadas`}
+              </Text>
+            </Group>
+            {matches.map((tx) => (
+              <Card
+                key={tx.id}
+                withBorder
+                padding="sm"
+                data-testid={ImportTestIds.DrawerDuplicatesTransactionCard(tx.id)}
+              >
+                <Group justify="space-between" wrap="nowrap">
+                  <Stack gap={2}>
+                    <Text fw={500} fz="sm">
+                      {tx.description}
                     </Text>
-                    <Badge size="xs" variant="light">
-                      {accountName(tx.account_id)}
-                    </Badge>
-                  </Group>
-                </Stack>
-                <Text fw={600} fz="sm">
-                  {formatBalance(tx.amount)}
-                </Text>
-              </Group>
-            </Card>
-          ))}
-        </Stack>
+                    <Group gap={6}>
+                      <Text fz="xs" c="dimmed">
+                        {formatDate(tx.date)}
+                      </Text>
+                      <Badge size="xs" variant="light">
+                        {accountName(tx.account_id)}
+                      </Badge>
+                    </Group>
+                  </Stack>
+                  <Text fw={600} fz="sm">
+                    {formatBalance(tx.amount)}
+                  </Text>
+                </Group>
+              </Card>
+            ))}
+          </Stack>
+        )}
+
+        {hasSettlements && (
+          <Stack gap={4} data-testid={ImportTestIds.DrawerDuplicatesSettlementsSection}>
+            <Group gap={6}>
+              <IconArrowsExchange size={16} color="var(--mantine-color-teal-6)" />
+              <Text fz="xs" c="dimmed" tt="uppercase" fw={600}>
+                {settlementMatches.length === 1
+                  ? '1 liquidação possivelmente duplicada'
+                  : `${settlementMatches.length} liquidações possivelmente duplicadas`}
+              </Text>
+            </Group>
+            {settlementMatches.map((st) => (
+              <Card
+                key={st.id}
+                withBorder
+                padding="sm"
+                data-testid={ImportTestIds.DrawerDuplicatesSettlementCard(st.id)}
+              >
+                <Group justify="space-between" wrap="nowrap">
+                  <Stack gap={2}>
+                    <Text fw={500} fz="sm">
+                      {st.description || '—'}
+                    </Text>
+                    <Group gap={6}>
+                      <Text fz="xs" c="dimmed">
+                        {formatDate(st.date)}
+                      </Text>
+                      <Badge size="xs" variant="light" color="teal">
+                        {accountName(st.account_id)}
+                      </Badge>
+                      <Badge size="xs" variant="outline" color="teal">
+                        {st.type === 'credit' ? 'Liquidação · crédito' : 'Liquidação · débito'}
+                      </Badge>
+                    </Group>
+                  </Stack>
+                  <Text fw={600} fz="sm">
+                    {formatBalance(st.amount)}
+                  </Text>
+                </Group>
+              </Card>
+            ))}
+          </Stack>
+        )}
 
         <Button
           color="red"

--- a/frontend/src/components/transactions/import/ImportReviewRow.tsx
+++ b/frontend/src/components/transactions/import/ImportReviewRow.tsx
@@ -71,6 +71,7 @@ export const ImportReviewRow = memo(
       sourceAccountId,
       destinationAccountId,
       duplicateMatches,
+      settlementMatches,
     ] = useWatch({
       control: form.control,
       name: [
@@ -86,6 +87,7 @@ export const ImportReviewRow = memo(
         `rows.${rowIndex}.account_id`,
         `rows.${rowIndex}.destination_account_id`,
         `rows.${rowIndex}.duplicate_matches`,
+        `rows.${rowIndex}.settlement_matches`,
       ],
     });
 
@@ -112,6 +114,7 @@ export const ImportReviewRow = memo(
         <DuplicateTransactionsDrawer
           row={{ date: row.date, description: row.description, amount: row.amount }}
           matches={row.duplicate_matches ?? []}
+          settlementMatches={row.settlement_matches ?? []}
           criteria={criteria ?? undefined}
         />
       ))
@@ -149,7 +152,7 @@ export const ImportReviewRow = memo(
           </Tooltip>
         );
       }
-      if (duplicateMatches?.length) {
+      if (duplicateMatches?.length || settlementMatches?.length) {
         return (
           <Tooltip label="Possível duplicidade detectada" withArrow>
             <ActionIcon
@@ -579,12 +582,13 @@ function RecurrencePopover({ namePrefix, summary, hasRecurrence, disabled }: Rec
 
 function RowDuplicateCheck({ rowIndex }: { rowIndex: number }) {
   const form = useFormContext<ImportFormValues>();
-  const [date, amount, description, action] = useWatch({
+  const [date, amount, description, type, action] = useWatch({
     control: form.control,
     name: [
       `rows.${rowIndex}.date`,
       `rows.${rowIndex}.amount`,
       `rows.${rowIndex}.description`,
+      `rows.${rowIndex}.transaction_type`,
       `rows.${rowIndex}.action`,
     ],
   });
@@ -593,9 +597,13 @@ function RowDuplicateCheck({ rowIndex }: { rowIndex: number }) {
     date: date as string,
     amount: amount as number,
     description: description as string,
+    type: type as Transactions.TransactionType,
     accountId: form.getValues("accountId"),
     enabled: action === "import",
-    onResult: (matches) => form.setValue(`rows.${rowIndex}.duplicate_matches`, matches),
+    onResult: ({ matches, settlement_matches }) => {
+      form.setValue(`rows.${rowIndex}.duplicate_matches`, matches);
+      form.setValue(`rows.${rowIndex}.settlement_matches`, settlement_matches);
+    },
   });
 
   return null;

--- a/frontend/src/components/transactions/import/importPayload.ts
+++ b/frontend/src/components/transactions/import/importPayload.ts
@@ -62,6 +62,7 @@ export function parsedRowToFormValues(
     import_status: 'idle',
     import_error: '',
     duplicate_matches: r.duplicate_matches ?? [],
+    settlement_matches: r.settlement_matches ?? [],
     account_id: accountId,
     date: r.date ?? '',
     description: r.description,

--- a/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
+++ b/frontend/src/hooks/import/useDuplicateTransactionCheck.ts
@@ -9,9 +9,14 @@ interface Args {
   date: string
   amount: number
   description: string
+  type: Transactions.TransactionType
   accountId: number
-  /** Receives the latest duplicate matches whenever a re-check resolves. */
-  onResult: (matches: Transactions.Transaction[]) => void
+  /** Receives the latest transaction and settlement matches whenever a
+   * re-check resolves. Both are overwritten on every result. */
+  onResult: (result: {
+    matches: Transactions.Transaction[]
+    settlement_matches: Transactions.SettlementMatch[]
+  }) => void
   debounceMs?: number
   /** When false, the hook never calls the backend. Default `true`. */
   enabled?: boolean
@@ -34,6 +39,7 @@ export function useDuplicateTransactionCheck({
   date,
   amount,
   description,
+  type,
   accountId,
   onResult,
   debounceMs = 500,
@@ -42,14 +48,16 @@ export function useDuplicateTransactionCheck({
   const [debouncedDate] = useDebouncedValue(date, debounceMs)
   const [debouncedAmount] = useDebouncedValue(amount, debounceMs)
   const [debouncedDescription] = useDebouncedValue(description, debounceMs)
+  const [debouncedType] = useDebouncedValue(type, debounceMs)
 
   // Captured once on mount: the CSV parse already returned matches for these
   // values, so a check only fires once a field differs from what was imported.
-  const [initial] = useState({ date, amount, description })
+  const [initial] = useState({ date, amount, description, type })
   const fieldsChanged =
     debouncedDate !== initial.date ||
     debouncedAmount !== initial.amount ||
-    debouncedDescription !== initial.description
+    debouncedDescription !== initial.description ||
+    debouncedType !== initial.type
 
   const { data } = useQuery({
     queryKey: [
@@ -57,6 +65,7 @@ export function useDuplicateTransactionCheck({
       debouncedDate,
       debouncedAmount,
       debouncedDescription,
+      debouncedType,
       accountId,
     ],
     queryFn: async () => {
@@ -68,10 +77,15 @@ export function useDuplicateTransactionCheck({
             date: debouncedDate,
             amount: debouncedAmount,
             description: debouncedDescription,
+            type: debouncedType,
           },
         ],
       })
-      return res.rows[0]?.matches ?? []
+      const row = res.rows[0]
+      return {
+        matches: row?.matches ?? [],
+        settlement_matches: row?.settlement_matches ?? [],
+      }
     },
     enabled: enabled && !!debouncedDate && debouncedAmount > 0 && fieldsChanged,
     staleTime: Infinity,

--- a/frontend/src/testIds/import.ts
+++ b/frontend/src/testIds/import.ts
@@ -85,6 +85,12 @@ export const ImportTestIds = {
   // Duplicate-transactions drawer
   DrawerDuplicates: 'drawer_duplicate_transactions',
   DrawerDuplicatesSkipBtn: 'btn_drawer_duplicates_skip',
+  DrawerDuplicatesTransactionsSection: 'section_drawer_duplicates_transactions',
+  DrawerDuplicatesSettlementsSection: 'section_drawer_duplicates_settlements',
+  DrawerDuplicatesTransactionCard: (id: number) =>
+    `card_drawer_duplicates_transaction_${id}` as const,
+  DrawerDuplicatesSettlementCard: (id: number) =>
+    `card_drawer_duplicates_settlement_${id}` as const,
 
   // Category-creation drawer (mounted from the import flow)
   DrawerCreateCategory: 'drawer_create_category',

--- a/frontend/src/types/transactions.ts
+++ b/frontend/src/types/transactions.ts
@@ -227,6 +227,22 @@ export namespace Transactions {
     parse_errors?: string[];
     /** Existing transactions detected as possible duplicates of this row. */
     duplicate_matches?: Transaction[];
+    /** Existing settlements detected as possible duplicates of this row.
+     * Populated only for income/expense rows on the destination account
+     * (income vs credit settlements, expense vs debit settlements). */
+    settlement_matches?: SettlementMatch[];
+  }
+
+  /** A settlement flagged as a possible duplicate of an imported row.
+   * Description is hydrated from the source transaction. */
+  export interface SettlementMatch {
+    id: number;
+    account_id: number;
+    amount: number; // cents
+    type: "credit" | "debit";
+    date: string;
+    source_transaction_id: number;
+    description: string;
   }
 
   export type TypeDefinitionRule = "positive_as_income" | "positive_as_expense";
@@ -249,6 +265,7 @@ export namespace Transactions {
   export interface CheckDuplicateRowResult {
     row_index: number;
     matches: Transaction[];
+    settlement_matches?: SettlementMatch[];
   }
 
   export interface ImportRowState {


### PR DESCRIPTION
## Summary

Extends the import duplicate detection system to flag settlements (credit/debit records from shared expenses) as possible duplicates, in addition to existing transactions. When importing an income row on a connection account, the system now matches it against credit settlements from shared expenses; expense rows match against debit settlements. This surfaces settlement matches in a dedicated UI section, distinct from transaction matches.

## Key Changes

**Backend:**
- Added `SettlementMatch` domain type to represent a settlement flagged as a duplicate, hydrated with the source transaction's description for fuzzy matching
- Implemented `searchSettlementMonthWindow()` to fetch settlements for a calendar month, hydrated with source transaction descriptions
- Implemented `allowedSettlementTypeFor()` to determine which settlement type (credit/debit) can duplicate a given transaction type (income/expense); transfers skip settlement matching entirely
- Implemented `filterSettlementDuplicateMatches()` to filter settlement candidates by amount tolerance (±2 cents), description similarity (trigram-based), and settlement type alignment
- Updated `checkDuplicatesByWindow()` to return both transaction and settlement matches per row, with lazy-loading of settlement windows only when needed
- Updated `detectDuplicateRows()` to populate both `DuplicateMatches` and `SettlementMatches` on parsed rows
- Extended `CheckDuplicateRowResult` to include `settlement_matches` field
- Extended `ParsedImportRow` to include `settlement_matches` field
- Added `Type` field to `CheckDuplicateRowInput` so the service knows whether to match against credit or debit settlements
- Updated settlement repository filter to support date range queries (`StartDate`, `EndDate`) and settlement type filtering
- Updated API documentation (Swagger/OpenAPI) to reflect settlement matching capability

**Frontend:**
- Updated `DuplicateTransactionsDrawer` to render two independent sections: existing transactions and existing settlements, each with its own header and card list
- Added settlement-specific styling (teal icon for settlements vs. orange for transactions)
- Updated `useDuplicateTransactionCheck` hook to accept transaction type and return both transaction and settlement matches
- Updated `ImportReviewRow` to pass settlement matches to the drawer
- Extended form schema and payload parsing to handle `settlement_matches`
- Added test IDs for settlement sections and cards in the drawer
- Updated API client to include transaction type in duplicate check requests

**E2E Tests:**
- Added comprehensive test suite (`import-settlement-duplicates.spec.ts`) covering:
  - Income row matching credit settlement on the same connection account when amount, description, and month align
  - Expense row not matching credit settlement (type mismatch)
  - Transfer row never matching settlements
  - Different month preventing matches
  - Amount outside tolerance preventing matches
  - Description mismatch preventing matches
  - Transfer row type change clearing settlement matches

## Implementation Details

- Settlement matching uses the same trigram similarity and amount tolerance thresholds as transaction matching (≥0.8 similarity, ±2 cents)
- Settlements are only fetched for calendar months that contain rows needing settlement matching (lazy-loading optimization)
- Settlement descriptions are hydrated from source transactions at query time, enabling fuzzy matching without storing descriptions on settlements themselves
- The system gracefully handles nil settlements and missing source transactions without panicking
- Empty descriptions skip similarity checks, allowing amount-only matching

https://claude.ai/code/session_01EJSrfwFUEHKK2Qexisokqz