### PR TITLE
Fix transaction search to prevent tag filter duplication

### DIFF
--- a/backend/internal/repository/transaction_repository.go
+++ b/backend/internal/repository/transaction_repository.go
@@ -144,8 +144,10 @@ func (r *transactionRepository) Search(ctx context.Context, filter domain.Transa
 	}
 
 	if len(filter.TagIDs) > 0 {
-		query = query.Joins("JOIN transaction_tags ON transaction_tags.transaction_id = transactions.id")
-		query = query.Where("transaction_tags.tag_id IN ?", filter.TagIDs)
+		// EXISTS keeps the result set on one row per transaction. A JOIN here
+		// would multiply rows by the number of matching tags (a tx with 4 of
+		// the filtered tags would appear 4x in the listing).
+		query = query.Where("EXISTS (SELECT 1 FROM transaction_tags tt WHERE tt.transaction_id = transactions.id AND tt.tag_id IN ?)", filter.TagIDs)
 	}
 
 	if len(filter.RecurrenceIDs) > 0 {

--- a/backend/internal/service/transaction_coverage_gaps_test.go
+++ b/backend/internal/service/transaction_coverage_gaps_test.go
@@ -523,6 +523,54 @@ func (suite *TransactionDeleteTestWithDBSuite) TestDelete_Standalone_Propagation
 	suite.Assert().Len(txs, 0, "standalone tx must be deleted with propagation=all")
 }
 
+// TestSearch_MultipleTagFilterDoesNotDuplicate guards against the JOIN-based
+// tag filter that previously multiplied result rows by the number of matching
+// tags on each transaction. A transaction carrying N of the filter's tags
+// must still appear exactly once.
+func (suite *TransactionDeleteTestWithDBSuite) TestSearch_MultipleTagFilterDoesNotDuplicate() {
+	ctx := context.Background()
+
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	account, err := suite.createTestAccount(ctx, user)
+	suite.Require().NoError(err)
+	category, err := suite.createTestCategory(ctx, user)
+	suite.Require().NoError(err)
+
+	tag1, err := suite.createTestTag(ctx, user)
+	suite.Require().NoError(err)
+	tag2, err := suite.createTestTag(ctx, user)
+	suite.Require().NoError(err)
+	tag3, err := suite.createTestTag(ctx, user)
+	suite.Require().NoError(err)
+	tag4, err := suite.createTestTag(ctx, user)
+	suite.Require().NoError(err)
+
+	txID, err := suite.Services.Transaction.Create(ctx, user.ID, &domain.TransactionCreateRequest{
+		AccountID:       account.ID,
+		CategoryID:      category.ID,
+		TransactionType: domain.TransactionTypeExpense,
+		Amount:          5000,
+		Date:            domain.Date{Time: time.Now().UTC()},
+		Description:     "multi-tag tx",
+		Tags: []domain.Tag{
+			{ID: tag1.ID, Name: tag1.Name},
+			{ID: tag2.ID, Name: tag2.Name},
+			{ID: tag3.ID, Name: tag3.Name},
+			{ID: tag4.ID, Name: tag4.Name},
+		},
+	})
+	suite.Require().NoError(err)
+
+	txs, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user.ID,
+		TagIDs: []int{tag1.ID, tag2.ID, tag3.ID, tag4.ID},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(txs, 1, "tx with 4 matching tags must not be duplicated 4x")
+	suite.Assert().Equal(txID, txs[0].ID)
+}
+
 // TestDelete_Standalone_PropagationCurrentAndFuture exercises
 // deleteCurrentAndFutureInstallmentsOfRecurrence when TransactionRecurrenceID == nil.
 func (suite *TransactionDeleteTestWithDBSuite) TestDelete_Standalone_PropagationCurrentAndFuture() {


### PR DESCRIPTION
## Summary
Fixed a bug in the transaction search query where filtering by multiple tags would duplicate result rows. A transaction matching N of the filtered tags would appear N times in the result set instead of once.

## Changes
- **backend/internal/repository/transaction_repository.go**: Replaced JOIN-based tag filtering with an EXISTS subquery to prevent row multiplication when a transaction matches multiple filter tags.
- **backend/internal/service/transaction_coverage_gaps_test.go**: Added `TestSearch_MultipleTagFilterDoesNotDuplicate` test case to guard against regression. The test creates a transaction with 4 tags and filters by all 4, verifying the transaction appears exactly once in results.

## Implementation Details
The previous implementation used:
```sql
JOIN transaction_tags ON transaction_tags.transaction_id = transactions.id
WHERE transaction_tags.tag_id IN (...)
```

This caused a Cartesian product effect—each matching tag row would duplicate the transaction row in the result set.

The fix uses an EXISTS subquery:
```sql
WHERE EXISTS (SELECT 1 FROM transaction_tags tt WHERE tt.transaction_id = transactions.id AND tt.tag_id IN (...))
```

This preserves the one-row-per-transaction invariant while still filtering correctly for transactions that have any of the specified tags.

https://claude.ai/code/session_01P5q8Xc3nt9ia1fTxqUB1Pd