### PR TITLE
Speed up PWA startup and prompt users when a new version ships

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,8 +13,53 @@
     <link rel="icon" type="image/png" sizes="512x512" href="/icon-512.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>FinanceApp</title>
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem("mantine-color-scheme-value");
+          var scheme =
+            stored && stored !== "auto"
+              ? stored
+              : window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light";
+          document.documentElement.setAttribute("data-mantine-color-scheme", scheme);
+        } catch (e) {}
+      })();
+    </script>
+    <style>
+      #app-splash {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #ffffff;
+        z-index: 9999;
+        transition: opacity 200ms ease-out;
+      }
+      :root[data-mantine-color-scheme="dark"] #app-splash {
+        background: #1a1b1e;
+      }
+      #app-splash.is-hidden {
+        opacity: 0;
+        pointer-events: none;
+      }
+      #app-splash .app-splash-spinner {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        border: 3px solid rgba(34, 139, 230, 0.2);
+        border-top-color: #228be6;
+        animation: app-splash-spin 0.8s linear infinite;
+      }
+      @keyframes app-splash-spin {
+        to { transform: rotate(360deg); }
+      }
+    </style>
   </head>
   <body>
+    <div id="app-splash"><div class="app-splash-spinner" aria-label="Carregando"></div></div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy } from 'react'
 import { RouterProvider } from '@tanstack/react-router'
 import { router } from './router'
 import { queryClient } from './queryClient'
+import { PWAUpdateNotifier } from './components/PWAUpdateNotifier'
 
 const ReactQueryDevtools = import.meta.env.PROD
   ? () => null
@@ -23,6 +24,7 @@ export default function App() {
   return (
     <>
       <RouterProvider router={router} context={{ queryClient }} />
+      <PWAUpdateNotifier />
       <Suspense>
         <ReactQueryDevtools initialIsOpen={false} />
         <TanStackRouterDevtools router={router} initialIsOpen={false} />

--- a/frontend/src/components/PWAUpdateNotifier.tsx
+++ b/frontend/src/components/PWAUpdateNotifier.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from 'react'
+import { useRegisterSW } from 'virtual:pwa-register/react'
+import { notifications } from '@mantine/notifications'
+import { Button, Group, Stack, Text } from '@mantine/core'
+
+const NOTIFICATION_ID = 'pwa-update-available'
+const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000
+
+export function PWAUpdateNotifier() {
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return
+
+      const checkForUpdates = () => {
+        void registration.update()
+      }
+
+      const intervalId = window.setInterval(checkForUpdates, UPDATE_CHECK_INTERVAL_MS)
+
+      // PWA standalone keeps the page alive between sessions; checking on
+      // visibility change ensures a returning user picks up updates without
+      // having to fully reload the app.
+      const onVisibilityChange = () => {
+        if (document.visibilityState === 'visible') checkForUpdates()
+      }
+      document.addEventListener('visibilitychange', onVisibilityChange)
+
+      return () => {
+        window.clearInterval(intervalId)
+        document.removeEventListener('visibilitychange', onVisibilityChange)
+      }
+    },
+  })
+
+  useEffect(() => {
+    if (!needRefresh) return
+
+    notifications.show({
+      id: NOTIFICATION_ID,
+      title: 'Nova versão disponível',
+      message: (
+        <Stack gap="xs" mt={4}>
+          <Text size="sm">Atualize para ver as novidades.</Text>
+          <Group justify="flex-end">
+            <Button
+              size="xs"
+              variant="subtle"
+              onClick={() => {
+                notifications.hide(NOTIFICATION_ID)
+                setNeedRefresh(false)
+              }}
+            >
+              Depois
+            </Button>
+            <Button
+              size="xs"
+              onClick={() => {
+                void updateServiceWorker(true)
+              }}
+            >
+              Atualizar
+            </Button>
+          </Group>
+        </Stack>
+      ),
+      autoClose: false,
+      withCloseButton: false,
+    })
+  }, [needRefresh, setNeedRefresh, updateServiceWorker])
+
+  return null
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
-import { ColorSchemeScript, MantineProvider } from '@mantine/core'
+import { MantineProvider } from '@mantine/core'
 import { Notifications } from '@mantine/notifications'
 import '@mantine/core/styles.css'
 import '@mantine/notifications/styles.css'
@@ -13,7 +13,6 @@ import { queryClient } from './queryClient'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <ColorSchemeScript defaultColorScheme="auto" />
       <MantineProvider theme={theme} defaultColorScheme="auto">
         <Notifications position="top-right" autoClose={3000} />
         <App />
@@ -21,3 +20,9 @@ createRoot(document.getElementById('root')!).render(
     </QueryClientProvider>
   </StrictMode>,
 )
+
+const splash = document.getElementById('app-splash')
+if (splash) {
+  splash.classList.add('is-hidden')
+  splash.addEventListener('transitionend', () => splash.remove(), { once: true })
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
+/// <reference types="vite-plugin-pwa/react" />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,6 +32,23 @@ export default defineConfig({
         clientsClaim: true,
         skipWaiting: true,
         navigateFallback: "/index.html",
+        // Cache do boot de autenticação: serve a resposta anterior
+        // imediatamente se o backend (Cloud Run) demorar mais que 2s para
+        // responder, evitando tela branca durante cold start.
+        runtimeCaching: [
+          {
+            urlPattern: ({ url }) =>
+              url.pathname === "/api/auth/me" ||
+              url.pathname === "/api/onboarding/status",
+            handler: "NetworkFirst",
+            options: {
+              cacheName: "auth-boot",
+              networkTimeoutSeconds: 2,
+              expiration: { maxEntries: 8, maxAgeSeconds: 60 * 60 * 24 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
       },
       manifest: {
         name: "FinanceApp",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,15 +22,14 @@ export default defineConfig({
     tanstackRouter({ routesDirectory: "./src/routes", generatedRouteTree: "./src/routeTree.gen.ts" }),
     react(),
     VitePWA({
-      registerType: "autoUpdate",
+      registerType: "prompt",
+      injectRegister: false,
       devOptions: {
         enabled: false,
       },
       workbox: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
         cleanupOutdatedCaches: true,
-        clientsClaim: true,
-        skipWaiting: true,
         navigateFallback: "/index.html",
         // Cache do boot de autenticação: serve a resposta anterior
         // imediatamente se o backend (Cloud Run) demorar mais que 2s para


### PR DESCRIPTION
## Resumo

Dois sintomas reportados ao usar o PWA instalado:

1. Abrir o app leva alguns segundos com tela branca.
2. Após um deploy do frontend, o PWA continua na versão antiga até reinstalar.

Esta branch ataca os dois.

## Mudanças

### 1. Boot mais rápido (commit `51e4db8`)

- **`vite.config.ts`** — adicionado `runtimeCaching` no Workbox para `/api/auth/me` e `/api/onboarding/status` com `NetworkFirst` e `networkTimeoutSeconds: 2`. O `beforeLoad` do `_authenticated.tsx` espera essas duas requests síncronas antes de renderizar; quando o Cloud Run está em cold start, a tela fica em branco até o backend responder. Com o fallback de cache do SW, o boot destrava em ≤ 2s mesmo se o backend estiver lento.
- **`index.html`** — splash spinner inline e script que aplica o color scheme da Mantine no `<html>` antes de qualquer JS rodar. Antes era branco até o React montar, e ainda dava flash de tema porque o `<ColorSchemeScript />` vivia dentro da árvore React.
- **`src/main.tsx`** — esconde o splash quando o React monta; remove o `<ColorSchemeScript />` (agora inline no `<head>`).

### 2. Auto-update do PWA (commit `1a42d83`)

A config anterior combinava `registerType: "autoUpdate"` com `skipWaiting + clientsClaim` no workbox. O novo SW assumia o controle imediatamente, mas a página em uso continuava rodando o JS antigo na memória sem nenhum sinal para o usuário recarregar. Em PWA standalone fica pior: a sessão "ressuscita" sem nova navegação, então o browser nem sempre re-checa o SW.

- **`vite.config.ts`** — trocado para `registerType: "prompt"`, removidos `skipWaiting`/`clientsClaim`, e `injectRegister: false`. O SW gerado agora escuta uma mensagem `SKIP_WAITING` em vez de se auto-ativar.
- **`src/components/PWAUpdateNotifier.tsx`** (novo) — registra o SW via `virtual:pwa-register/react` e mostra uma notificação Mantine ("Atualizar" / "Depois") quando há nova versão. O botão "Atualizar" envia `SKIP_WAITING` e recarrega.
- **Update checks ativos** — o componente roda `registration.update()` a cada 30 min e em todo `visibilitychange → visible`, então quem volta ao PWA depois de um deploy é notificado sem precisar reinstalar.

## Validação

- `npm run build` passa.
- `dist/sw.js` inspecionado: tem listener de `SKIP_WAITING`, sem `skipWaiting()` automático, mantém o `runtimeCaching` da auth.

## Test plan

- [ ] Abrir o PWA instalado e medir o tempo até o primeiro paint em uma sessão fria (deve ser ≤ 2s mesmo com backend cold-startando).
- [ ] Fazer um deploy do frontend e confirmar que aparece a notificação "Nova versão disponível" sem reinstalar.
- [ ] Clicar "Atualizar" e confirmar que a página recarrega com o novo bundle.
- [ ] Clicar "Depois" e confirmar que a notificação fecha sem recarregar.
- [ ] Fechar o PWA, deployar de novo, abrir o PWA — confirmar que o prompt aparece em alguns segundos (graças ao `visibilitychange`).

## Follow-up sugerido

O bundle JS está em ~1.08 MB (322 KB gzipped) num chunk único, porque nenhuma rota usa `createLazyFileRoute`. Migrar as rotas pesadas (`transactions`, `transactions_.import`, `charges`) reduziria ainda mais o time-to-interactive, mas é um refactor maior — fora do escopo aqui.

https://claude.ai/code/session_01EVvcoErDZg7mXtRKUkeYLi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVvcoErDZg7mXtRKUkeYLi)_