### PR TITLE
Add split percentage selection to invite flow

### DIFF
--- a/backend/internal/service/test_setup_with_db.go
+++ b/backend/internal/service/test_setup_with_db.go
@@ -197,7 +197,7 @@ func (suite *ServiceTestWithDBSuite) createAcceptedTestUserConnection(ctx contex
 	assert.Greater(suite.T(), userConnection.ToAccountID, 0)
 
 	assert.Equal(suite.T(), fromDefaultSplitPercentage, userConnection.FromDefaultSplitPercentage)
-	assert.Equal(suite.T(), fromDefaultSplitPercentage, userConnection.ToDefaultSplitPercentage)
+	assert.Equal(suite.T(), 100-fromDefaultSplitPercentage, userConnection.ToDefaultSplitPercentage)
 	assert.Equal(suite.T(), domain.UserConnectionStatusPending, userConnection.ConnectionStatus)
 
 	err = suite.Services.UserConnection.UpdateStatus(ctx, toUserID, userConnection.ID, domain.UserConnectionStatusAccepted)

--- a/backend/internal/service/user_connection_service.go
+++ b/backend/internal/service/user_connection_service.go
@@ -75,7 +75,7 @@ func (s *userConnectionService) Create(ctx context.Context, fromUserID, toUserID
 		FromDefaultSplitPercentage: fromDefaultSplitPercentage,
 		ToUserID:                   toUserID,
 		ToAccountID:                toAccount.ID,
-		ToDefaultSplitPercentage:   fromDefaultSplitPercentage,
+		ToDefaultSplitPercentage:   100 - fromDefaultSplitPercentage,
 		ConnectionStatus:           domain.UserConnectionStatusPending,
 	}); err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
@@ -139,7 +139,7 @@ func (s *userConnectionService) AcceptInviteByExternalID(ctx context.Context, cu
 		FromDefaultSplitPercentage: fromDefaultSplitPercentage,
 		ToUserID:                   currentUserID,
 		ToAccountID:                currentUserAccount.ID,
-		ToDefaultSplitPercentage:   fromDefaultSplitPercentage,
+		ToDefaultSplitPercentage:   100 - fromDefaultSplitPercentage,
 		ConnectionStatus:           domain.UserConnectionStatusAccepted,
 	})
 	if err != nil {

--- a/frontend/src/api/userConnections.ts
+++ b/frontend/src/api/userConnections.ts
@@ -29,6 +29,12 @@ export async function fetchInviteInfo(externalId: string): Promise<UserConnectio
   return res.json()
 }
 
+export async function fetchUserConnections(): Promise<UserConnections.Connection[]> {
+  const res = await fetch(`${apiUrl}/api/user-connections`, { credentials: 'include' })
+  if (!res.ok) throw new Error('Failed to fetch user connections')
+  return res.json()
+}
+
 export type AcceptInviteResult = {
   alreadyConnected: boolean
   connection: UserConnections.Connection

--- a/frontend/src/api/userConnections.ts
+++ b/frontend/src/api/userConnections.ts
@@ -29,19 +29,32 @@ export async function fetchInviteInfo(externalId: string): Promise<UserConnectio
   return res.json()
 }
 
-export async function acceptInvite(externalId: string): Promise<UserConnections.Connection> {
+export type AcceptInviteResult = {
+  alreadyConnected: boolean
+  connection: UserConnections.Connection
+}
+
+export async function acceptInvite(
+  externalId: string,
+  splitPercentage = 50,
+): Promise<AcceptInviteResult> {
   const res = await fetch(`${apiUrl}/api/user-connections/accept-invite`, {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ external_id: externalId, from_default_split_percentage: 50 }),
+    body: JSON.stringify({
+      external_id: externalId,
+      from_default_split_percentage: splitPercentage,
+    }),
   })
   if (res.status === 409) {
-    return res.json().catch(() => ({}) as UserConnections.Connection)
+    const conn = await res.json().catch(() => ({}) as UserConnections.Connection)
+    return { alreadyConnected: true, connection: conn }
   }
   if (!res.ok) {
     const err = await res.json().catch(() => ({}))
     throw new Error(err.message ?? 'Failed to accept invite')
   }
-  return res.json()
+  const conn = (await res.json()) as UserConnections.Connection
+  return { alreadyConnected: false, connection: conn }
 }

--- a/frontend/src/components/InviteDrawer.tsx
+++ b/frontend/src/components/InviteDrawer.tsx
@@ -1,53 +1,132 @@
-import { Stack, Text, TextInput, Button, CopyButton, Group } from '@mantine/core'
-import { IconCopy, IconCheck } from '@tabler/icons-react'
+import { useState } from 'react'
+import { Box, Button, CopyButton, Group, Stack, Text, TextInput } from '@mantine/core'
+import { IconCheck, IconCopy, IconInfoCircle } from '@tabler/icons-react'
 import { useMe } from '@/hooks/useMe'
 import { CommonTestIds } from '@/testIds'
 import { useDrawerContext } from '@/utils/renderDrawer'
 import { ResponsiveDrawer } from '@/components/ResponsiveDrawer'
+import { PartnerAvatarPair } from '@/components/connections/PartnerAvatarPair'
+import { SplitSelector } from '@/components/connections/SplitSelector'
+import { SplitFlowDiagram } from '@/components/connections/SplitFlowDiagram'
+
+function buildInviteUrl(externalId: string, splitPct: number) {
+  const base = `${window.location.origin}/connect-with/${externalId}`
+  if (splitPct === 50) return base
+  return `${base}?split=${splitPct}`
+}
 
 export function InviteDrawer() {
   const { opened, reject } = useDrawerContext<void>()
   const { query: meQuery } = useMe()
   const user = meQuery.data
 
+  const [partnerName, setPartnerName] = useState('')
+  const [splitValue, setSplitValue] = useState<number | 'custom'>(50)
+  const [customSplit, setCustomSplit] = useState(65)
+
+  const effectiveSplit = splitValue === 'custom' ? customSplit : splitValue
+  const trimmedPartner = partnerName.trim()
+  const partnerHasName = trimmedPartner.length > 0
+  const partnerDisplay = partnerHasName ? trimmedPartner : 'Parceiro(a)'
+
   const inviteUrl = user?.external_id
-    ? `${window.location.origin}/connect-with/${user.external_id}`
+    ? buildInviteUrl(user.external_id, effectiveSplit)
     : ''
+
+  const userName = user?.name ?? 'Você'
+  const userFirstName = userName.split(' ')[0] ?? userName
 
   return (
     <ResponsiveDrawer
       opened={opened}
       onClose={reject}
-      title="Criar Conexão"
+      title="Criar conexão"
       data-testid={CommonTestIds.DrawerInvite}
+      padding={0}
     >
-      <Stack gap="lg">
-        <Text size="sm" c="dimmed">
-          Compartilhe o link abaixo com seu parceiro. Ao acessar o link, ele poderá aceitar a conexão com você.
-        </Text>
+      <Stack gap={0} style={{ minHeight: '100%' }}>
+        <PartnerAvatarPair
+          userName={userFirstName}
+          userAvatarUrl={user?.avatar_url}
+          partnerName={trimmedPartner || undefined}
+        />
 
-        <Stack gap="xs">
-          <Text size="sm" fw={500}>Seu link de convite</Text>
-          <Group gap="xs" wrap="nowrap">
+        <Stack gap="lg" p="md">
+          <Box>
+            <Group justify="space-between" align="baseline" mb={6}>
+              <Text size="sm" fw={600} c="dimmed">
+                Como você chama essa pessoa?
+              </Text>
+              <Text size="xs" c="dimmed">Opcional</Text>
+            </Group>
             <TextInput
-              value={inviteUrl}
-              readOnly
-              style={{ flex: 1 }}
-              onClick={(e) => (e.target as HTMLInputElement).select()}
+              data-testid={CommonTestIds.InvitePartnerNameInput}
+              value={partnerName}
+              onChange={(e) => setPartnerName(e.currentTarget.value)}
+              placeholder="Ex.: Amanda, meu marido, mãe…"
+              maxLength={40}
             />
+            <Text size="xs" c="dimmed" mt={6}>
+              Só pra ficar mais claro pra você aqui. O nome real virá quando a outra
+              pessoa aceitar.
+            </Text>
+          </Box>
+
+          <SplitSelector
+            value={splitValue}
+            customValue={customSplit}
+            userName={userFirstName}
+            userAvatarUrl={user?.avatar_url}
+            partnerName={partnerDisplay}
+            partnerHasName={partnerHasName}
+            onChange={setSplitValue}
+            onCustomChange={setCustomSplit}
+          />
+
+          <SplitFlowDiagram
+            split={effectiveSplit}
+            userName={userFirstName}
+            userAvatarUrl={user?.avatar_url}
+            partnerName={partnerDisplay}
+            partnerHasName={partnerHasName}
+          />
+        </Stack>
+
+        <Box
+          mt="auto"
+          p="md"
+          style={{
+            borderTop: '1px solid var(--mantine-color-default-border)',
+            background: 'var(--mantine-color-body)',
+            position: 'sticky',
+            bottom: 0,
+          }}
+        >
+          <Stack gap={8}>
             <CopyButton value={inviteUrl} timeout={2000}>
               {({ copied, copy }) => (
                 <Button
+                  fullWidth
+                  size="md"
                   color={copied ? 'teal' : 'blue'}
                   onClick={copy}
+                  disabled={!inviteUrl}
                   leftSection={copied ? <IconCheck size={16} /> : <IconCopy size={16} />}
+                  data-testid={CommonTestIds.InviteCopyLink}
+                  title={inviteUrl}
                 >
-                  {copied ? 'Copiado!' : 'Copiar'}
+                  {copied ? 'Link copiado!' : 'Copiar link de convite'}
                 </Button>
               )}
             </CopyButton>
-          </Group>
-        </Stack>
+            <Group gap={6} justify="center">
+              <IconInfoCircle size={12} color="var(--mantine-color-dimmed)" />
+              <Text size="xs" c="dimmed">
+                Link único — envie no seu app favorito
+              </Text>
+            </Group>
+          </Stack>
+        </Box>
       </Stack>
     </ResponsiveDrawer>
   )

--- a/frontend/src/components/connections/ConnectedAlreadyCard.tsx
+++ b/frontend/src/components/connections/ConnectedAlreadyCard.tsx
@@ -1,0 +1,43 @@
+import { Button, Paper, Stack, Text, ThemeIcon } from '@mantine/core'
+import { IconCheck } from '@tabler/icons-react'
+import { CommonTestIds } from '@/testIds'
+
+interface ConnectedAlreadyCardProps {
+  inviterName: string
+  onGoToApp: () => void
+}
+
+export function ConnectedAlreadyCard({ inviterName, onGoToApp }: ConnectedAlreadyCardProps) {
+  return (
+    <Paper
+      withBorder
+      shadow="sm"
+      radius="md"
+      p="xl"
+      maw={460}
+      w="100%"
+    >
+      <Stack align="center" gap="md">
+        <ThemeIcon size={56} radius="xl" color="teal" variant="light">
+          <IconCheck size={28} />
+        </ThemeIcon>
+        <Stack gap={6} align="center">
+          <Text fw={700} size="xl" ta="center">
+            Vocês já estão conectados
+          </Text>
+          <Text size="sm" c="dimmed" ta="center">
+            Você e <Text component="span" fw={700}>{inviterName}</Text> já compartilham finanças.
+            Não é preciso aceitar de novo.
+          </Text>
+        </Stack>
+        <Button
+          data-testid={CommonTestIds.ConnectWithGoToApp}
+          onClick={onGoToApp}
+          mt="xs"
+        >
+          Ir para o app
+        </Button>
+      </Stack>
+    </Paper>
+  )
+}

--- a/frontend/src/components/connections/PartnerAvatarPair.tsx
+++ b/frontend/src/components/connections/PartnerAvatarPair.tsx
@@ -1,0 +1,76 @@
+import { Avatar, Box, Stack, Text, ThemeIcon, useMantineColorScheme } from '@mantine/core'
+import { IconLink } from '@tabler/icons-react'
+import { UserAvatar } from '@/components/UserAvatar'
+
+interface PartnerAvatarPairProps {
+  userName: string
+  userAvatarUrl?: string
+  partnerName?: string
+}
+
+export function PartnerAvatarPair({ userName, userAvatarUrl, partnerName }: PartnerAvatarPairProps) {
+  const { colorScheme } = useMantineColorScheme()
+  const isDark = colorScheme === 'dark'
+  const partnerInitial = partnerName?.trim().charAt(0).toUpperCase() || ''
+  const placeholder = partnerInitial === ''
+
+  return (
+    <Box
+      px="lg"
+      pt="lg"
+      pb="md"
+      style={{
+        background: isDark
+          ? 'linear-gradient(180deg, rgba(86, 143, 179, 0.12) 0%, transparent 100%)'
+          : 'linear-gradient(180deg, var(--mantine-color-blue-0) 0%, transparent 100%)',
+        borderBottom: '1px solid var(--mantine-color-default-border)',
+      }}
+    >
+      <Stack align="center" gap="sm">
+        <Box style={{ display: 'flex', alignItems: 'center' }}>
+          <UserAvatar
+            name={userName}
+            avatarUrl={userAvatarUrl}
+            size="xl"
+            color="blue"
+          />
+          <ThemeIcon
+            size={28}
+            radius="xl"
+            variant="filled"
+            color="blue"
+            style={{
+              marginInline: -10,
+              border: '2px solid var(--mantine-color-body)',
+              zIndex: 1,
+            }}
+          >
+            <IconLink size={14} />
+          </ThemeIcon>
+          <Avatar
+            size="xl"
+            radius="xl"
+            color={placeholder ? 'gray' : 'grape'}
+            variant={placeholder ? 'outline' : 'filled'}
+            style={
+              placeholder
+                ? { borderStyle: 'dashed', borderWidth: 2 }
+                : undefined
+            }
+          >
+            {placeholder ? '?' : partnerInitial}
+          </Avatar>
+        </Box>
+
+        <Stack gap={4} align="center">
+          <Text fw={700} size="lg" ta="center">
+            Convide quem divide a vida com você
+          </Text>
+          <Text size="sm" c="dimmed" ta="center" maw={340}>
+            Despesas, transferências e acertos compartilhados — sem planilha no meio.
+          </Text>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}

--- a/frontend/src/components/connections/SplitFlowDiagram.tsx
+++ b/frontend/src/components/connections/SplitFlowDiagram.tsx
@@ -1,0 +1,208 @@
+import { Avatar, Box, Group, Stack, Text } from '@mantine/core'
+import { IconInfoCircle } from '@tabler/icons-react'
+import { UserAvatar } from '@/components/UserAvatar'
+import { PARTNER_COLOR } from './SplitSelector'
+
+interface SplitFlowDiagramProps {
+  split: number
+  userName: string
+  userAvatarUrl?: string
+  partnerName: string
+  partnerHasName: boolean
+}
+
+const formatBrl = (n: number) => `R$ ${n.toFixed(2).replace('.', ',')}`
+
+export function SplitFlowDiagram({
+  split,
+  userName,
+  userAvatarUrl,
+  partnerName,
+  partnerHasName,
+}: SplitFlowDiagramProps) {
+  const userPct = split
+  const partnerPct = 100 - split
+
+  return (
+    <Box
+      style={{
+        borderRadius: 10,
+        border: '1px solid var(--mantine-color-default-border)',
+        background: 'var(--mantine-color-default-hover)',
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        px="sm"
+        py={8}
+        style={{
+          borderBottom: '1px solid var(--mantine-color-default-border)',
+          background: 'var(--mantine-color-body)',
+        }}
+      >
+        <Group gap={7}>
+          <IconInfoCircle size={12} />
+          <Text
+            size="xs"
+            fw={700}
+            c="dimmed"
+            tt="uppercase"
+            style={{ letterSpacing: '0.04em' }}
+          >
+            Como funciona · exemplo de R$ 100,00
+          </Text>
+        </Group>
+      </Box>
+
+      <Stack gap={4} p="sm">
+        <FlowRow
+          avatar={<UserAvatar name={userName} avatarUrl={userAvatarUrl} size="sm" color="blue" />}
+          title={<><Text component="span" fw={700}>{userName}</Text> paga a despesa</>}
+          amount={formatBrl(100)}
+          amountColor="var(--mantine-color-text)"
+        />
+
+        <FlowArrow />
+
+        <Box
+          p="xs"
+          style={{
+            borderRadius: 8,
+            background: 'var(--mantine-color-body)',
+            border: '1px solid var(--mantine-color-default-border)',
+          }}
+        >
+          <Text size="xs" c="dimmed" mb={6}>
+            App sugere divisão
+          </Text>
+          <Box
+            style={{
+              display: 'grid',
+              gridTemplateColumns: `${userPct}fr ${partnerPct}fr`,
+              gap: 3,
+              height: 22,
+              marginBottom: 8,
+              transition: 'grid-template-columns 180ms ease',
+            }}
+          >
+            <BarSegment color="var(--mantine-color-blue-6)" pct={userPct} />
+            <BarSegment
+              color={partnerHasName ? PARTNER_COLOR : 'var(--mantine-color-default-border)'}
+              pct={partnerPct}
+            />
+          </Box>
+          <Group justify="space-between" gap="xs">
+            <Text size="xs" c="dimmed" style={{ fontVariantNumeric: 'tabular-nums' }}>
+              <Text component="span" fw={700} style={{ color: 'var(--mantine-color-text)' }}>{userName}:</Text>{' '}
+              {formatBrl(userPct)}
+            </Text>
+            <Text size="xs" c="dimmed" ta="right" style={{ fontVariantNumeric: 'tabular-nums' }}>
+              <Text component="span" fw={700} style={{ color: 'var(--mantine-color-text)' }}>{partnerName}:</Text>{' '}
+              {formatBrl(partnerPct)}
+            </Text>
+          </Group>
+        </Box>
+
+        <FlowArrow />
+
+        <FlowRow
+          avatar={
+            <Avatar
+              size="sm"
+              radius="xl"
+              color={partnerHasName ? 'grape' : 'gray'}
+              variant={partnerHasName ? 'filled' : 'outline'}
+              style={!partnerHasName ? { borderStyle: 'dashed' } : undefined}
+            >
+              {partnerHasName ? partnerName.charAt(0).toUpperCase() : '?'}
+            </Avatar>
+          }
+          title={
+            <>
+              <Text component="span" fw={700}>{partnerName}</Text> fica devendo {userName}
+              <Text size="xs" c="dimmed" mt={2}>entra no acerto do mês</Text>
+            </>
+          }
+          amount={formatBrl(partnerPct)}
+          amountColor={PARTNER_COLOR}
+        />
+      </Stack>
+    </Box>
+  )
+}
+
+function BarSegment({ color, pct }: { color: string; pct: number }) {
+  return (
+    <Box
+      style={{
+        background: color,
+        borderRadius: 4,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 10.5,
+        fontWeight: 700,
+        color: '#fff',
+        fontVariantNumeric: 'tabular-nums',
+        minWidth: 0,
+        overflow: 'hidden',
+      }}
+    >
+      {pct}%
+    </Box>
+  )
+}
+
+interface FlowRowProps {
+  avatar: React.ReactNode
+  title: React.ReactNode
+  amount: string
+  amountColor: string
+}
+
+function FlowRow({ avatar, title, amount, amountColor }: FlowRowProps) {
+  return (
+    <Box
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '28px 1fr auto',
+        alignItems: 'center',
+        gap: 10,
+        padding: '6px 0',
+      }}
+    >
+      {avatar}
+      <Text size="xs" c="dimmed" style={{ lineHeight: 1.35 }}>
+        {title}
+      </Text>
+      <Text fw={700} style={{ color: amountColor, fontVariantNumeric: 'tabular-nums', fontSize: 13 }}>
+        {amount}
+      </Text>
+    </Box>
+  )
+}
+
+function FlowArrow() {
+  return (
+    <Box
+      style={{
+        display: 'flex',
+        justifyContent: 'flex-start',
+        paddingLeft: 13,
+        color: 'var(--mantine-color-dimmed)',
+        height: 14,
+        alignItems: 'center',
+      }}
+    >
+      <svg width="10" height="14" viewBox="0 0 10 14" fill="none" aria-hidden>
+        <path
+          d="M5 0v12M1 9l4 4 4-4"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </Box>
+  )
+}

--- a/frontend/src/components/connections/SplitSelector.tsx
+++ b/frontend/src/components/connections/SplitSelector.tsx
@@ -1,0 +1,263 @@
+import { Avatar, Box, Button, Group, Stack, Text, UnstyledButton } from '@mantine/core'
+import { IconArrowsHorizontal, IconPlus } from '@tabler/icons-react'
+import { UserAvatar } from '@/components/UserAvatar'
+import { CommonTestIds } from '@/testIds'
+
+const PRESETS = [50, 60, 70, 80] as const
+
+export const PARTNER_COLOR = '#9c6ade'
+
+interface SplitSelectorProps {
+  value: number | 'custom'
+  customValue: number
+  userName: string
+  userAvatarUrl?: string
+  partnerName: string
+  partnerHasName: boolean
+  onChange: (next: number | 'custom') => void
+  onCustomChange: (pct: number) => void
+}
+
+export function SplitSelector({
+  value,
+  customValue,
+  userName,
+  userAvatarUrl,
+  partnerName,
+  partnerHasName,
+  onChange,
+  onCustomChange,
+}: SplitSelectorProps) {
+  const isCustom = value === 'custom'
+  const userPct = isCustom ? customValue : (value as number)
+  const partnerPct = 100 - userPct
+
+  return (
+    <Stack gap="sm">
+      <Group justify="space-between" gap="xs">
+        <Group gap={6}>
+          <IconArrowsHorizontal size={14} />
+          <Text size="sm" fw={600}>Divisão padrão sugerida</Text>
+        </Group>
+        <Text size="xs" c="dimmed">Ajustável por transação</Text>
+      </Group>
+
+      <Box
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `${userPct}fr ${partnerPct}fr`,
+          gap: 4,
+          height: 56,
+          transition: 'grid-template-columns 180ms ease',
+        }}
+      >
+        <SplitBar
+          pct={userPct}
+          label={userName}
+          color="var(--mantine-color-blue-6)"
+          colorSoft="var(--mantine-color-blue-light)"
+          avatar={<UserAvatar name={userName} avatarUrl={userAvatarUrl} size="sm" color="blue" />}
+        />
+        <SplitBar
+          pct={partnerPct}
+          label={partnerName}
+          color={PARTNER_COLOR}
+          colorSoft="rgba(156, 106, 222, 0.15)"
+          placeholder={!partnerHasName}
+          avatar={
+            <Avatar
+              size="sm"
+              radius="xl"
+              color={partnerHasName ? 'grape' : 'gray'}
+              variant={partnerHasName ? 'filled' : 'outline'}
+              style={!partnerHasName ? { borderStyle: 'dashed' } : undefined}
+            >
+              {partnerHasName ? partnerName.charAt(0).toUpperCase() : '?'}
+            </Avatar>
+          }
+        />
+      </Box>
+
+      <Group gap="xs">
+        {PRESETS.map((pct) => {
+          const active = !isCustom && value === pct
+          return (
+            <UnstyledButton
+              key={pct}
+              data-testid={CommonTestIds.InviteSplitChip(pct)}
+              onClick={() => onChange(pct)}
+              px={11}
+              py={5}
+              style={{
+                borderRadius: 999,
+                fontSize: 12,
+                fontWeight: 600,
+                background: active ? 'var(--mantine-color-blue-6)' : 'transparent',
+                color: active ? '#fff' : 'var(--mantine-color-dimmed)',
+                border: `1px solid ${active ? 'var(--mantine-color-blue-6)' : 'var(--mantine-color-default-border)'}`,
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {pct}/{100 - pct}
+            </UnstyledButton>
+          )
+        })}
+        <UnstyledButton
+          data-testid={CommonTestIds.InviteSplitChipCustom}
+          onClick={() => onChange('custom')}
+          px={11}
+          py={5}
+          style={{
+            borderRadius: 999,
+            fontSize: 12,
+            fontWeight: 600,
+            background: isCustom ? 'var(--mantine-color-blue-light)' : 'transparent',
+            color: isCustom ? 'var(--mantine-color-blue-7)' : 'var(--mantine-color-dimmed)',
+            border: `1px dashed ${isCustom ? 'var(--mantine-color-blue-6)' : 'var(--mantine-color-default-border)'}`,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+          }}
+        >
+          {isCustom ? (
+            <>Personalizado · {customValue}/{100 - customValue}</>
+          ) : (
+            <>
+              <IconPlus size={11} /> Personalizar
+            </>
+          )}
+        </UnstyledButton>
+      </Group>
+
+      {isCustom && (
+        <CustomSplitEditor
+          userName={userName}
+          value={customValue}
+          onChange={onCustomChange}
+        />
+      )}
+    </Stack>
+  )
+}
+
+interface SplitBarProps {
+  pct: number
+  label: string
+  color: string
+  colorSoft: string
+  avatar: React.ReactNode
+  placeholder?: boolean
+}
+
+function SplitBar({ pct, label, color, colorSoft, avatar, placeholder }: SplitBarProps) {
+  return (
+    <Box
+      px="xs"
+      py={8}
+      style={{
+        borderRadius: 8,
+        background: colorSoft,
+        border: `1px ${placeholder ? 'dashed' : 'solid'} ${color}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 8,
+        minWidth: 0,
+        overflow: 'hidden',
+        opacity: placeholder ? 0.9 : 1,
+      }}
+    >
+      <Group gap={8} wrap="nowrap" style={{ minWidth: 0 }}>
+        {avatar}
+        <Text size="xs" fw={600} truncate>
+          {label}
+        </Text>
+      </Group>
+      <Text fw={700} style={{ color, fontVariantNumeric: 'tabular-nums' }}>
+        {pct}%
+      </Text>
+    </Box>
+  )
+}
+
+interface CustomSplitEditorProps {
+  value: number
+  userName: string
+  onChange: (pct: number) => void
+}
+
+function CustomSplitEditor({ value, userName, onChange }: CustomSplitEditorProps) {
+  const clamp = (n: number) => Math.max(1, Math.min(99, n))
+
+  return (
+    <Box
+      p="sm"
+      style={{
+        borderRadius: 8,
+        background: 'var(--mantine-color-body)',
+        border: '1px solid var(--mantine-color-default-border)',
+      }}
+    >
+      <Group justify="space-between" gap="md">
+        <Text size="xs" fw={600}>
+          {userName} paga
+        </Text>
+        <Group gap={0} style={{
+          border: '1px solid var(--mantine-color-default-border)',
+          borderRadius: 6,
+          height: 30,
+          overflow: 'hidden',
+        }}>
+          <Button
+            data-testid={CommonTestIds.InviteSplitCustomDec}
+            variant="subtle"
+            color="gray"
+            size="xs"
+            radius={0}
+            onClick={() => onChange(clamp(value - 5))}
+            style={{
+              width: 28,
+              height: '100%',
+              borderRight: '1px solid var(--mantine-color-default-border)',
+              fontSize: 14,
+              fontWeight: 600,
+            }}
+            px={0}
+          >
+            −
+          </Button>
+          <Box style={{
+            width: 50,
+            textAlign: 'center',
+            fontSize: 13,
+            fontWeight: 700,
+            fontVariantNumeric: 'tabular-nums',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            {value}%
+          </Box>
+          <Button
+            data-testid={CommonTestIds.InviteSplitCustomInc}
+            variant="subtle"
+            color="gray"
+            size="xs"
+            radius={0}
+            onClick={() => onChange(clamp(value + 5))}
+            style={{
+              width: 28,
+              height: '100%',
+              borderLeft: '1px solid var(--mantine-color-default-border)',
+              fontSize: 14,
+              fontWeight: 600,
+            }}
+            px={0}
+          >
+            +
+          </Button>
+        </Group>
+      </Group>
+    </Box>
+  )
+}

--- a/frontend/src/components/connections/SuggestedSplitCard.tsx
+++ b/frontend/src/components/connections/SuggestedSplitCard.tsx
@@ -1,0 +1,83 @@
+import { Box, Group, Stack, Text } from '@mantine/core'
+import { IconSparkles } from '@tabler/icons-react'
+
+interface SuggestedSplitCardProps {
+  inviterPct: number
+  inviterName: string
+}
+
+export function SuggestedSplitCard({ inviterPct, inviterName }: SuggestedSplitCardProps) {
+  const youPct = 100 - inviterPct
+  return (
+    <Stack
+      gap="xs"
+      p="sm"
+      style={{
+        borderRadius: 10,
+        background: 'rgba(244, 162, 97, 0.10)',
+        border: '1px solid rgba(244, 162, 97, 0.35)',
+      }}
+    >
+      <Group gap={8}>
+        <IconSparkles size={14} />
+        <Text size="sm" fw={700}>
+          {inviterName} sugeriu uma divisão diferente
+        </Text>
+      </Group>
+      <Box
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `${inviterPct}fr ${youPct}fr`,
+          gap: 4,
+          height: 36,
+        }}
+      >
+        <SplitChunk
+          background="var(--mantine-color-blue-light)"
+          borderColor="var(--mantine-color-blue-6)"
+          textColor="var(--mantine-color-blue-7)"
+          label={`${inviterName} · ${inviterPct}%`}
+        />
+        <SplitChunk
+          background="rgba(156,106,222,0.15)"
+          borderColor="#9c6ade"
+          textColor="#7048b8"
+          label={`Você · ${youPct}%`}
+        />
+      </Box>
+      <Text size="xs" c="dimmed">
+        Você pode aceitar esta sugestão ou usar o padrão 50/50.
+      </Text>
+    </Stack>
+  )
+}
+
+function SplitChunk({
+  background,
+  borderColor,
+  textColor,
+  label,
+}: {
+  background: string
+  borderColor: string
+  textColor: string
+  label: string
+}) {
+  return (
+    <Box
+      style={{
+        borderRadius: 6,
+        background,
+        border: `1px solid ${borderColor}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 12,
+        fontWeight: 700,
+        color: textColor,
+      }}
+    >
+      {label}
+    </Box>
+  )
+}

--- a/frontend/src/components/onboarding/AcceptInviteStep.tsx
+++ b/frontend/src/components/onboarding/AcceptInviteStep.tsx
@@ -1,0 +1,180 @@
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Group,
+  Loader,
+  Stack,
+  Text,
+  ThemeIcon,
+} from '@mantine/core'
+import {
+  IconAlertCircle,
+  IconArrowsHorizontal,
+  IconReceipt,
+  IconWallet,
+} from '@tabler/icons-react'
+import { useInviteInfo } from '@/hooks/useInviteInfo'
+import { useAcceptInvite } from '@/hooks/useAcceptInvite'
+import { getInitials } from '@/utils/getInitials'
+import { CommonTestIds, OnboardingTestIds } from '@/testIds'
+import { SuggestedSplitCard } from '@/components/connections/SuggestedSplitCard'
+
+interface Props {
+  externalId: string
+  suggestedSplit?: number
+  onAccepted: () => void
+  onSkip: () => void
+}
+
+export function AcceptInviteStep({ externalId, suggestedSplit, onAccepted, onSkip }: Props) {
+  const { query: inviteQuery } = useInviteInfo(externalId)
+  const { mutation: acceptMutation } = useAcceptInvite({
+    onSuccess: () => onAccepted(),
+  })
+
+  const hasSuggestion =
+    typeof suggestedSplit === 'number' && suggestedSplit !== 50
+
+  function handleAccept() {
+    acceptMutation.mutate({ externalId, splitPercentage: suggestedSplit ?? 50 })
+  }
+
+  if (inviteQuery.isLoading) {
+    return (
+      <Stack align="center" gap="md" py="xl">
+        <Loader />
+        <Text c="dimmed" size="sm">Carregando convite...</Text>
+      </Stack>
+    )
+  }
+
+  if (inviteQuery.isError || !inviteQuery.data) {
+    return (
+      <Stack gap="md">
+        <Alert icon={<IconAlertCircle size={18} />} color="red" title="Convite inválido">
+          Não conseguimos carregar este convite. Você pode continuar a configuração e
+          pedir um novo link depois.
+        </Alert>
+        <Button variant="subtle" onClick={onSkip}>Pular e continuar</Button>
+      </Stack>
+    )
+  }
+
+  const inviter = inviteQuery.data
+  const inviterFirstName = inviter.name.split(' ')[0] ?? inviter.name
+
+  return (
+    <Stack gap="md" data-testid={OnboardingTestIds.StepAcceptInvite}>
+      <Stack gap={4}>
+        <Text fw={600} size="lg">Você recebeu um convite</Text>
+        <Text c="dimmed" size="sm">
+          Antes de configurar suas contas e categorias, aceite a conexão para já começar a
+          dividir despesas com {inviterFirstName}.
+        </Text>
+      </Stack>
+
+      <Stack
+        align="center"
+        gap="xs"
+        p="md"
+        style={{
+          borderRadius: 10,
+          background: 'var(--mantine-color-default-hover)',
+          border: '1px solid var(--mantine-color-default-border)',
+        }}
+      >
+        <Avatar size={68} radius="xl" color="blue">
+          {getInitials(inviter.name)}
+        </Avatar>
+        <Text fw={700} size="lg">{inviter.name}</Text>
+        <Text size="sm" c="dimmed">{inviter.email}</Text>
+      </Stack>
+
+      {hasSuggestion && (
+        <SuggestedSplitCard
+          inviterPct={suggestedSplit}
+          inviterName={inviterFirstName}
+        />
+      )}
+
+      <Box
+        p="md"
+        style={{
+          borderRadius: 10,
+          background: 'var(--mantine-color-default-hover)',
+          border: '1px solid var(--mantine-color-default-border)',
+        }}
+      >
+        <Stack gap="xs">
+          <Text
+            size="xs"
+            fw={700}
+            c="dimmed"
+            tt="uppercase"
+            style={{ letterSpacing: '0.04em' }}
+          >
+            Ao aceitar
+          </Text>
+          <Bullet icon={<IconWallet size={13} />}>
+            Duas contas compartilhadas serão criadas — uma em cada app.
+          </Bullet>
+          <Bullet icon={<IconArrowsHorizontal size={13} />}>
+            Vocês poderão dividir transações com split{' '}
+            {hasSuggestion ? (
+              <Text component="span" fw={700}>
+                {suggestedSplit}/{100 - suggestedSplit} sugerido
+              </Text>
+            ) : (
+              <>
+                de <Text component="span" fw={700}>50/50</Text> por padrão
+              </>
+            )}
+            .
+          </Bullet>
+          <Bullet icon={<IconReceipt size={13} />}>
+            Os acertos do mês passam a ser calculados automaticamente.
+          </Bullet>
+        </Stack>
+      </Box>
+
+      {acceptMutation.isError && (
+        <Alert icon={<IconAlertCircle size={16} />} color="red">
+          {acceptMutation.error?.message ?? 'Erro ao aceitar convite. Tente novamente.'}
+        </Alert>
+      )}
+
+      <Stack gap="xs">
+        <Button
+          size="md"
+          onClick={handleAccept}
+          loading={acceptMutation.isPending}
+          data-testid={CommonTestIds.ConnectWithAccept}
+        >
+          Aceitar conexão
+        </Button>
+        <Button
+          variant="subtle"
+          color="gray"
+          onClick={onSkip}
+          disabled={acceptMutation.isPending}
+          data-testid={OnboardingTestIds.BtnSkipInvite}
+        >
+          Pular por enquanto
+        </Button>
+      </Stack>
+    </Stack>
+  )
+}
+
+function Bullet({ icon, children }: { icon: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <Group gap="xs" wrap="nowrap" align="flex-start">
+      <ThemeIcon size={22} radius={6} color="blue" variant="light" style={{ flexShrink: 0, marginTop: -1 }}>
+        {icon}
+      </ThemeIcon>
+      <Text size="sm" c="dimmed" style={{ lineHeight: 1.5 }}>{children}</Text>
+    </Group>
+  )
+}

--- a/frontend/src/components/onboarding/CategoriesStep.tsx
+++ b/frontend/src/components/onboarding/CategoriesStep.tsx
@@ -142,7 +142,9 @@ function CategoryRow({ category, checked, onToggle, onUpdateName, onRemove, isPa
         borderRadius: 6,
         cursor: disabled ? 'not-allowed' : 'pointer',
         opacity: disabled ? 0.5 : 1,
-        background: isParent ? 'var(--mantine-color-gray-0)' : undefined,
+        background: isParent
+          ? 'light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6))'
+          : undefined,
       }}
     >
       <Checkbox
@@ -221,7 +223,9 @@ function InlineAdd({ onSave, onCancel, isParent }: InlineAddProps) {
       style={{
         padding: '0.5rem 0.75rem',
         borderRadius: 6,
-        background: isParent ? 'var(--mantine-color-gray-0)' : undefined,
+        background: isParent
+          ? 'light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6))'
+          : undefined,
       }}
     >
       <Box w={28} ta="center">

--- a/frontend/src/hooks/useAcceptInvite.ts
+++ b/frontend/src/hooks/useAcceptInvite.ts
@@ -1,9 +1,13 @@
 import { useMutation } from '@tanstack/react-query'
-import { acceptInvite } from '@/api/userConnections'
+import { acceptInvite, type AcceptInviteResult } from '@/api/userConnections'
 
-export function useAcceptInvite() {
+type AcceptArgs = { externalId: string; splitPercentage?: number }
+
+export function useAcceptInvite(options?: { onSuccess?: (result: AcceptInviteResult) => void }) {
   const mutation = useMutation({
-    mutationFn: (externalId: string) => acceptInvite(externalId),
+    mutationFn: ({ externalId, splitPercentage }: AcceptArgs) =>
+      acceptInvite(externalId, splitPercentage),
+    onSuccess: options?.onSuccess,
   })
   return { mutation }
 }

--- a/frontend/src/hooks/useUserConnections.ts
+++ b/frontend/src/hooks/useUserConnections.ts
@@ -1,0 +1,16 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchUserConnections, UserConnections } from '@/api/userConnections'
+import { QueryKeys } from '@/utils/queryKeys'
+
+export function useUserConnections<T = UserConnections.Connection[]>(
+  select?: (data: UserConnections.Connection[]) => T,
+) {
+  const queryClient = useQueryClient()
+  const query = useQuery({
+    queryKey: [QueryKeys.UserConnections],
+    queryFn: fetchUserConnections,
+    select,
+  })
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: [QueryKeys.UserConnections] })
+  return { query, invalidate }
+}

--- a/frontend/src/pages/ConnectWithPage.tsx
+++ b/frontend/src/pages/ConnectWithPage.tsx
@@ -19,6 +19,7 @@ import {
 } from '@tabler/icons-react'
 import { useInviteInfo } from '@/hooks/useInviteInfo'
 import { useAcceptInvite } from '@/hooks/useAcceptInvite'
+import { useUserConnections } from '@/hooks/useUserConnections'
 import { getInitials } from '@/utils/getInitials'
 import { CommonTestIds } from '@/testIds'
 import { SuggestedSplitCard } from '@/components/connections/SuggestedSplitCard'
@@ -29,6 +30,14 @@ export function ConnectWithPage() {
   const search = useSearch({ from: '/_authenticated/connect-with/$externalId' })
   const navigate = useNavigate()
   const { query: inviteQuery } = useInviteInfo(externalId)
+  const inviterId = inviteQuery.data?.id
+  const { query: existingConnectionQuery } = useUserConnections((connections) =>
+    inviterId
+      ? connections.find(
+          (c) => c.from_user_id === inviterId && c.connection_status === 'accepted',
+        )
+      : undefined,
+  )
   const { mutation: acceptMutation } = useAcceptInvite({
     onSuccess: (result) => {
       if (!result.alreadyConnected) {
@@ -84,7 +93,10 @@ export function ConnectWithPage() {
   const inviter = inviteQuery.data
   const inviterFirstName = inviter.name.split(' ')[0] ?? inviter.name
 
-  if (acceptMutation.data?.alreadyConnected) {
+  const alreadyConnected =
+    acceptMutation.data?.alreadyConnected || Boolean(existingConnectionQuery.data)
+
+  if (alreadyConnected) {
     return (
       <PageShell>
         <ConnectedAlreadyCard inviterName={inviter.name} onGoToApp={goHome} />

--- a/frontend/src/pages/ConnectWithPage.tsx
+++ b/frontend/src/pages/ConnectWithPage.tsx
@@ -1,82 +1,196 @@
-import { Stack, Title, Text, Button, Loader, Alert, Avatar, Group, Paper } from '@mantine/core'
-import { useNavigate, useParams } from '@tanstack/react-router'
-import { IconAlertCircle, IconUsers } from '@tabler/icons-react'
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Group,
+  Loader,
+  Paper,
+  Stack,
+  Text,
+  ThemeIcon,
+} from '@mantine/core'
+import { useNavigate, useParams, useSearch } from '@tanstack/react-router'
+import {
+  IconAlertCircle,
+  IconArrowsHorizontal,
+  IconReceipt,
+  IconWallet,
+} from '@tabler/icons-react'
 import { useInviteInfo } from '@/hooks/useInviteInfo'
 import { useAcceptInvite } from '@/hooks/useAcceptInvite'
+import { getInitials } from '@/utils/getInitials'
+import { CommonTestIds } from '@/testIds'
+import { SuggestedSplitCard } from '@/components/connections/SuggestedSplitCard'
+import { ConnectedAlreadyCard } from '@/components/connections/ConnectedAlreadyCard'
 
 export function ConnectWithPage() {
   const { externalId } = useParams({ from: '/_authenticated/connect-with/$externalId' })
+  const search = useSearch({ from: '/_authenticated/connect-with/$externalId' })
   const navigate = useNavigate()
   const { query: inviteQuery } = useInviteInfo(externalId)
-  const { mutation: acceptMutation } = useAcceptInvite()
+  const { mutation: acceptMutation } = useAcceptInvite({
+    onSuccess: (result) => {
+      if (!result.alreadyConnected) {
+        void navigate({ to: '/' })
+      }
+    },
+  })
+
+  const suggestedSplit = search.split
+  const hasSuggestion =
+    typeof suggestedSplit === 'number' && suggestedSplit !== 50
 
   function handleAccept() {
-    acceptMutation.mutate(externalId, {
-      onSuccess: () => navigate({ to: '/' }),
-    })
+    acceptMutation.mutate({ externalId, splitPercentage: suggestedSplit ?? 50 })
+  }
+
+  function goHome() {
+    void navigate({ to: '/' })
   }
 
   if (inviteQuery.isLoading) {
     return (
-      <Stack align="center" justify="center" h="60vh" gap="md">
-        <Loader size="lg" />
-        <Text c="dimmed" size="sm">Carregando convite...</Text>
-      </Stack>
+      <PageShell>
+        <Stack align="center" justify="center" gap="md" mih={240}>
+          <Loader size="lg" />
+          <Text c="dimmed" size="sm">Carregando convite...</Text>
+        </Stack>
+      </PageShell>
     )
   }
 
   if (inviteQuery.isError || !inviteQuery.data) {
     return (
-      <Stack align="center" justify="center" h="60vh" gap="md" p="xl">
-        <Alert icon={<IconAlertCircle size={18} />} color="red" title="Convite inválido" maw={400} w="100%">
-          Este link de convite não é válido ou expirou. Peça um novo link ao seu parceiro.
-        </Alert>
-        <Button variant="subtle" onClick={() => navigate({ to: '/' })}>
-          Voltar para o início
-        </Button>
-      </Stack>
+      <PageShell>
+        <Stack align="center" gap="md">
+          <Alert
+            icon={<IconAlertCircle size={18} />}
+            color="red"
+            title="Convite inválido"
+            maw={460}
+            w="100%"
+          >
+            Este link de convite não é válido ou expirou. Peça um novo link ao seu parceiro.
+          </Alert>
+          <Button variant="subtle" onClick={goHome}>
+            Voltar para o início
+          </Button>
+        </Stack>
+      </PageShell>
     )
   }
 
   const inviter = inviteQuery.data
-  const initials = inviter.name.split(' ').map((n: string) => n[0]).slice(0, 2).join('').toUpperCase()
+  const inviterFirstName = inviter.name.split(' ')[0] ?? inviter.name
+
+  if (acceptMutation.data?.alreadyConnected) {
+    return (
+      <PageShell>
+        <ConnectedAlreadyCard inviterName={inviter.name} onGoToApp={goHome} />
+      </PageShell>
+    )
+  }
 
   return (
-    <Stack align="center" justify="center" h="60vh" gap="xl" p="xl">
-      <Paper withBorder p="xl" radius="md" maw={420} w="100%">
-        <Stack gap="lg" align="center">
-          <IconUsers size={40} color="var(--mantine-color-blue-6)" />
-
-          <Stack gap="xs" align="center">
-            <Title order={3} ta="center">Convite de conexão</Title>
-            <Text c="dimmed" size="sm" ta="center">
-              Você foi convidado para se conectar com:
-            </Text>
-          </Stack>
-
-          <Group gap="sm">
-            <Avatar color="blue" radius="xl" size="md">{initials}</Avatar>
-            <Stack gap={2}>
-              <Text fw={600}>{inviter.name}</Text>
-              <Text size="xs" c="dimmed">{inviter.email}</Text>
-            </Stack>
-          </Group>
-
-          <Text size="sm" c="dimmed" ta="center">
-            Ao aceitar, vocês poderão gerenciar finanças compartilhadas juntos.
+    <PageShell>
+      <Paper
+        withBorder
+        shadow="sm"
+        radius="md"
+        p="xl"
+        maw={460}
+        w="100%"
+      >
+        <Stack gap="lg">
+          <Text
+            size="xs"
+            fw={700}
+            c="dimmed"
+            ta="center"
+            tt="uppercase"
+            style={{ letterSpacing: '0.05em' }}
+          >
+            Convite de conexão
           </Text>
 
+          <Stack align="center" gap="xs">
+            <Avatar size={76} radius="xl" color="blue">
+              {getInitials(inviter.name)}
+            </Avatar>
+            <Stack gap={2} align="center">
+              <Text size="xs" c="dimmed">
+                Você foi convidado para se conectar com
+              </Text>
+              <Text fw={700} size="xl">
+                {inviter.name}
+              </Text>
+              <Text size="sm" c="dimmed">
+                {inviter.email}
+              </Text>
+            </Stack>
+          </Stack>
+
+          {hasSuggestion && (
+            <SuggestedSplitCard
+              inviterPct={suggestedSplit}
+              inviterName={inviterFirstName}
+            />
+          )}
+
+          <Box
+            p="md"
+            style={{
+              borderRadius: 10,
+              background: 'var(--mantine-color-default-hover)',
+              border: '1px solid var(--mantine-color-default-border)',
+            }}
+          >
+            <Stack gap="xs">
+              <Text
+                size="xs"
+                fw={700}
+                c="dimmed"
+                tt="uppercase"
+                style={{ letterSpacing: '0.04em' }}
+              >
+                Ao aceitar
+              </Text>
+              <Bullet icon={<IconWallet size={13} />}>
+                Duas contas compartilhadas serão criadas — uma em cada app.
+              </Bullet>
+              <Bullet icon={<IconArrowsHorizontal size={13} />}>
+                Vocês poderão dividir transações com split{' '}
+                {hasSuggestion ? (
+                  <Text component="span" fw={700}>
+                    {suggestedSplit}/{100 - suggestedSplit} sugerido
+                  </Text>
+                ) : (
+                  <>
+                    de <Text component="span" fw={700}>50/50</Text> por padrão
+                  </>
+                )}
+                .
+              </Bullet>
+              <Bullet icon={<IconReceipt size={13} />}>
+                Os acertos do mês passam a ser calculados automaticamente.
+              </Bullet>
+            </Stack>
+          </Box>
+
           {acceptMutation.isError && (
-            <Alert icon={<IconAlertCircle size={16} />} color="red" w="100%">
+            <Alert icon={<IconAlertCircle size={16} />} color="red">
               {acceptMutation.error?.message ?? 'Erro ao aceitar convite. Tente novamente.'}
             </Alert>
           )}
 
-          <Stack gap="xs" w="100%">
+          <Stack gap="xs">
             <Button
               fullWidth
+              size="md"
               onClick={handleAccept}
               loading={acceptMutation.isPending}
+              data-testid={CommonTestIds.ConnectWithAccept}
             >
               Aceitar conexão
             </Button>
@@ -84,14 +198,48 @@ export function ConnectWithPage() {
               fullWidth
               variant="subtle"
               color="gray"
-              onClick={() => navigate({ to: '/' })}
+              onClick={goHome}
               disabled={acceptMutation.isPending}
+              data-testid={CommonTestIds.ConnectWithDecline}
             >
               Recusar
             </Button>
           </Stack>
         </Stack>
       </Paper>
+    </PageShell>
+  )
+}
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <Stack align="center" gap="xl" py="xl" px="md">
+      <Group gap={10}>
+        <img src="/icon.svg" width={28} height={28} alt="FinanceApp" />
+        <Text fw={700} size="lg" c="blue.7">
+          FinanceApp
+        </Text>
+      </Group>
+      {children}
     </Stack>
+  )
+}
+
+function Bullet({ icon, children }: { icon: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <Group gap="xs" wrap="nowrap" align="flex-start">
+      <ThemeIcon
+        size={22}
+        radius={6}
+        color="blue"
+        variant="light"
+        style={{ flexShrink: 0, marginTop: -1 }}
+      >
+        {icon}
+      </ThemeIcon>
+      <Text size="sm" c="dimmed" style={{ lineHeight: 1.5 }}>
+        {children}
+      </Text>
+    </Group>
   )
 }

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -1,12 +1,14 @@
 import { useMemo, useState } from 'react'
 import { Alert, Button, Container, Group, Paper, Stack, Stepper, Text } from '@mantine/core'
 import { IconAlertCircle } from '@tabler/icons-react'
+import { useSearch } from '@tanstack/react-router'
 import { useAccounts } from '@/hooks/useAccounts'
 import { useCategories } from '@/hooks/useCategories'
 import { useCompleteOnboarding, useOnboardingStatus } from '@/hooks/useOnboardingStatus'
 import { AccountsStep } from '@/components/onboarding/AccountsStep'
 import { CategoriesStep } from '@/components/onboarding/CategoriesStep'
 import { ImportStep } from '@/components/onboarding/ImportStep'
+import { AcceptInviteStep } from '@/components/onboarding/AcceptInviteStep'
 import { PRESET_COLORS } from '@/components/accounts/ColorSwatchPicker'
 import {
   buildInitialAccounts,
@@ -17,12 +19,31 @@ import {
 import type { OnboardingSetupRequest } from '@/api/onboarding'
 import { OnboardingTestIds } from '@/testIds'
 
-const STEP_ACCOUNTS = 0
-const STEP_CATEGORIES = 1
-const STEP_IMPORT = 2
+const STEP_INVITE = 'invite'
+const STEP_ACCOUNTS = 'accounts'
+const STEP_CATEGORIES = 'categories'
+const STEP_IMPORT = 'import'
+
+type OnboardingStepKey =
+  | typeof STEP_INVITE
+  | typeof STEP_ACCOUNTS
+  | typeof STEP_CATEGORIES
+  | typeof STEP_IMPORT
 
 export function OnboardingPage() {
-  const [step, setStep] = useState(STEP_ACCOUNTS)
+  const { invite, split } = useSearch({ from: '/_authenticated/onboarding' })
+  const hasInvite = Boolean(invite)
+
+  const stepOrder = useMemo<OnboardingStepKey[]>(
+    () =>
+      hasInvite
+        ? [STEP_INVITE, STEP_ACCOUNTS, STEP_CATEGORIES, STEP_IMPORT]
+        : [STEP_ACCOUNTS, STEP_CATEGORIES, STEP_IMPORT],
+    [hasInvite],
+  )
+
+  const [stepKey, setStepKey] = useState<OnboardingStepKey>(stepOrder[0])
+  const stepIndex = stepOrder.indexOf(stepKey)
   const [accounts, setAccounts] = useState<OnboardingAccount[]>(buildInitialAccounts)
   const [categories, setCategories] = useState<OnboardingCategoryItem[]>(buildInitialCategories)
 
@@ -35,9 +56,19 @@ export function OnboardingPage() {
       invalidateOnboarding()
       invalidateAccounts()
       invalidateCategories()
-      setStep(STEP_IMPORT)
+      setStepKey(STEP_IMPORT)
     },
   })
+
+  function goNext() {
+    const next = stepOrder[stepIndex + 1]
+    if (next) setStepKey(next)
+  }
+
+  function goPrev() {
+    const prev = stepOrder[stepIndex - 1]
+    if (prev) setStepKey(prev)
+  }
 
   // --- Account handlers ---
 
@@ -156,21 +187,30 @@ export function OnboardingPage() {
         </Stack>
 
         <Stepper
-          active={step}
+          active={stepIndex}
           allowNextStepsSelect={false}
           onStepClick={(s) => {
-            if (s < step) setStep(s)
+            if (s < stepIndex) setStepKey(stepOrder[s])
           }}
           size="sm"
           data-testid={OnboardingTestIds.Stepper}
         >
+          {hasInvite && <Stepper.Step label="Conexão" />}
           <Stepper.Step label="Contas" />
           <Stepper.Step label="Categorias" />
           <Stepper.Step label="Importar" />
         </Stepper>
 
         <Paper withBorder radius="md" p="md">
-          {step === STEP_ACCOUNTS && (
+          {stepKey === STEP_INVITE && invite && (
+            <AcceptInviteStep
+              externalId={invite}
+              suggestedSplit={split}
+              onAccepted={goNext}
+              onSkip={goNext}
+            />
+          )}
+          {stepKey === STEP_ACCOUNTS && (
             <AccountsStep
               accounts={accounts}
               onToggle={toggleAccount}
@@ -180,7 +220,7 @@ export function OnboardingPage() {
               onRemoveAccount={removeAccount}
             />
           )}
-          {step === STEP_CATEGORIES && (
+          {stepKey === STEP_CATEGORIES && (
             <CategoriesStep
               categories={categories}
               onToggle={toggleCategory}
@@ -190,7 +230,7 @@ export function OnboardingPage() {
               onRemove={removeCategory}
             />
           )}
-          {step === STEP_IMPORT && <ImportStep />}
+          {stepKey === STEP_IMPORT && <ImportStep />}
         </Paper>
 
         {error && (
@@ -204,19 +244,19 @@ export function OnboardingPage() {
           </Alert>
         )}
 
-        {step !== STEP_IMPORT && (
+        {stepKey !== STEP_IMPORT && stepKey !== STEP_INVITE && (
           <Group justify="space-between">
             <Button
               variant="subtle"
-              onClick={() => setStep((s) => Math.max(STEP_ACCOUNTS, s - 1))}
-              disabled={step === STEP_ACCOUNTS || completeMutation.isPending}
+              onClick={goPrev}
+              disabled={stepIndex === 0 || completeMutation.isPending}
               data-testid={OnboardingTestIds.BtnBack}
             >
               Voltar
             </Button>
-            {step === STEP_ACCOUNTS ? (
+            {stepKey === STEP_ACCOUNTS ? (
               <Button
-                onClick={() => setStep(STEP_CATEGORIES)}
+                onClick={() => setStepKey(STEP_CATEGORIES)}
                 data-testid={OnboardingTestIds.BtnNext}
               >
                 Próximo

--- a/frontend/src/routes/_authenticated.connect-with.$externalId.tsx
+++ b/frontend/src/routes/_authenticated.connect-with.$externalId.tsx
@@ -1,6 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { zodValidator } from '@tanstack/zod-adapter'
+import { z } from 'zod'
 import { ConnectWithPage } from '@/pages/ConnectWithPage'
 
+const connectWithSearchSchema = z.object({
+  split: z.coerce.number().int().min(1).max(99).optional(),
+})
+
 export const Route = createFileRoute('/_authenticated/connect-with/$externalId')({
+  validateSearch: zodValidator(connectWithSearchSchema),
   component: ConnectWithPage,
 })

--- a/frontend/src/routes/_authenticated.onboarding.tsx
+++ b/frontend/src/routes/_authenticated.onboarding.tsx
@@ -1,9 +1,17 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
+import { zodValidator } from '@tanstack/zod-adapter'
+import { z } from 'zod'
 import { fetchOnboardingStatus } from '@/api/onboarding'
 import { OnboardingPage } from '@/pages/OnboardingPage'
 import { QueryKeys } from '@/utils/queryKeys'
 
+const onboardingSearchSchema = z.object({
+  invite: z.string().optional(),
+  split: z.coerce.number().int().min(1).max(99).optional(),
+})
+
 export const Route = createFileRoute('/_authenticated/onboarding')({
+  validateSearch: zodValidator(onboardingSearchSchema),
   beforeLoad: async ({ context }) => {
     const status = await context.queryClient
       .ensureQueryData({

--- a/frontend/src/routes/_authenticated.tsx
+++ b/frontend/src/routes/_authenticated.tsx
@@ -23,6 +23,17 @@ export const Route = createFileRoute('/_authenticated')({
         })
         .catch(() => ({ completed: true }))
       if (!status.completed) {
+        const connectWithMatch = location.pathname.match(/^\/connect-with\/([^/]+)\/?$/)
+        if (connectWithMatch) {
+          const splitParam = (location.search as { split?: number }).split
+          throw redirect({
+            to: '/onboarding',
+            search: {
+              invite: connectWithMatch[1],
+              ...(typeof splitParam === 'number' ? { split: splitParam } : {}),
+            },
+          })
+        }
         throw redirect({ to: '/onboarding' })
       }
     }

--- a/frontend/src/testIds/common.ts
+++ b/frontend/src/testIds/common.ts
@@ -19,4 +19,15 @@ export const CommonTestIds = {
    * (e.g. `nav_badge_charges` for `/charges`).
    */
   NavBadge: (route: string) => `nav_badge_${route}` as const,
+
+  /* Invite drawer + accept-invite flow */
+  InvitePartnerNameInput: 'input_invite_partner_name',
+  InviteSplitChip: (pct: number) => `chip_invite_split_${pct}` as const,
+  InviteSplitChipCustom: 'chip_invite_split_custom',
+  InviteSplitCustomDec: 'btn_invite_split_custom_dec',
+  InviteSplitCustomInc: 'btn_invite_split_custom_inc',
+  InviteCopyLink: 'btn_invite_copy_link',
+  ConnectWithAccept: 'btn_connect_with_accept',
+  ConnectWithDecline: 'btn_connect_with_decline',
+  ConnectWithGoToApp: 'btn_connect_with_go_to_app',
 } as const

--- a/frontend/src/testIds/onboarding.ts
+++ b/frontend/src/testIds/onboarding.ts
@@ -1,6 +1,7 @@
 export const OnboardingTestIds = {
   Page: 'page_onboarding',
   Stepper: 'stepper_onboarding',
+  StepAcceptInvite: 'step_onboarding_accept_invite',
   StepAccounts: 'step_onboarding_accounts',
   StepCategories: 'step_onboarding_categories',
   StepImport: 'step_onboarding_import',
@@ -9,6 +10,7 @@ export const OnboardingTestIds = {
   BtnFinish: 'btn_onboarding_finish',
   BtnGoToImport: 'btn_onboarding_go_to_import',
   BtnSkipImport: 'btn_onboarding_skip_import',
+  BtnSkipInvite: 'btn_onboarding_skip_invite',
   AlertError: 'alert_onboarding_error',
 
   // Accounts

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -6,6 +6,7 @@ export const QueryKeys = {
   Categories: 'categories',
   Tags: 'tags',
   InviteInfo: 'invite-info',
+  UserConnections: 'user-connections',
   Charges: 'charges',
   ChargesPendingCount: 'charges-pending-count',
   Onboarding: 'onboarding',


### PR DESCRIPTION
## Summary
Adds the ability to suggest and customize split percentages when creating invites and accepting connections. Users can now select from preset splits (50/50, 60/40, 70/30, 80/20) or define a custom split, which is encoded in the invite URL and applied when the recipient accepts.

## Key Changes

**New Components:**
- `SplitSelector` — Interactive component for choosing preset or custom split percentages with visual split bars showing user/partner distribution
- `SplitFlowDiagram` — Educational visualization showing how a split works with a R$100 example
- `SuggestedSplitCard` — Card displaying the suggested split when accepting an invite
- `PartnerAvatarPair` — Header component showing the user-partner connection with avatars
- `ConnectedAlreadyCard` — Card shown when users are already connected
- `AcceptInviteStep` — Onboarding step for accepting invites during setup

**Modified Pages & Flows:**
- `ConnectWithPage` — Enhanced to display suggested splits, show connection benefits, and handle already-connected state
- `InviteDrawer` — Now includes partner name input, split selector, and flow diagram; generates invite URLs with split query parameter
- `OnboardingPage` — Integrated invite acceptance as an optional first step when `?invite=` parameter is present

**API & Hooks:**
- `useAcceptInvite` — Updated to accept `splitPercentage` parameter
- `useUserConnections` — New hook to fetch and query user connections
- `acceptInvite` API — Now accepts `splitPercentage` and returns `alreadyConnected` flag
- `fetchUserConnections` — New API function to list user connections

**Routing:**
- `connect-with.$externalId` route — Now accepts optional `?split=` query parameter (validated with Zod)
- `onboarding` route — Now accepts optional `?invite=` and `?split=` query parameters

**Test IDs:**
- Added test IDs for split selector chips, custom split controls, partner name input, and connection acceptance flows

## Implementation Details

- Split percentages are clamped to 1-99% range to ensure both parties have meaningful shares
- Invite URLs only include the `?split=` parameter when split differs from default 50/50
- Custom split editor uses ±5% increment/decrement buttons for fine-tuning
- Visual feedback distinguishes between preset (solid border) and custom (dashed border) selections
- Partner avatar shows dashed outline and "?" when name is not yet provided
- Already-connected state is detected both from API response and by querying existing connections

https://claude.ai/code/session_016eCxuGPKuH6GSKgYLdmyTn