### PR TITLE
Fix settlement balance accounting and connection account initial balance

### DIFF
--- a/backend/internal/repository/transaction_repository.go
+++ b/backend/internal/repository/transaction_repository.go
@@ -378,16 +378,23 @@ func (r *transactionRepository) GetBalance(ctx context.Context, filter domain.Ba
 			)
 		}
 	} else {
-		// Settlements leg — filtered by account_id only (no category/tag columns on settlements)
+		// Settlements leg — filtered by account_id only (no category/tag columns on settlements).
+		// Bucket settlements by their own date (s.date), not the source transaction's
+		// date (t.date): settlement dates are user-customizable and decoupled from the
+		// source transaction. The transaction list places settlements by s.date, so
+		// using t.date here would put a settlement in a different month than the list
+		// shows, making the accumulated balance disagree with the displayed running
+		// balance. The join still excludes settlements whose source transaction was
+		// soft-deleted, matching FindOrphanedSettlementTransactions.
 		settlementSQL := `SELECT CASE WHEN s.type = 'credit' THEN s.amount ELSE -s.amount END AS amount
 			FROM settlements s
 			JOIN transactions t ON t.id = s.source_transaction_id
-			WHERE s.user_id = ? AND t.date <= ?`
+			WHERE t.deleted_at IS NULL AND s.user_id = ? AND s.date <= ?`
 		args = append(args, filter.UserID, endDate)
 
 		if !filter.Accumulated {
 			startDate := filter.Period.StartDate()
-			settlementSQL += " AND t.date >= ?"
+			settlementSQL += " AND s.date >= ?"
 			args = append(args, startDate)
 		}
 

--- a/backend/internal/repository/transaction_repository.go
+++ b/backend/internal/repository/transaction_repository.go
@@ -361,7 +361,16 @@ func (r *transactionRepository) GetBalance(ctx context.Context, filter domain.Ba
 	var combined string
 	if filter.HideSettlements {
 		if filter.Accumulated {
-			initialBalanceSQL := `SELECT initial_balance AS amount FROM accounts WHERE user_id = ?`
+			// Connection accounts cannot hold an opening balance (the account
+			// service rejects setting one), so they must never contribute
+			// initial_balance to the accumulated total. Exclude any account
+			// referenced by a user_connection.
+			initialBalanceSQL := `SELECT initial_balance AS amount FROM accounts
+				WHERE user_id = ?
+				AND NOT EXISTS (
+					SELECT 1 FROM user_connections uc
+					WHERE uc.from_account_id = accounts.id OR uc.to_account_id = accounts.id
+				)`
 			args = append(args, filter.UserID)
 			if len(filter.AccountIDs) > 0 {
 				initialBalanceSQL += " AND id IN ?"
@@ -408,7 +417,16 @@ func (r *transactionRepository) GetBalance(ctx context.Context, filter domain.Ba
 		}
 
 		if filter.Accumulated {
-			initialBalanceSQL := `SELECT initial_balance AS amount FROM accounts WHERE user_id = ?`
+			// Connection accounts cannot hold an opening balance (the account
+			// service rejects setting one), so they must never contribute
+			// initial_balance to the accumulated total. Exclude any account
+			// referenced by a user_connection.
+			initialBalanceSQL := `SELECT initial_balance AS amount FROM accounts
+				WHERE user_id = ?
+				AND NOT EXISTS (
+					SELECT 1 FROM user_connections uc
+					WHERE uc.from_account_id = accounts.id OR uc.to_account_id = accounts.id
+				)`
 			args = append(args, filter.UserID)
 			if len(filter.AccountIDs) > 0 {
 				initialBalanceSQL += " AND id IN ?"

--- a/backend/internal/service/transaction_balance_test.go
+++ b/backend/internal/service/transaction_balance_test.go
@@ -1404,6 +1404,59 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Accumulated_Spans
 	suite.Assert().Equal(int64(6000), resultAccum.Balance)
 }
 
+// TestGetBalance_Accumulated_ExcludesConnectionAccountInitialBalance verifies
+// that the accumulated balance does NOT add a connection account's
+// initial_balance. Connection accounts represent a shared ledger and have no
+// opening balance; if one carries a stale initial_balance (e.g. it held a
+// balance before becoming a connection account), it must not inflate the
+// accumulated total.
+func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Accumulated_ExcludesConnectionAccountInitialBalance() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	// Force a stale initial_balance onto the connection account, bypassing the
+	// account service guard, to simulate an account that carried a balance
+	// before it became a connection account.
+	err = suite.DB.Exec(
+		"UPDATE accounts SET initial_balance = ? WHERE id = ?",
+		int64(25000), conn.FromAccountID,
+	).Error
+	suite.Require().NoError(err)
+
+	date := now()
+	period := domain.Period{Month: int(date.Month()), Year: date.Year()}
+
+	// Accumulated balance for the connection account must be 0 — its stale
+	// initial_balance is excluded.
+	result, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
+		Accumulated: true,
+		AccountIDs:  []int{conn.FromAccountID},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(0), result.Balance)
+
+	// A regular account's initial_balance is still included.
+	regular, err := suite.Repos.Account.Create(ctx, &domain.Account{
+		UserID:         user1.ID,
+		Name:           "regular account",
+		InitialBalance: 7000,
+	})
+	suite.Require().NoError(err)
+
+	resultRegular, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
+		Accumulated: true,
+		AccountIDs:  []int{regular.ID},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(7000), resultRegular.Balance)
+}
+
 func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Accumulated_ConnectionAccountRejectsInitialBalance() {
 	ctx := context.Background()
 	user1, err := suite.createTestUser(ctx)

--- a/backend/internal/service/transaction_balance_test.go
+++ b/backend/internal/service/transaction_balance_test.go
@@ -106,6 +106,79 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_IncludesSettlemen
 	suite.Assert().Equal(int64(-500), result.Balance)
 }
 
+// TestGetBalance_SettlementCountedBySettlementDate verifies that a settlement
+// contributes to the balance of the month of its own date (s.date), not the
+// month of its source transaction (t.date). Settlement dates are user-
+// customizable via SplitSettings.Date and decoupled from the source
+// transaction, and the transaction list buckets settlements by s.date — the
+// balance must agree so the accumulated balance matches the displayed list.
+func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_SettlementCountedBySettlementDate() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	personal1, err := suite.createTestAccount(ctx, user1)
+	suite.Require().NoError(err)
+	category, err := suite.createTestCategory(ctx, user1)
+	suite.Require().NoError(err)
+
+	lastMonth := clampToEndOfMonth(now(), now().Year(), now().Month()-1)
+	thisMonth := now()
+	lastMonthPeriod := domain.Period{Month: int(lastMonth.Month()), Year: lastMonth.Year()}
+	thisMonthPeriod := domain.Period{Month: int(thisMonth.Month()), Year: thisMonth.Year()}
+
+	// Source transaction dated last month, but the settlement's date is
+	// overridden to this month via SplitSettings.Date.
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		TransactionType: domain.TransactionTypeExpense,
+		AccountID:       personal1.ID,
+		CategoryID:      category.ID,
+		Amount:          1000,
+		Date:            domain.Date{Time: lastMonth},
+		Description:     "split expense, settlement moved to this month",
+		SplitSettings: []domain.SplitSettings{
+			{ConnectionID: conn.ID, Percentage: lo.ToPtr(50), Date: &domain.Date{Time: thisMonth}},
+		},
+	})
+	suite.Require().NoError(err)
+
+	// The settlement credit (+500) belongs to THIS month — its own date —
+	// not last month, where the source transaction lives.
+	resultThisMonth, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, thisMonthPeriod, domain.BalanceFilter{
+		AccountIDs: []int{conn.FromAccountID},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(500), resultThisMonth.Balance)
+
+	// Last month's balance must NOT include a settlement dated this month.
+	resultLastMonth, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, lastMonthPeriod, domain.BalanceFilter{
+		AccountIDs: []int{conn.FromAccountID},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(0), resultLastMonth.Balance)
+
+	// Accumulated through last month must NOT include a settlement dated this month.
+	resultAccumLastMonth, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, lastMonthPeriod, domain.BalanceFilter{
+		AccountIDs:  []int{conn.FromAccountID},
+		Accumulated: true,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(0), resultAccumLastMonth.Balance)
+
+	// Accumulated through this month includes it.
+	resultAccumThisMonth, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, thisMonthPeriod, domain.BalanceFilter{
+		AccountIDs:  []int{conn.FromAccountID},
+		Accumulated: true,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(500), resultAccumThisMonth.Balance)
+}
+
 func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_SettlementDoesNotLeakIntoPrivateAccount() {
 	ctx := context.Background()
 	user1, err := suite.createTestUser(ctx)

--- a/backend/internal/service/transaction_balance_test.go
+++ b/backend/internal/service/transaction_balance_test.go
@@ -179,6 +179,72 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_SettlementCounted
 	suite.Assert().Equal(int64(500), resultAccumThisMonth.Balance)
 }
 
+// TestGetBalance_ExcludesSettlementsWithDeletedSourceTransaction verifies that
+// a settlement whose source transaction was soft-deleted no longer counts
+// toward the balance. The transaction list (FindOrphanedSettlementTransactions)
+// already filters t.deleted_at IS NULL; GetBalance must do the same, otherwise
+// such orphaned settlements silently inflate the (accumulated) balance while
+// never appearing in the list.
+func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_ExcludesSettlementsWithDeletedSourceTransaction() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	personal1, err := suite.createTestAccount(ctx, user1)
+	suite.Require().NoError(err)
+	category, err := suite.createTestCategory(ctx, user1)
+	suite.Require().NoError(err)
+
+	date := now()
+	period := domain.Period{Month: int(date.Month()), Year: date.Year()}
+
+	// split expense → settlement credit +500 on the connection account
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		TransactionType: domain.TransactionTypeExpense,
+		AccountID:       personal1.ID,
+		CategoryID:      category.ID,
+		Amount:          1000,
+		Date:            domain.Date{Time: date},
+		Description:     "split expense",
+		SplitSettings:   []domain.SplitSettings{{ConnectionID: conn.ID, Percentage: lo.ToPtr(50)}},
+	})
+	suite.Require().NoError(err)
+
+	before, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
+		AccountIDs: []int{conn.FromAccountID},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Equal(int64(500), before.Balance)
+
+	// Soft-delete the settlement's source transaction directly, leaving the
+	// settlement orphaned (the transaction list would already hide it).
+	err = suite.DB.Exec(
+		"UPDATE transactions SET deleted_at = ? WHERE account_id = ? AND deleted_at IS NULL",
+		time.Now(), personal1.ID,
+	).Error
+	suite.Require().NoError(err)
+
+	// The orphaned settlement must no longer count — neither in the period
+	// balance nor in the accumulated balance.
+	after, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
+		AccountIDs: []int{conn.FromAccountID},
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(0), after.Balance)
+
+	afterAccum, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
+		AccountIDs:  []int{conn.FromAccountID},
+		Accumulated: true,
+	})
+	suite.Require().NoError(err)
+	suite.Assert().Equal(int64(0), afterAccum.Balance)
+}
+
 func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_SettlementDoesNotLeakIntoPrivateAccount() {
 	ctx := context.Background()
 	user1, err := suite.createTestUser(ctx)

--- a/frontend/e2e/pages/ChargesPage.ts
+++ b/frontend/e2e/pages/ChargesPage.ts
@@ -1,7 +1,7 @@
 import { type Page, type Locator, expect } from "@playwright/test";
 import { ChargesTestIds, CommonTestIds, type ChargeRole } from '@/testIds'
 import {
-  NumberField,
+  CurrencyField,
   RadioField,
   SelectField,
   TextareaField,
@@ -95,9 +95,9 @@ export class ChargesPage {
     await new RadioField(this.createDrawer, ChargesTestIds.RadioRole(opts.role)).pick();
 
     if (opts.amount != null) {
-      // Mantine NumberInput uses comma as the decimal separator (locale pt-BR).
-      await new NumberField(this.createDrawer, ChargesTestIds.InputAmount).fill(
-        opts.amount.toFixed(2).replace('.', ','),
+      // opts.amount is in reais; CurrencyInput works in cents.
+      await new CurrencyField(this.createDrawer, ChargesTestIds.InputAmount).fillCents(
+        Math.round(opts.amount * 100),
       );
     }
 

--- a/frontend/src/components/charges/AcceptChargeDrawer.tsx
+++ b/frontend/src/components/charges/AcceptChargeDrawer.tsx
@@ -183,6 +183,7 @@ export function AcceptChargeDrawer({ charge, partnerName }: AcceptChargeDrawerPr
                 label="Data da transferência"
                 description="Data utilizada na transferência entre contas para quitação da cobrança"
                 placeholder="Selecione uma data"
+                valueFormat="DD/MM/YYYY"
                 value={field.value || null}
                 onChange={(date) => field.onChange(date ?? "")}
                 error={fieldState.error?.message}

--- a/frontend/src/components/charges/CreateChargeDrawer.tsx
+++ b/frontend/src/components/charges/CreateChargeDrawer.tsx
@@ -123,8 +123,8 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
     <Skeleton height={16} mt={4} width={160} />
   ) : balanceQuery.data ? (
     balanceQuery.data.balance < 0
-      ? `Voce deve ${formatBalance(Math.abs(balanceQuery.data.balance))}`
-      : `Devem a voce ${formatBalance(balanceQuery.data.balance)}`
+      ? `Você deve ${formatBalance(Math.abs(balanceQuery.data.balance))}`
+      : `Devem a você ${formatBalance(balanceQuery.data.balance)}`
   ) : undefined;
 
   function handleSubmit(values: CreateChargeFormValues) {

--- a/frontend/src/components/charges/CreateChargeDrawer.tsx
+++ b/frontend/src/components/charges/CreateChargeDrawer.tsx
@@ -7,7 +7,6 @@ import {
   Avatar,
   Button,
   Group,
-  NumberInput,
   Radio,
   Select,
   Skeleton,
@@ -16,6 +15,7 @@ import {
   Textarea,
 } from "@mantine/core";
 import { ResponsiveDrawer } from "@/components/ResponsiveDrawer";
+import { CurrencyInput } from "@/components/transactions/form/CurrencyInput";
 import { DateInput, MonthPickerInput } from "@mantine/dates";
 import { notifications } from "@mantine/notifications";
 import "@mantine/dates/styles.css";
@@ -40,7 +40,8 @@ const createChargeSchema = z.object({
   period_year: z.number(),
   description: z.string().optional(),
   role: z.enum(["charger", "payer"], { error: "Selecione seu papel" }),
-  amount: z.number().positive("Informe um valor maior que zero").optional(),
+  // Amount in cents. 0 means "not informed" — the backend uses the current balance.
+  amount: z.number().int().nonnegative(),
   date: z.string().min(1, "Selecione uma data"),
 });
 
@@ -101,7 +102,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
       period_year: periodYear,
       description: "",
       role: undefined,
-      amount: undefined,
+      amount: 0,
       date: localDateStr(new Date()),
     },
   });
@@ -135,7 +136,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
       period_year: values.period_year,
       description: values.description || undefined,
       role: values.role,
-      amount: values.amount != null ? Math.round(values.amount * 100) : undefined,
+      amount: values.amount > 0 ? values.amount : undefined,
       date: new Date(values.date).toISOString(),
     };
     mutation.mutate(payload, {
@@ -296,18 +297,11 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
             name="amount"
             control={form.control}
             render={({ field, fieldState }) => (
-              <NumberInput
+              <CurrencyInput
                 label="Valor (opcional)"
-                description="Deixe em branco para usar o saldo atual"
-                placeholder="0,00"
-                value={field.value ?? ""}
-                onChange={(v) => field.onChange(typeof v === "number" ? v : undefined)}
-                min={0}
-                step={0.01}
-                decimalScale={2}
-                thousandSeparator="."
-                decimalSeparator=","
-                prefix="R$ "
+                description="Deixe em 0,00 para usar o saldo atual"
+                value={field.value ?? 0}
+                onChange={field.onChange}
                 error={fieldState.error?.message}
                 data-testid={ChargesTestIds.InputAmount}
               />

--- a/frontend/src/components/charges/CreateChargeDrawer.tsx
+++ b/frontend/src/components/charges/CreateChargeDrawer.tsx
@@ -245,6 +245,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
               <MonthPickerInput
                 label="Periodo"
                 placeholder="Selecione o mês"
+                valueFormat="MM/YYYY"
                 value={`${watchedYear}-${String(field.value).padStart(2, "0")}-01`}
                 onChange={(date) => {
                   if (date) {
@@ -265,6 +266,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
               <DateInput
                 label="Data"
                 placeholder="Selecione uma data"
+                valueFormat="DD/MM/YYYY"
                 value={field.value || null}
                 onChange={(date) => field.onChange(date ?? "")}
                 error={fieldState.error?.message}

--- a/frontend/src/components/charges/CreateChargeDrawer.tsx
+++ b/frontend/src/components/charges/CreateChargeDrawer.tsx
@@ -34,7 +34,7 @@ import { Charges } from "@/types/charges";
 import { ChargesTestIds } from '@/testIds'
 
 const createChargeSchema = z.object({
-  connection_id: z.number("Selecione uma conexao"),
+  connection_id: z.number("Selecione uma conexão"),
   my_account_id: z.number("Selecione uma conta"),
   period_month: z.number().min(1).max(12),
   period_year: z.number(),
@@ -198,8 +198,8 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
               control={form.control}
               render={({ field, fieldState }) => (
                 <Select
-                  label="Conexao"
-                  placeholder="Selecione uma conexao"
+                  label="Conexão"
+                  placeholder="Selecione uma conexão"
                   data={connectionOptions}
                   value={field.value != null ? String(field.value) : null}
                   onChange={(val) => field.onChange(val != null ? Number(val) : undefined)}
@@ -244,7 +244,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
             render={({ field, fieldState }) => (
               <MonthPickerInput
                 label="Periodo"
-                placeholder="Selecione o mes"
+                placeholder="Selecione o mês"
                 value={`${watchedYear}-${String(field.value).padStart(2, "0")}-01`}
                 onChange={(date) => {
                   if (date) {
@@ -299,7 +299,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
             render={({ field, fieldState }) => (
               <CurrencyInput
                 label="Valor (opcional)"
-                description="Deixe em 0,00 para usar o saldo atual"
+                description="Deixe em 0,00 para usar o saldo atual da conexão"
                 value={field.value ?? 0}
                 onChange={field.onChange}
                 error={fieldState.error?.message}
@@ -309,7 +309,7 @@ export function CreateChargeDrawer({ periodMonth, periodYear }: CreateChargeDraw
           />
 
           <Textarea
-            label="Descricao (opcional)"
+            label="Descrição (opcional)"
             autosize
             minRows={2}
             {...form.register("description")}

--- a/frontend/src/components/transactions/form/CurrencyInput.tsx
+++ b/frontend/src/components/transactions/form/CurrencyInput.tsx
@@ -10,6 +10,7 @@ interface Props {
   onChange: (cents: number) => void;
   error?: string;
   label?: string;
+  description?: string;
   required?: boolean;
   disabled?: boolean;
   allowNegative?: boolean;
@@ -37,6 +38,7 @@ export const CurrencyInput = forwardRef<CurrencyInputHandle, Props>(function Cur
     onChange,
     error,
     label,
+    description,
     required,
     disabled,
     allowNegative,
@@ -100,6 +102,7 @@ export const CurrencyInput = forwardRef<CurrencyInputHandle, Props>(function Cur
     <TextInput
       ref={inputRef}
       label={label}
+      description={description}
       required={required}
       disabled={disabled}
       value={formatCents(value)}


### PR DESCRIPTION
## Summary

Fixes three related bugs in transaction balance calculation:

1. **Settlement date bucketing**: Settlements are now correctly bucketed by their own date (`s.date`), not the source transaction's date (`t.date`). This ensures the accumulated balance matches the transaction list display, which already buckets settlements by settlement date.

2. **Orphaned settlement filtering**: Settlements whose source transaction was soft-deleted are now excluded from balance calculations, matching the behavior of the transaction list's `FindOrphanedSettlementTransactions`.

3. **Connection account initial balance**: Connection accounts no longer contribute their `initial_balance` to accumulated balance calculations. Connection accounts represent a shared ledger and cannot hold an opening balance by design; any stale `initial_balance` must not inflate the accumulated total.

## Key Changes

**Backend (`transaction_repository.go`)**
- Modified settlement SQL queries to filter by `s.date` instead of `t.date` for both period and accumulated balance calculations
- Added `t.deleted_at IS NULL` check to settlement queries to exclude orphaned settlements
- Updated accumulated balance initial balance query to exclude accounts referenced in `user_connections` (both `from_account_id` and `to_account_id`)
- Added detailed comments explaining the settlement date bucketing and connection account logic

**Backend Tests (`transaction_balance_test.go`)**
- Added `TestGetBalance_SettlementCountedBySettlementDate`: Verifies settlements are bucketed by their own date, not the source transaction date, and that accumulated balance respects this boundary
- Added `TestGetBalance_ExcludesSettlementsWithDeletedSourceTransaction`: Verifies orphaned settlements don't inflate balance
- Added `TestGetBalance_Accumulated_ExcludesConnectionAccountInitialBalance`: Verifies connection accounts don't contribute initial balance to accumulated totals

**Frontend (`CreateChargeDrawer.tsx`, `CurrencyInput.tsx`, `ChargesPage.ts`)**
- Replaced `NumberInput` with `CurrencyInput` for amount field to ensure consistent cents-based handling
- Updated schema to use `nonnegative` integer (cents) instead of optional positive decimal
- Changed default from `undefined` to `0` to represent "not informed" state
- Updated e2e test helper to use `CurrencyField.fillCents()` instead of `NumberField`
- Updated field description to clarify "0,00" means "use current balance"

## Implementation Details

- Settlement queries now use `s.date <= ?` and `s.date >= ?` instead of `t.date` comparisons
- Connection account exclusion uses a NOT EXISTS subquery to check both directions of the relationship
- Frontend amount field now consistently works in cents (int64) throughout the form lifecycle

https://claude.ai/code/session_01SddQaof1W3uEySEZjBmv9U