### PR TITLE
Add keyboard shortcuts for form submission and drawer creation

### DIFF
--- a/frontend/src/components/ShortcutHint.tsx
+++ b/frontend/src/components/ShortcutHint.tsx
@@ -1,5 +1,4 @@
 import { Group, Kbd } from '@mantine/core'
-import { useIsMobile } from '@/hooks/useIsMobile'
 
 const isMac =
   typeof navigator !== 'undefined' && /Mac|iPhone|iPod|iPad/i.test(navigator.userAgent)
@@ -13,13 +12,12 @@ interface ShortcutHintProps {
 
 /**
  * Inline `Kbd` group rendered next to a button label to advertise a keyboard
- * shortcut. Hidden on mobile (no physical keyboard).
+ * shortcut. Hidden on mobile (no physical keyboard) via a CSS breakpoint, so
+ * it never flashes and stays hidden even inside the isolated drawer roots.
  */
 export function ShortcutHint({ keys }: ShortcutHintProps) {
-  const isMobile = useIsMobile()
-  if (isMobile) return null
   return (
-    <Group gap={4} wrap="nowrap" aria-hidden>
+    <Group gap={4} wrap="nowrap" aria-hidden visibleFrom="sm">
       {keys.map((k) => (
         <Kbd key={k} size="xs">
           {k}

--- a/frontend/src/components/ShortcutHint.tsx
+++ b/frontend/src/components/ShortcutHint.tsx
@@ -1,0 +1,30 @@
+import { Group, Kbd } from '@mantine/core'
+import { useIsMobile } from '@/hooks/useIsMobile'
+
+const isMac =
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPod|iPad/i.test(navigator.userAgent)
+
+export const MOD_LABEL = isMac ? '⌘' : 'Ctrl'
+
+interface ShortcutHintProps {
+  /** Pre-rendered key labels — caller decides the modifier label (e.g. via MOD_LABEL). */
+  keys: string[]
+}
+
+/**
+ * Inline `Kbd` group rendered next to a button label to advertise a keyboard
+ * shortcut. Hidden on mobile (no physical keyboard).
+ */
+export function ShortcutHint({ keys }: ShortcutHintProps) {
+  const isMobile = useIsMobile()
+  if (isMobile) return null
+  return (
+    <Group gap={4} wrap="nowrap" aria-hidden>
+      {keys.map((k) => (
+        <Kbd key={k} size="xs">
+          {k}
+        </Kbd>
+      ))}
+    </Group>
+  )
+}

--- a/frontend/src/components/accounts/AccountForm.tsx
+++ b/frontend/src/components/accounts/AccountForm.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Stack, TextInput, Textarea, Button, Group, Alert } from '@mantine/core'
 import { CurrencyInput } from '@/components/transactions/form/CurrencyInput'
+import { ShortcutHint, MOD_LABEL } from '@/components/ShortcutHint'
 import { ColorSwatchPicker, DEFAULT_AVATAR_COLOR } from '@/components/accounts/ColorSwatchPicker'
 import { useResetFormOnChange } from '@/hooks/useResetFormOnChange'
 import { Transactions } from '@/types/transactions'
@@ -63,8 +64,17 @@ export function AccountForm({ initialValues, onSubmit, isPending, error }: Props
   const initialBalance = useWatch({ control, name: 'initial_balance' })
   const avatarColor = useWatch({ control, name: 'avatar_background_color' })
 
+  const submit = handleSubmit(onSubmit)
+
+  function handleFormKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault()
+      void submit()
+    }
+  }
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)} noValidate data-testid={AccountsTestIds.Form}>
+    <form onSubmit={submit} onKeyDown={handleFormKeyDown} noValidate data-testid={AccountsTestIds.Form}>
       <Stack gap="md">
         {error && (
           <Alert color="red" title="Erro" variant="light">
@@ -103,7 +113,12 @@ export function AccountForm({ initialValues, onSubmit, isPending, error }: Props
         />
 
         <Group justify="flex-end" mt="sm">
-          <Button type="submit" loading={isPending} data-testid={AccountsTestIds.BtnSave}>
+          <Button
+            type="submit"
+            loading={isPending}
+            rightSection={<ShortcutHint keys={[MOD_LABEL, '↵']} />}
+            data-testid={AccountsTestIds.BtnSave}
+          >
             Salvar
           </Button>
         </Group>

--- a/frontend/src/components/charges/CreateChargeDrawer.tsx
+++ b/frontend/src/components/charges/CreateChargeDrawer.tsx
@@ -32,6 +32,7 @@ import { formatBalance } from "@/utils/formatCents";
 import { localDateStr } from "@/utils/parseDate";
 import { Charges } from "@/types/charges";
 import { ChargesTestIds } from '@/testIds'
+import { ShortcutHint, MOD_LABEL } from '@/components/ShortcutHint'
 
 const createChargeSchema = z.object({
   connection_id: z.number("Selecione uma conexao"),
@@ -176,7 +177,16 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
       title="Criar Cobrança"
       data-testid={ChargesTestIds.DrawerCreate}
     >
-      <form onSubmit={form.handleSubmit(handleSubmit)} noValidate>
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        onKeyDown={(e) => {
+          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+            e.preventDefault();
+            void form.handleSubmit(handleSubmit)();
+          }
+        }}
+        noValidate
+      >
         <Stack gap="md">
           {submitError && (
             <Alert color="red" title="Erro" variant="light">
@@ -328,6 +338,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
             loading={mutation.isPending}
             disabled={mutation.isPending}
             fullWidth
+            rightSection={<ShortcutHint keys={[MOD_LABEL, "↵"]} />}
             data-testid={ChargesTestIds.BtnSubmitCreate}
           >
             Criar Cobrança

--- a/frontend/src/components/transactions/form/TransactionForm.tsx
+++ b/frontend/src/components/transactions/form/TransactionForm.tsx
@@ -20,6 +20,7 @@ import {
   ComboboxItemGroup,
   ComboboxItem,
 } from "@mantine/core";
+import { ShortcutHint, MOD_LABEL } from "@/components/ShortcutHint";
 import { DatePickerInput } from "@mantine/dates";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useGroupedAccountOptions } from "@/hooks/useGroupedAccountOptions";
@@ -182,8 +183,17 @@ export const TransactionForm = ({
     };
   }
 
+  const submit = handleSubmit(onSubmit, onInvalid);
+
+  function handleFormKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      e.preventDefault();
+      void submit();
+    }
+  }
+
   return (
-    <form onSubmit={handleSubmit(onSubmit, onInvalid)} noValidate>
+    <form onSubmit={submit} onKeyDown={handleFormKeyDown} noValidate>
       <Stack gap="md">
         {generalError && (
           <Alert color="red" title="Erro" variant="light" data-testid={TransactionsTestIds.AlertFormError}>
@@ -425,7 +435,12 @@ export const TransactionForm = ({
               Salvar e criar outra
             </Button>
           )}
-          <Button type="submit" loading={isSubmitting || isPending} data-testid={TransactionsTestIds.BtnSave}>
+          <Button
+            type="submit"
+            loading={isSubmitting || isPending}
+            rightSection={<ShortcutHint keys={[MOD_LABEL, "↵"]} />}
+            data-testid={TransactionsTestIds.BtnSave}
+          >
             Salvar
           </Button>
         </Group>

--- a/frontend/src/hooks/useHotkey.ts
+++ b/frontend/src/hooks/useHotkey.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react'
+
+interface ParsedHotkey {
+  key: string
+  mod: boolean
+  shift: boolean
+  alt: boolean
+}
+
+function parseHotkey(spec: string): ParsedHotkey {
+  const parts = spec.toLowerCase().split('+').map((p) => p.trim())
+  return {
+    mod: parts.includes('mod') || parts.includes('ctrl') || parts.includes('cmd'),
+    shift: parts.includes('shift'),
+    alt: parts.includes('alt'),
+    key: parts[parts.length - 1],
+  }
+}
+
+function matches(event: KeyboardEvent, hk: ParsedHotkey): boolean {
+  const mod = event.ctrlKey || event.metaKey
+  if (hk.mod !== mod) return false
+  if (hk.shift !== event.shiftKey) return false
+  if (hk.alt !== event.altKey) return false
+  return event.key.toLowerCase() === hk.key
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  if (target.isContentEditable) return true
+  return false
+}
+
+function isModalOpen(): boolean {
+  return document.querySelector('[aria-modal="true"]') !== null
+}
+
+interface UseHotkeyOptions {
+  enabled?: boolean
+  /** When true, fires even if focus is in an input/textarea (needed for in-form submits). */
+  allowInTyping?: boolean
+  /** When true, fires even if a modal/drawer is open (the default suppresses page hotkeys while a drawer is up). */
+  allowWithModal?: boolean
+}
+
+/**
+ * Page-level keyboard shortcut. By default it is suppressed while the user is
+ * typing in a field or while a Mantine drawer/modal is open, so a stray `n`
+ * inside a search box won't open the create drawer.
+ */
+export function useHotkey(spec: string, callback: () => void, options: UseHotkeyOptions = {}) {
+  const { enabled = true, allowInTyping = false, allowWithModal = false } = options
+
+  const callbackRef = useRef(callback)
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    if (!enabled) return
+    const hk = parseHotkey(spec)
+
+    function handler(event: KeyboardEvent) {
+      if (!matches(event, hk)) return
+      if (!allowInTyping && isTypingTarget(event.target)) return
+      if (!allowWithModal && isModalOpen()) return
+      event.preventDefault()
+      callbackRef.current()
+    }
+
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [spec, enabled, allowInTyping, allowWithModal])
+}

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -4,10 +4,12 @@ import { useAccounts } from '@/hooks/useAccounts'
 import { useActivateAccount } from '@/hooks/useActivateAccount'
 import { useDeleteAccount } from '@/hooks/useDeleteAccount'
 import { useIsMobile } from '@/hooks/useIsMobile'
+import { useHotkey } from '@/hooks/useHotkey'
 import { AccountDrawer } from '@/components/accounts/AccountDrawer'
 import { AccountSection } from '@/components/accounts/AccountSection'
 import { Fab } from '@/components/Fab'
 import { PullToRefresh } from '@/components/PullToRefresh'
+import { ShortcutHint } from '@/components/ShortcutHint'
 import { renderDrawer } from '@/utils/renderDrawer'
 import { Transactions } from '@/types/transactions'
 import { AccountsTestIds } from '@/testIds'
@@ -35,6 +37,8 @@ export function AccountsPage() {
     void renderDrawer(() => <AccountDrawer />)
   }
 
+  useHotkey('n', handleAdd)
+
   const hasAccounts = (query.data?.length ?? 0) > 0
   const isMobile = useIsMobile()
 
@@ -44,7 +48,12 @@ export function AccountsPage() {
       <Group justify="space-between" align="center">
         <Text fw={700} size="xl">Contas</Text>
         {!isMobile && (
-          <Button leftSection={<IconPlus size={16} />} onClick={handleAdd} data-testid={AccountsTestIds.BtnNew}>
+          <Button
+            leftSection={<IconPlus size={16} />}
+            rightSection={<ShortcutHint keys={['N']} />}
+            onClick={handleAdd}
+            data-testid={AccountsTestIds.BtnNew}
+          >
             Nova Conta
           </Button>
         )}

--- a/frontend/src/pages/ChargesPage.tsx
+++ b/frontend/src/pages/ChargesPage.tsx
@@ -4,6 +4,7 @@ import { IconPlus } from "@tabler/icons-react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useMe } from "@/hooks/useMe";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useHotkey } from "@/hooks/useHotkey";
 import { useTransactions } from "@/hooks/useTransactions";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useCharges } from "@/hooks/useCharges";
@@ -13,6 +14,7 @@ import { useCancelCharge } from "@/hooks/useCancelCharge";
 import { renderDrawer } from "@/utils/renderDrawer";
 import { Fab } from "@/components/Fab";
 import { PullToRefresh } from "@/components/PullToRefresh";
+import { ShortcutHint } from "@/components/ShortcutHint";
 import { Charges } from "@/types/charges";
 import { ChargeCard } from "@/components/charges/ChargeCard";
 import { ConfirmChargeActionDrawer, type ConfirmChargeAction } from "@/components/charges/ConfirmChargeActionDrawer";
@@ -94,6 +96,8 @@ export function ChargesPage() {
     void renderDrawer(() => <CreateChargeDrawer periodMonth={search.month} periodYear={search.year} />);
   }
 
+  useHotkey("n", openCreateCharge);
+
   async function refreshAll() {
     await Promise.all([invalidateCharges(), invalidatePendingCount()]);
   }
@@ -121,6 +125,7 @@ export function ChargesPage() {
           {!isMobile && (
             <Button
               leftSection={<IconPlus size={16} />}
+              rightSection={<ShortcutHint keys={["N"]} />}
               onClick={openCreateCharge}
               data-testid={ChargesTestIds.BtnNew}
             >

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useMemo, useState } from "react";
 import { useMe } from "@/hooks/useMe";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useHotkey } from "@/hooks/useHotkey";
 import { useActiveFilters } from "@/hooks/useActiveFilters";
 import { useTransactions } from "@/hooks/useTransactions";
 import { useAccounts } from "@/hooks/useAccounts";
@@ -20,6 +21,7 @@ import { PeriodNavigator } from "@/components/transactions/PeriodNavigator";
 import { TransactionFilters } from "@/components/transactions/TransactionFilters";
 import { TransactionList } from "@/components/transactions/TransactionList";
 import { SelectionActionBar } from "@/components/transactions/SelectionActionBar";
+import { ShortcutHint } from "@/components/ShortcutHint";
 import { PropagationSettingsDrawer, PropagationSetting } from "@/components/transactions/PropagationSettingsDrawer";
 import { BulkProgressDrawer, BulkProgressItem } from "@/components/transactions/BulkProgressDrawer";
 import { BulkDivisionDrawer } from "@/components/transactions/BulkDivisionDrawer";
@@ -464,6 +466,11 @@ export function TransactionsPage() {
   const isSelecting = selectedIds.size > 0 || selectedSettlementIds.size > 0;
   const totalSelected = selectedIds.size + selectedSettlementIds.size;
 
+  const openCreateTransaction = useCallback(() => {
+    void renderDrawer(() => <CreateTransactionDrawer />);
+  }, []);
+  useHotkey("n", openCreateTransaction, { enabled: !isSelecting });
+
   async function handleSwipeDelete(tx: Transactions.Transaction) {
     try {
       let propagation: PropagationSetting | undefined;
@@ -554,7 +561,8 @@ export function TransactionsPage() {
             <Group gap="xs">
               <Button
                 leftSection={<IconPlus size={16} />}
-                onClick={() => void renderDrawer(() => <CreateTransactionDrawer />)}
+                rightSection={<ShortcutHint keys={["N"]} />}
+                onClick={openCreateTransaction}
                 data-testid={TransactionsTestIds.BtnNew}
               >
                 Nova Transação


### PR DESCRIPTION
## Summary
Introduces keyboard shortcut support across the application with a new `useHotkey` hook and `ShortcutHint` component. Users can now submit forms with `Ctrl+Enter` (or `Cmd+Enter` on Mac) and open creation drawers with the `N` key.

## Key Changes

- **New `useHotkey` hook** (`frontend/src/hooks/useHotkey.ts`): Provides page-level keyboard shortcut handling with intelligent suppression:
  - Disabled while typing in input/textarea/select fields (configurable via `allowInTyping`)
  - Disabled while modals/drawers are open (configurable via `allowWithModal`)
  - Cross-platform modifier key support (Ctrl/Cmd)
  - Prevents default browser behavior for registered shortcuts

- **New `ShortcutHint` component** (`frontend/src/components/ShortcutHint.ts`): Displays keyboard shortcut hints next to buttons:
  - Shows platform-appropriate modifier label (⌘ on Mac, Ctrl on others)
  - Hidden on mobile devices (no physical keyboard)
  - Uses Mantine's `Kbd` component for consistent styling

- **Form submission shortcuts**: Added `Ctrl+Enter` / `Cmd+Enter` support to:
  - `AccountForm`
  - `TransactionForm`
  - `CreateChargeDrawer`
  - Each form displays the shortcut hint on its submit button

- **Creation drawer shortcuts**: Added `N` key to open creation drawers on:
  - `AccountsPage` (new account)
  - `TransactionsPage` (new transaction, disabled while items are selected)
  - `ChargesPage` (new charge)
  - Each button displays the shortcut hint

## Implementation Details

- The `useHotkey` hook uses a ref-based callback pattern to avoid dependency issues while keeping the handler up-to-date
- Hotkey specs use a simple string format: `"mod+shift+k"` or `"ctrl+alt+enter"`
- Modal detection uses the standard `[aria-modal="true"]` attribute (Mantine convention)
- Form handlers prevent default and call the submit function directly to maintain form validation flow

https://claude.ai/code/session_01T1hw1RGqa2DuZBiNQJ7BmK