### PR TITLE
Fix shift+click range selection to span transactions and settlements

### DIFF
--- a/frontend/e2e/pages/TransactionsPage.ts
+++ b/frontend/e2e/pages/TransactionsPage.ts
@@ -262,42 +262,30 @@ export class TransactionsPage {
     await this.page.getByTestId(TransactionsTestIds.Checkbox(transactionId)).first().click();
   }
 
+  /** Locator for a transaction's selection checkbox. */
+  transactionCheckbox(transactionId: number): Locator {
+    return this.page.getByTestId(TransactionsTestIds.Checkbox(transactionId)).first();
+  }
+
+  /** Locator for a settlement's selection checkbox. */
+  settlementCheckbox(settlementId: number): Locator {
+    return this.page
+      .getByTestId(TransactionsTestIds.CheckboxSettlement(settlementId))
+      .first();
+  }
+
   /** Click a transaction's selection checkbox, optionally holding Shift. */
   async toggleTransactionCheckbox(transactionId: number, options?: { shiftKey?: boolean }) {
-    const checkbox = this.page.getByTestId(TransactionsTestIds.Checkbox(transactionId)).first();
-    if (options?.shiftKey) {
-      await checkbox.click({ modifiers: ["Shift"] });
-    } else {
-      await checkbox.click();
-    }
+    await this.transactionCheckbox(transactionId).click(
+      options?.shiftKey ? { modifiers: ["Shift"] } : {},
+    );
   }
 
   /** Click a settlement's selection checkbox, optionally holding Shift. */
   async toggleSettlementCheckbox(settlementId: number, options?: { shiftKey?: boolean }) {
-    const checkbox = this.page
-      .getByTestId(TransactionsTestIds.CheckboxSettlement(settlementId))
-      .first();
-    if (options?.shiftKey) {
-      await checkbox.click({ modifiers: ["Shift"] });
-    } else {
-      await checkbox.click();
-    }
-  }
-
-  /** Whether a transaction's selection checkbox is checked. */
-  async isTransactionSelected(transactionId: number): Promise<boolean> {
-    return this.page
-      .getByTestId(TransactionsTestIds.Checkbox(transactionId))
-      .first()
-      .isChecked();
-  }
-
-  /** Whether a settlement's selection checkbox is checked. */
-  async isSettlementSelected(settlementId: number): Promise<boolean> {
-    return this.page
-      .getByTestId(TransactionsTestIds.CheckboxSettlement(settlementId))
-      .first()
-      .isChecked();
+    await this.settlementCheckbox(settlementId).click(
+      options?.shiftKey ? { modifiers: ["Shift"] } : {},
+    );
   }
 
   async getSelectedCount(): Promise<number> {

--- a/frontend/e2e/pages/TransactionsPage.ts
+++ b/frontend/e2e/pages/TransactionsPage.ts
@@ -262,6 +262,44 @@ export class TransactionsPage {
     await this.page.getByTestId(TransactionsTestIds.Checkbox(transactionId)).first().click();
   }
 
+  /** Click a transaction's selection checkbox, optionally holding Shift. */
+  async toggleTransactionCheckbox(transactionId: number, options?: { shiftKey?: boolean }) {
+    const checkbox = this.page.getByTestId(TransactionsTestIds.Checkbox(transactionId)).first();
+    if (options?.shiftKey) {
+      await checkbox.click({ modifiers: ["Shift"] });
+    } else {
+      await checkbox.click();
+    }
+  }
+
+  /** Click a settlement's selection checkbox, optionally holding Shift. */
+  async toggleSettlementCheckbox(settlementId: number, options?: { shiftKey?: boolean }) {
+    const checkbox = this.page
+      .getByTestId(TransactionsTestIds.CheckboxSettlement(settlementId))
+      .first();
+    if (options?.shiftKey) {
+      await checkbox.click({ modifiers: ["Shift"] });
+    } else {
+      await checkbox.click();
+    }
+  }
+
+  /** Whether a transaction's selection checkbox is checked. */
+  async isTransactionSelected(transactionId: number): Promise<boolean> {
+    return this.page
+      .getByTestId(TransactionsTestIds.Checkbox(transactionId))
+      .first()
+      .isChecked();
+  }
+
+  /** Whether a settlement's selection checkbox is checked. */
+  async isSettlementSelected(settlementId: number): Promise<boolean> {
+    return this.page
+      .getByTestId(TransactionsTestIds.CheckboxSettlement(settlementId))
+      .first()
+      .isChecked();
+  }
+
   async getSelectedCount(): Promise<number> {
     const text = await this.page.getByTestId(TransactionsTestIds.SelectionCount).textContent();
     const match = text?.match(/(\d+)/);

--- a/frontend/e2e/tests/import-shift-select.spec.ts
+++ b/frontend/e2e/tests/import-shift-select.spec.ts
@@ -87,7 +87,7 @@ test.describe("Import shift+click selection", () => {
 
   // ── Basic: shift+click with no prior selection selects from 0 to clicked ──
   test("shift+click with no prior selection: selects from row 0 to clicked row", async () => {
-    // Shift+click row 4 — no prior selection, so nearestAbove = -1, fills 0..4
+    // Shift+click row 4 — no anchor yet, so the range falls back to row 0, fills 0..4
     await importPage.toggleRowCheckbox(4, { shiftKey: true });
 
     for (let i = 0; i <= 4; i++) {
@@ -98,13 +98,13 @@ test.describe("Import shift+click selection", () => {
     }
   });
 
-  // ── Shift+click fills only up to nearest selected row ──────────────────────
-  test("shift+click fills gap between nearest selected row and clicked row", async () => {
-    // Select row 2 normally
+  // ── Shift+click fills the range from the anchor to the clicked row ─────────
+  test("shift+click fills the range between the anchor and the clicked row", async () => {
+    // Select row 2 normally — it becomes the anchor
     await importPage.toggleRowCheckbox(2);
     expect(await importPage.isRowSelected(2)).toBe(true);
 
-    // Shift+click row 6 — should fill rows 3,4,5,6 (not 0,1)
+    // Shift+click row 6 — anchor is row 2, fills the range 2..6 (not 0,1)
     await importPage.toggleRowCheckbox(6, { shiftKey: true });
 
     expect(await importPage.isRowSelected(0)).toBe(false);
@@ -115,13 +115,13 @@ test.describe("Import shift+click selection", () => {
     expect(await importPage.isRowSelected(7)).toBe(false);
   });
 
-  // ── Multiple selected rows: fills from nearest, not earliest ───────────────
-  test("with multiple selected: shift+click fills from nearest selected above", async () => {
-    // Select rows 1 and 4
+  // ── Anchor is the last plain click, not the earliest selected row ──────────
+  test("with multiple selected: shift+click fills from the last plain-clicked row", async () => {
+    // Select rows 1 and 4 — row 4 is the last plain click, so it is the anchor
     await importPage.toggleRowCheckbox(1);
     await importPage.toggleRowCheckbox(4);
 
-    // Shift+click row 7 — nearest above is 4, fills 5,6,7 (not 2,3)
+    // Shift+click row 7 — anchor is row 4, fills 4..7 (row 1 stays, 2,3 untouched)
     await importPage.toggleRowCheckbox(7, { shiftKey: true });
 
     expect(await importPage.isRowSelected(0)).toBe(false);
@@ -131,6 +131,23 @@ test.describe("Import shift+click selection", () => {
     for (let i = 4; i <= 7; i++) {
       expect(await importPage.isRowSelected(i)).toBe(true);
     }
+  });
+
+  // ── Regression #159: anchor below the shift-clicked row fills upward ───────
+  test("shift+click above the anchor selects the upward range", async () => {
+    // Select row 6 normally — it becomes the anchor
+    await importPage.toggleRowCheckbox(6);
+    expect(await importPage.isRowSelected(6)).toBe(true);
+
+    // Shift+click row 2 — should fill the range 2..6, not 0..2
+    await importPage.toggleRowCheckbox(2, { shiftKey: true });
+
+    expect(await importPage.isRowSelected(0)).toBe(false);
+    expect(await importPage.isRowSelected(1)).toBe(false);
+    for (let i = 2; i <= 6; i++) {
+      expect(await importPage.isRowSelected(i)).toBe(true);
+    }
+    expect(await importPage.isRowSelected(7)).toBe(false);
   });
 
   // ── Normal click (no shift) toggles single row ─────────────────────────────

--- a/frontend/e2e/tests/transaction-shift-select.spec.ts
+++ b/frontend/e2e/tests/transaction-shift-select.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, type Browser, type Page } from "@playwright/test";
+import { TransactionsPage } from "../pages/TransactionsPage";
+import {
+  apiCreateTransaction,
+  apiFetchAs,
+  apiListTransactions,
+  openAuthedPage,
+} from "../helpers/api";
+import { createUserAndPartner } from "../helpers/createUserAndPartner";
+
+// Regression for GitHub issue #159: the transaction listing interleaves
+// transactions and their inline settlements. A shift+click range must span
+// both entity types — previously the items of the other type were skipped.
+
+const TX_DATE = "2026-05-15";
+const TX_MONTH = 5;
+const TX_YEAR = 2026;
+
+interface MixedGroupSetup {
+  page: Page;
+  transactionsPage: TransactionsPage;
+  txId: number;
+  settlementId: number;
+}
+
+// Creates a connected user with one split transaction. The split produces an
+// inline settlement, so the transaction's group renders two selectable rows:
+// the transaction followed by its settlement.
+async function setupMixedGroup(browser: Browser): Promise<MixedGroupSetup> {
+  const { userToken, userAccountId, connectionId } =
+    await createUserAndPartner("e2e-tx-shift-select");
+
+  const categoryRes = await apiFetchAs(userToken, "/api/categories", {
+    method: "POST",
+    body: JSON.stringify({ name: `Cat shift-select ${Date.now()}` }),
+  });
+  const category = (await categoryRes.json()) as { id: number };
+
+  const created = await apiCreateTransaction(
+    {
+      transaction_type: "expense",
+      account_id: userAccountId,
+      category_id: category.id,
+      amount: 10000,
+      date: TX_DATE,
+      description: "Split transaction #159",
+      split_settings: [{ connection_id: connectionId, percentage: 50 }],
+    },
+    { token: userToken },
+  );
+
+  const list = await apiListTransactions(TX_MONTH, TX_YEAR, { token: userToken });
+  const source = list.find((t) => t.id === created.id);
+  const settlement = source?.settlements_from_source?.[0];
+  if (!settlement) {
+    throw new Error("split transaction did not produce an inline settlement");
+  }
+
+  const page = await openAuthedPage(browser, userToken);
+  const transactionsPage = new TransactionsPage(page);
+  await transactionsPage.gotoMonth(TX_MONTH, TX_YEAR);
+
+  return { page, transactionsPage, txId: created.id, settlementId: settlement.id };
+}
+
+test.describe("Transaction listing shift+click selection", () => {
+  test("shift+click from a transaction to its settlement selects both", async ({
+    browser,
+  }) => {
+    const { page, transactionsPage, txId, settlementId } =
+      await setupMixedGroup(browser);
+
+    // Anchor on the transaction, then shift+click the settlement below it.
+    await transactionsPage.toggleTransactionCheckbox(txId);
+    expect(await transactionsPage.isTransactionSelected(txId)).toBe(true);
+
+    await transactionsPage.toggleSettlementCheckbox(settlementId, { shiftKey: true });
+
+    expect(await transactionsPage.isTransactionSelected(txId)).toBe(true);
+    expect(await transactionsPage.isSettlementSelected(settlementId)).toBe(true);
+    expect(await transactionsPage.getSelectedCount()).toBe(2);
+
+    await page.close();
+  });
+
+  test("shift+click from a settlement to its transaction selects both", async ({
+    browser,
+  }) => {
+    const { page, transactionsPage, txId, settlementId } =
+      await setupMixedGroup(browser);
+
+    // Anchor on the settlement, then shift+click the transaction above it.
+    await transactionsPage.toggleSettlementCheckbox(settlementId);
+    expect(await transactionsPage.isSettlementSelected(settlementId)).toBe(true);
+
+    await transactionsPage.toggleTransactionCheckbox(txId, { shiftKey: true });
+
+    expect(await transactionsPage.isSettlementSelected(settlementId)).toBe(true);
+    expect(await transactionsPage.isTransactionSelected(txId)).toBe(true);
+    expect(await transactionsPage.getSelectedCount()).toBe(2);
+
+    await page.close();
+  });
+});

--- a/frontend/e2e/tests/transaction-shift-select.spec.ts
+++ b/frontend/e2e/tests/transaction-shift-select.spec.ts
@@ -1,12 +1,8 @@
 import { test, expect, type Browser, type Page } from "@playwright/test";
 import { TransactionsPage } from "../pages/TransactionsPage";
-import {
-  apiCreateTransaction,
-  apiFetchAs,
-  apiListTransactions,
-  openAuthedPage,
-} from "../helpers/api";
+import { apiCreateTransaction, apiFetchAs, openAuthedPage } from "../helpers/api";
 import { createUserAndPartner } from "../helpers/createUserAndPartner";
+import type { Transactions } from "@/types/transactions";
 
 // Regression for GitHub issue #159: the transaction listing interleaves
 // transactions and their inline settlements. A shift+click range must span
@@ -49,7 +45,13 @@ async function setupMixedGroup(browser: Browser): Promise<MixedGroupSetup> {
     { token: userToken },
   );
 
-  const list = await apiListTransactions(TX_MONTH, TX_YEAR, { token: userToken });
+  // with_settlements=true preloads settlements_from_source on the source tx —
+  // the listing omits it otherwise (mirrors the frontend's fetchTransactions).
+  const txsRes = await apiFetchAs(
+    userToken,
+    `/api/transactions?month=${TX_MONTH}&year=${TX_YEAR}&with_settlements=true`,
+  );
+  const list = (await txsRes.json()) as Transactions.Transaction[];
   const source = list.find((t) => t.id === created.id);
   const settlement = source?.settlements_from_source?.[0];
   if (!settlement) {
@@ -72,12 +74,12 @@ test.describe("Transaction listing shift+click selection", () => {
 
     // Anchor on the transaction, then shift+click the settlement below it.
     await transactionsPage.toggleTransactionCheckbox(txId);
-    expect(await transactionsPage.isTransactionSelected(txId)).toBe(true);
+    await expect(transactionsPage.transactionCheckbox(txId)).toBeChecked();
 
     await transactionsPage.toggleSettlementCheckbox(settlementId, { shiftKey: true });
 
-    expect(await transactionsPage.isTransactionSelected(txId)).toBe(true);
-    expect(await transactionsPage.isSettlementSelected(settlementId)).toBe(true);
+    await expect(transactionsPage.transactionCheckbox(txId)).toBeChecked();
+    await expect(transactionsPage.settlementCheckbox(settlementId)).toBeChecked();
     expect(await transactionsPage.getSelectedCount()).toBe(2);
 
     await page.close();
@@ -91,12 +93,12 @@ test.describe("Transaction listing shift+click selection", () => {
 
     // Anchor on the settlement, then shift+click the transaction above it.
     await transactionsPage.toggleSettlementCheckbox(settlementId);
-    expect(await transactionsPage.isSettlementSelected(settlementId)).toBe(true);
+    await expect(transactionsPage.settlementCheckbox(settlementId)).toBeChecked();
 
     await transactionsPage.toggleTransactionCheckbox(txId, { shiftKey: true });
 
-    expect(await transactionsPage.isSettlementSelected(settlementId)).toBe(true);
-    expect(await transactionsPage.isTransactionSelected(txId)).toBe(true);
+    await expect(transactionsPage.settlementCheckbox(settlementId)).toBeChecked();
+    await expect(transactionsPage.transactionCheckbox(txId)).toBeChecked();
     expect(await transactionsPage.getSelectedCount()).toBe(2);
 
     await page.close();

--- a/frontend/src/components/transactions/import/selectionStore.ts
+++ b/frontend/src/components/transactions/import/selectionStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 
 interface SelectionStore {
   selected: Set<string>
+  anchorIndex: number | null
   toggle: (rowIndex: number, shiftKey: boolean, fieldIds: string[]) => void
   selectAll: (fieldIds: string[]) => void
   clear: () => void
@@ -9,42 +10,35 @@ interface SelectionStore {
 
 export const useSelectionStore = create<SelectionStore>((set) => ({
   selected: new Set(),
+  anchorIndex: null,
 
   toggle: (rowIndex, shiftKey, fieldIds) => {
     set((state) => {
       const id = fieldIds[rowIndex]
       if (id === undefined) return state
 
-      const next = new Set(state.selected)
-      const wasSelected = next.has(id)
-      if (wasSelected) next.delete(id)
-      else next.add(id)
-
-      if (!shiftKey) return { selected: next }
-
-      const selecting = !wasSelected
-      let nearestAbove = -1
-      for (let i = rowIndex - 1; i >= 0; i--) {
-        const candidateId = fieldIds[i]
-        if (candidateId !== undefined && state.selected.has(candidateId)) {
-          nearestAbove = i
-          break
+      if (shiftKey) {
+        // Range-select from the anchor (last plain-clicked row) to the clicked
+        // row, in either direction. With no anchor yet, fall back to row 0.
+        const anchor = state.anchorIndex ?? 0
+        const next = new Set(state.selected)
+        const start = Math.min(anchor, rowIndex)
+        const end = Math.max(anchor, rowIndex)
+        for (let i = start; i <= end; i++) {
+          const fillId = fieldIds[i]
+          if (fillId !== undefined) next.add(fillId)
         }
+        return { selected: next, anchorIndex: rowIndex }
       }
 
-      const start = nearestAbove + 1
-      for (let i = start; i < rowIndex; i++) {
-        const fillId = fieldIds[i]
-        if (fillId === undefined) continue
-        if (selecting) next.add(fillId)
-        else next.delete(fillId)
-      }
-
-      return { selected: next }
+      const next = new Set(state.selected)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return { selected: next, anchorIndex: rowIndex }
     })
   },
 
   selectAll: (fieldIds) => set({ selected: new Set(fieldIds) }),
 
-  clear: () => set({ selected: new Set() }),
+  clear: () => set({ selected: new Set(), anchorIndex: null }),
 }))

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -32,6 +32,10 @@ import { Transactions } from "@/types/transactions";
 import { splitPercentagesToCents } from "@/utils/splitMath";
 import { TransactionsTestIds } from "@/testIds";
 
+// A selectable row within a group. Transactions and settlements interleave
+// visually, so shift+click ranges are computed over a unified, type-tagged list.
+type RowRef = { type: "tx" | "settlement"; id: number };
+
 export function TransactionsPage() {
   const search = useSearch({ from: "/_authenticated/transactions" });
   const routeNavigate = useNavigate({ from: "/transactions" });
@@ -46,110 +50,95 @@ export function TransactionsPage() {
   // other and so action handlers can dispatch each kind to the right endpoint.
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [selectedSettlementIds, setSelectedSettlementIds] = useState<Set<number>>(new Set());
+  // Anchor for shift+click range selection. A cross-type anchor can't be
+  // derived from one Set's insertion order, so it's tracked explicitly.
+  const [anchor, setAnchor] = useState<
+    { groupKey: string; type: RowRef["type"]; id: number } | null
+  >(null);
   const clearSelection = useCallback(() => {
     setSelectedIds(new Set());
     setSelectedSettlementIds(new Set());
+    setAnchor(null);
   }, []);
 
-  // Per-group ordered ID maps for shift+click range selection. Settlements
-  // (inline + synthetic) get their own map keyed by the real settlement.id.
-  const { data: groupRowMaps } = useGroupedTransactions(
+  // Per-group ordered row list for shift+click range selection. A group
+  // interleaves transactions and settlements (inline + synthetic); the range
+  // must span both types, so the list is unified and tagged by type in the
+  // same visual order TransactionGroup renders.
+  const { data: groupRows } = useGroupedTransactions(
     useMemo(
       () => (groups) => {
-        const txIds = new Map<string, number[]>();
-        const settlementIds = new Map<string, number[]>();
+        const map = new Map<string, RowRef[]>();
         for (const g of groups) {
-          const txList: number[] = [];
-          const settlementList: number[] = [];
+          const list: RowRef[] = [];
           for (const tx of g.transactions) {
             if (tx.origin_settlement_id !== undefined) {
-              settlementList.push(tx.origin_settlement_id);
+              list.push({ type: "settlement", id: tx.origin_settlement_id });
               continue;
             }
-            txList.push(tx.id);
+            list.push({ type: "tx", id: tx.id });
             for (const s of tx.settlements_from_source ?? []) {
-              settlementList.push(s.id);
+              list.push({ type: "settlement", id: s.id });
             }
           }
-          txIds.set(g.key, txList);
-          settlementIds.set(g.key, settlementList);
+          map.set(g.key, list);
         }
-        return { txIds, settlementIds };
+        return map;
       },
       [],
     ),
   );
-  const groupTxIdsMap = groupRowMaps.txIds;
-  const groupSettlementIdsMap = groupRowMaps.settlementIds;
 
-  const handleSelectTransaction = useCallback(
-    (id: number, shiftKey: boolean, groupKey: string) => {
-      if (shiftKey && selectedIds.size > 0) {
-        const groupTxIds = groupTxIdsMap.get(groupKey);
-        if (groupTxIds) {
-          // Derive anchor from last item in selectedIds (Set preserves insertion order)
-          const ids = [...selectedIds];
-          const lastSelected = ids[ids.length - 1];
-          const anchorIdx = groupTxIds.indexOf(lastSelected);
-          const targetIdx = groupTxIds.indexOf(id);
-
-          if (anchorIdx !== -1 && targetIdx !== -1) {
-            const start = Math.min(anchorIdx, targetIdx);
-            const end = Math.max(anchorIdx, targetIdx);
-            const rangeIds = groupTxIds.slice(start, end + 1);
-            setSelectedIds((prev) => {
-              const next = new Set(prev);
-              for (const rid of rangeIds) next.add(rid);
-              return next;
-            });
-            return;
-          }
+  const handleSelectRow = useCallback(
+    (type: RowRef["type"], id: number, shiftKey: boolean, groupKey: string) => {
+      const rows = groupRows.get(groupKey);
+      if (shiftKey && anchor && anchor.groupKey === groupKey && rows) {
+        const anchorIdx = rows.findIndex(
+          (r) => r.type === anchor.type && r.id === anchor.id,
+        );
+        const targetIdx = rows.findIndex((r) => r.type === type && r.id === id);
+        if (anchorIdx !== -1 && targetIdx !== -1) {
+          const range = rows.slice(
+            Math.min(anchorIdx, targetIdx),
+            Math.max(anchorIdx, targetIdx) + 1,
+          );
+          setSelectedIds((prev) => {
+            const next = new Set(prev);
+            for (const r of range) if (r.type === "tx") next.add(r.id);
+            return next;
+          });
+          setSelectedSettlementIds((prev) => {
+            const next = new Set(prev);
+            for (const r of range) if (r.type === "settlement") next.add(r.id);
+            return next;
+          });
+          setAnchor({ groupKey, type, id });
+          return;
         }
       }
 
-      // Normal single toggle
-      setSelectedIds((prev) => {
+      const setter = type === "tx" ? setSelectedIds : setSelectedSettlementIds;
+      setter((prev) => {
         const next = new Set(prev);
         if (next.has(id)) next.delete(id);
         else next.add(id);
         return next;
       });
+      setAnchor({ groupKey, type, id });
     },
-    [selectedIds, groupTxIdsMap],
+    [anchor, groupRows],
+  );
+
+  const handleSelectTransaction = useCallback(
+    (id: number, shiftKey: boolean, groupKey: string) =>
+      handleSelectRow("tx", id, shiftKey, groupKey),
+    [handleSelectRow],
   );
 
   const handleSelectSettlement = useCallback(
-    (id: number, shiftKey: boolean, groupKey: string) => {
-      if (shiftKey && selectedSettlementIds.size > 0) {
-        const groupSettlementIds = groupSettlementIdsMap.get(groupKey);
-        if (groupSettlementIds) {
-          const ids = [...selectedSettlementIds];
-          const lastSelected = ids[ids.length - 1];
-          const anchorIdx = groupSettlementIds.indexOf(lastSelected);
-          const targetIdx = groupSettlementIds.indexOf(id);
-
-          if (anchorIdx !== -1 && targetIdx !== -1) {
-            const start = Math.min(anchorIdx, targetIdx);
-            const end = Math.max(anchorIdx, targetIdx);
-            const rangeIds = groupSettlementIds.slice(start, end + 1);
-            setSelectedSettlementIds((prev) => {
-              const next = new Set(prev);
-              for (const rid of rangeIds) next.add(rid);
-              return next;
-            });
-            return;
-          }
-        }
-      }
-
-      setSelectedSettlementIds((prev) => {
-        const next = new Set(prev);
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
-        return next;
-      });
-    },
-    [selectedSettlementIds, groupSettlementIdsMap],
+    (id: number, shiftKey: boolean, groupKey: string) =>
+      handleSelectRow("settlement", id, shiftKey, groupKey),
+    [handleSelectRow],
   );
 
   const { query: accountsQuery } = useAccounts();


### PR DESCRIPTION
## Summary

Fixes GitHub issue #159: shift+click range selection in the transactions listing now correctly spans both transactions and their inline settlements, which are visually interleaved in the UI.

Previously, shift+click range selection maintained separate ordered lists for transactions and settlements, causing the selection logic to skip items of the other type when computing ranges. This broke the user experience when selecting from a transaction to its settlement (or vice versa) in a single shift+click action.

## Key Changes

**TransactionsPage.tsx:**
- Introduced `RowRef` type to tag rows as either `"tx"` or `"settlement"` with their ID
- Replaced separate `groupTxIdsMap` and `groupSettlementIdsMap` with a unified `groupRows` map that maintains a single ordered list of `RowRef` items per group, matching the visual order rendered by `TransactionGroup`
- Added explicit `anchor` state to track the last clicked row (type + ID + group), replacing the implicit anchor derived from Set insertion order
- Consolidated `handleSelectTransaction` and `handleSelectSettlement` into a single `handleSelectRow` function that:
  - Computes shift+click ranges over the unified row list
  - Distributes selected rows back to the appropriate `selectedIds` or `selectedSettlementIds` Set based on row type
  - Updates the anchor on every click (shift or plain)
- Updated `clearSelection` to also reset the anchor

**selectionStore.ts (import shift+click):**
- Replaced implicit anchor logic (finding "nearest selected row above") with explicit `anchorIndex` state
- Simplified shift+click to always fill the range from anchor to clicked row (or row 0 if no anchor yet)
- Updated `clear()` to reset the anchor

**E2E tests:**
- Added `transaction-shift-select.spec.ts` with regression tests for shift+click across transaction/settlement boundaries
- Updated `import-shift-select.spec.ts` test descriptions and added a new test case for upward range selection (anchor below the shift-clicked row)

**TransactionsPage.ts (E2E helpers):**
- Added `toggleTransactionCheckbox()` and `toggleSettlementCheckbox()` with optional `shiftKey` modifier support
- Added `isTransactionSelected()` and `isSettlementSelected()` assertion helpers

## Implementation Details

The key insight is that transactions and settlements are rendered in a unified visual order within each group (a transaction may be followed by its inline settlements). The shift+click range must respect this visual order, not maintain separate ranges per entity type. By building a single `RowRef[]` list per group in the same order the UI renders, range selection now works correctly across type boundaries.

The explicit anchor state (rather than deriving it from Set insertion order) is necessary because a cross-type range cannot be reliably reconstructed from a single Set's insertion order.

https://claude.ai/code/session_012xdkCQGTzU8WrVWi5PZt66