### PR TITLE
Redesign login page with responsive layout and product showcase

### DIFF
--- a/frontend/src/components/login/BrandLogo.tsx
+++ b/frontend/src/components/login/BrandLogo.tsx
@@ -1,0 +1,8 @@
+/**
+ * The FinanceApp brand mark — two interlocking rings (white + gold) on a
+ * muted-blue rounded tile. Reuses the shipped PWA icon so the login screen,
+ * the sidebar and the installed-app icon stay in sync.
+ */
+export function BrandLogo({ size = 32 }: { size?: number }) {
+  return <img src="/icon.svg" width={size} height={size} alt="FinanceApp" />
+}

--- a/frontend/src/components/login/FeatureItem.tsx
+++ b/frontend/src/components/login/FeatureItem.tsx
@@ -1,9 +1,0 @@
-import { Text } from '@mantine/core'
-
-export function FeatureItem({ emoji, text }: { emoji: string; text: string }) {
-  return (
-    <Text c="dimmed" size="sm">
-      {emoji} {text}
-    </Text>
-  )
-}

--- a/frontend/src/components/login/GoogleButton.module.css
+++ b/frontend/src/components/login/GoogleButton.module.css
@@ -1,0 +1,16 @@
+.button {
+  height: 3.25rem;
+  border-radius: 0.625rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  background: var(--login-google-bg);
+  border: 1px solid var(--login-google-border);
+  color: var(--login-google-fg);
+  box-shadow: light-dark(0 1px 2px rgba(0, 0, 0, 0.06), none);
+  transition: box-shadow 120ms ease;
+}
+
+.button:hover:not([data-loading]) {
+  box-shadow: light-dark(0 2px 6px rgba(0, 0, 0, 0.1), none);
+  background: var(--login-google-bg);
+}

--- a/frontend/src/components/login/GoogleButton.tsx
+++ b/frontend/src/components/login/GoogleButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@mantine/core'
+import { LoginTestIds } from '@/testIds'
+import { GoogleIcon } from './GoogleIcon'
+import classes from './GoogleButton.module.css'
+
+export function GoogleButton({
+  loading,
+  onClick,
+}: {
+  loading: boolean
+  onClick: () => void
+}) {
+  return (
+    <Button
+      variant="default"
+      fullWidth
+      loading={loading}
+      leftSection={<GoogleIcon />}
+      onClick={onClick}
+      className={classes.button}
+      data-testid={LoginTestIds.GoogleButton}
+    >
+      {loading ? 'Entrando…' : 'Entrar com Google'}
+    </Button>
+  )
+}

--- a/frontend/src/components/login/LoginFeatureList.module.css
+++ b/frontend/src/components/login/LoginFeatureList.module.css
@@ -1,0 +1,37 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8125rem;
+}
+
+.chip {
+  width: 2.375rem;
+  height: 2.375rem;
+  flex-shrink: 0;
+  border-radius: 0.625rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--login-blue-glow);
+  color: var(--login-blue-7);
+}
+
+.title {
+  font-size: 0.90625rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--login-text);
+}
+
+.desc {
+  margin-top: 0.125rem;
+  font-size: 0.78125rem;
+  line-height: 1.4;
+  color: var(--login-dimmed);
+}

--- a/frontend/src/components/login/LoginFeatureList.tsx
+++ b/frontend/src/components/login/LoginFeatureList.tsx
@@ -1,0 +1,44 @@
+import { IconRepeat, IconTarget, IconUsers, type Icon } from '@tabler/icons-react'
+import classes from './LoginFeatureList.module.css'
+
+type Feature = {
+  icon: Icon
+  title: string
+  desc: string
+}
+
+const FEATURES: Feature[] = [
+  {
+    icon: IconUsers,
+    title: 'Visão compartilhada das despesas',
+    desc: 'Vocês dois veem tudo no mesmo lugar, em tempo real.',
+  },
+  {
+    icon: IconRepeat,
+    title: 'Transações recorrentes automáticas',
+    desc: 'Aluguel, assinaturas e contas que se repetem sozinhas.',
+  },
+  {
+    icon: IconTarget,
+    title: 'Controle de metas juntos',
+    desc: 'Planejem e acompanhem objetivos a dois.',
+  },
+]
+
+export function LoginFeatureList() {
+  return (
+    <div className={classes.list}>
+      {FEATURES.map(({ icon: Icon, title, desc }) => (
+        <div key={title} className={classes.row}>
+          <div className={classes.chip}>
+            <Icon size={20} stroke={1.75} />
+          </div>
+          <div>
+            <div className={classes.title}>{title}</div>
+            <div className={classes.desc}>{desc}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/login/ProductPeek.module.css
+++ b/frontend/src/components/login/ProductPeek.module.css
@@ -1,0 +1,156 @@
+.card {
+  width: 100%;
+  max-width: 20.625rem;
+  border-radius: 0.875rem;
+  overflow: hidden;
+  cursor: pointer;
+  user-select: none;
+  background: var(--login-surface);
+  border: 1px solid var(--login-peek-border);
+  box-shadow: light-dark(
+    0 16px 40px rgba(28, 60, 90, 0.16),
+    0 12px 30px rgba(0, 0, 0, 0.3)
+  );
+  transition: transform 120ms ease;
+}
+
+.card:active {
+  transform: scale(0.99);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6875rem 0.875rem;
+  border-bottom: 1px solid var(--login-border);
+}
+
+.period {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--login-dimmed);
+}
+
+.swap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3125rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--login-blue-7);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.8125rem 0.875rem;
+}
+
+.txRow {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.avatar {
+  width: 1.875rem;
+  height: 1.875rem;
+  flex-shrink: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #5b6cb0;
+  color: #fff;
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.txMeta {
+  flex: 1;
+  min-width: 0;
+}
+
+.txTitle {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--login-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.txSub {
+  font-size: 0.71875rem;
+  color: var(--login-dimmed);
+}
+
+.txAmount {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--login-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.splitBar {
+  display: grid;
+  gap: 0.25rem;
+  height: 0.5rem;
+  transition: grid-template-columns 260ms ease;
+}
+
+.splitMine,
+.splitPartner {
+  border-radius: 0.25rem;
+}
+
+.splitMine {
+  background: var(--login-blue-6);
+}
+
+.splitPartner {
+  background: #9c6ade;
+}
+
+.shares {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--login-text-2);
+  font-variant-numeric: tabular-nums;
+}
+
+.shares b {
+  color: var(--login-text);
+}
+
+.dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.3125rem;
+  margin-top: 0.0625rem;
+}
+
+.dot,
+.dotActive {
+  height: 0.3125rem;
+  border-radius: 999px;
+  transition:
+    width 200ms ease,
+    background 200ms ease;
+}
+
+.dot {
+  width: 0.3125rem;
+  background: var(--login-border-strong);
+}
+
+.dotActive {
+  width: 1rem;
+  background: var(--login-blue-6);
+}

--- a/frontend/src/components/login/ProductPeek.tsx
+++ b/frontend/src/components/login/ProductPeek.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react'
+import { IconRefresh } from '@tabler/icons-react'
+import { LoginTestIds } from '@/testIds'
+import classes from './ProductPeek.module.css'
+
+type Example = {
+  title: string
+  category: string
+  amount: string
+  split: number
+  mateus: string
+  amanda: string
+}
+
+const EXAMPLES: Example[] = [
+  {
+    title: 'Mercado do mês',
+    category: 'Mercado',
+    amount: 'R$ 218,45',
+    split: 50,
+    mateus: 'R$ 109,22',
+    amanda: 'R$ 109,23',
+  },
+  {
+    title: 'Aluguel de maio',
+    category: 'Moradia',
+    amount: 'R$ 1.850,00',
+    split: 60,
+    mateus: 'R$ 1.110,00',
+    amanda: 'R$ 740,00',
+  },
+  {
+    title: 'Jantar de aniversário',
+    category: 'Restaurante',
+    amount: 'R$ 320,00',
+    split: 70,
+    mateus: 'R$ 224,00',
+    amanda: 'R$ 96,00',
+  },
+]
+
+/**
+ * A live preview of a shared expense, reinforcing the product's "a dois"
+ * thesis. Tapping the card cycles through real-looking examples — the split
+ * bar, the amounts and the dot indicator animate between states.
+ */
+export function ProductPeek() {
+  const [index, setIndex] = useState(0)
+  const example = EXAMPLES[index]
+  const next = () => setIndex((i) => (i + 1) % EXAMPLES.length)
+
+  return (
+    <div
+      className={classes.card}
+      role="button"
+      tabIndex={0}
+      title="Toque para ver outro exemplo"
+      onClick={next}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          next()
+        }
+      }}
+      data-testid={LoginTestIds.Showcase}
+    >
+      <div className={classes.header}>
+        <span className={classes.period}>Maio · compartilhado</span>
+        <span className={classes.swap}>
+          <IconRefresh size={12} stroke={2} />
+          outro
+        </span>
+      </div>
+
+      <div className={classes.body}>
+        <div className={classes.txRow}>
+          <span className={classes.avatar}>M</span>
+          <div className={classes.txMeta}>
+            <div className={classes.txTitle}>{example.title}</div>
+            <div className={classes.txSub}>
+              {example.category} · dividido {example.split}/{100 - example.split}
+            </div>
+          </div>
+          <div className={classes.txAmount}>{example.amount}</div>
+        </div>
+
+        <div
+          className={classes.splitBar}
+          style={{
+            gridTemplateColumns: `${example.split}fr ${100 - example.split}fr`,
+          }}
+        >
+          <span className={classes.splitMine} />
+          <span className={classes.splitPartner} />
+        </div>
+
+        <div className={classes.shares}>
+          <span>
+            <b>Mateus</b> {example.mateus}
+          </span>
+          <span>
+            <b>Amanda</b> {example.amanda}
+          </span>
+        </div>
+
+        <div className={classes.dots}>
+          {EXAMPLES.map((_, i) => (
+            <span
+              key={i}
+              className={i === index ? classes.dotActive : classes.dot}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/login/TrustLine.module.css
+++ b/frontend/src/components/login/TrustLine.module.css
@@ -1,0 +1,8 @@
+.trust {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--login-dimmed);
+}

--- a/frontend/src/components/login/TrustLine.tsx
+++ b/frontend/src/components/login/TrustLine.tsx
@@ -1,0 +1,11 @@
+import { IconShieldCheck } from '@tabler/icons-react'
+import classes from './TrustLine.module.css'
+
+export function TrustLine() {
+  return (
+    <div className={classes.trust}>
+      <IconShieldCheck size={14} stroke={1.75} />
+      <span>Login seguro com sua conta Google</span>
+    </div>
+  )
+}

--- a/frontend/src/pages/LoginPage.module.css
+++ b/frontend/src/pages/LoginPage.module.css
@@ -1,57 +1,247 @@
-.container {
+.root {
+  /* Design tokens — the login screen mirrors the design-system palette and is
+     the one surface where the brand gradient is allowed. Tokens are set here
+     and inherited by every child (including the colocated component modules). */
+  --login-surface: light-dark(#ffffff, #1f1f1f);
+  --login-border: light-dark(#e7e7e7, #2e2e2e);
+  --login-border-strong: light-dark(#cdcdcd, #3a3b3f);
+  --login-peek-border: light-dark(#e7ecf0, #2e2e2e);
+  --login-text: light-dark(#1a1a1a, #ffffff);
+  --login-text-2: light-dark(#4a4a4a, #cdcdcd);
+  --login-dimmed: #8b8b8b;
+  --login-blue-6: #568fb3;
+  --login-blue-7: light-dark(#457b9d, #95b8cf);
+  --login-blue-glow: rgba(86, 143, 179, 0.18);
+  --login-google-bg: light-dark(#ffffff, #26272a);
+  --login-google-border: light-dark(#dcdfe3, #3a3b3f);
+  --login-google-fg: light-dark(#1a1a1a, #ffffff);
+
+  --login-gradient: linear-gradient(
+    155deg,
+    light-dark(#4d86ab, #1d2733) 0%,
+    light-dark(#568fb3, #1a1b1e) 50%,
+    light-dark(#6ba2c2, #1a1b1e) 100%
+  );
+
   min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--login-surface);
+  font-family: var(--mantine-font-family);
+}
+
+/* ── Shared atoms ──────────────────────────────────────────────── */
+.brandRow {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 1.5rem;
-  background: linear-gradient(
-    160deg,
-    light-dark(var(--mantine-color-blue-0), var(--mantine-color-dark-8)) 0%,
-    light-dark(var(--mantine-color-white), var(--mantine-color-dark-7)) 60%
-  );
+  gap: 0.6875rem;
 }
 
-.content {
-  width: 100%;
-  max-width: 24rem;
+.wordmark {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: #fff;
 }
 
-.emoji {
-  font-size: 3.5rem;
-  line-height: 1;
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.title {
-  font-size: 2rem;
+/* ── Responsive switch between the two layouts ─────────────────── */
+.desktop {
+  display: none;
+}
+
+.mobile {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+@media (min-width: 64em) {
+  .desktop {
+    display: flex;
+    min-height: 100vh;
+    min-height: 100dvh;
+  }
+
+  .mobile {
+    display: none;
+  }
+}
+
+/* ── Desktop: marketing panel ──────────────────────────────────── */
+.marketing {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 2.875rem 2.75rem;
+  color: #fff;
+  background: var(--login-gradient);
+}
+
+.glow {
+  position: absolute;
+  top: -5rem;
+  right: -3.75rem;
+  width: 17.5rem;
+  height: 17.5rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  filter: blur(10px);
+}
+
+.marketingBody {
+  position: relative;
+  z-index: 1;
+  margin: 1.75rem 0;
+}
+
+.headline {
+  margin: 0;
+  max-width: 26.25rem;
+  font-size: 2.125rem;
   font-weight: 800;
-  color: light-dark(var(--mantine-color-blue-8), var(--mantine-color-blue-2));
-  text-align: center;
+  letter-spacing: -0.6px;
+  line-height: 1.14;
 }
 
-.subtitle {
-  color: var(--mantine-color-dimmed);
-  text-align: center;
-  font-size: 1rem;
+.lede {
+  margin: 0.875rem 0 0;
+  max-width: 22.5rem;
+  font-size: 0.9375rem;
   line-height: 1.5;
-  max-width: 18rem;
+  color: rgba(255, 255, 255, 0.85);
 }
 
-.features {
+.peekWrap {
+  margin-top: 1.625rem;
+}
+
+.highlights {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.375rem;
+}
+
+.highlight {
+  display: flex;
+  align-items: center;
   gap: 0.5rem;
-  width: 100%;
-  padding: 1.25rem 1.5rem;
-  background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-6));
-  border-radius: var(--mantine-radius-md);
-  border: 1px solid light-dark(var(--mantine-color-grey-1), var(--mantine-color-dark-4));
+  font-size: 0.78125rem;
+  color: rgba(255, 255, 255, 0.9);
 }
 
-.googleButton {
-  min-height: 3rem;
-  font-size: 1rem;
-  font-weight: 500;
-  border-color: light-dark(var(--mantine-color-grey-2), var(--mantine-color-dark-4));
+.highlightDot {
+  width: 0.375rem;
+  height: 0.375rem;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: #ffd700;
 }
 
-.googleButton:hover {
-  background-color: light-dark(var(--mantine-color-grey-0), var(--mantine-color-dark-5));
+/* ── Desktop: login card ───────────────────────────────────────── */
+.card {
+  width: 26.25rem;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 3rem 2.875rem;
+  background: var(--login-surface);
+}
+
+.cardInner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.625rem;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+  color: var(--login-text);
+}
+
+.cardSub {
+  margin: 0.5rem 0 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--login-text-2);
+}
+
+.terms {
+  margin: 0;
+  font-size: 0.71875rem;
+  line-height: 1.5;
+  text-align: center;
+  color: var(--login-dimmed);
+}
+
+/* ── Mobile: hero band + card ──────────────────────────────────── */
+.hero {
+  position: relative;
+  overflow: hidden;
+  color: #fff;
+  background: var(--login-gradient);
+  padding: calc(4.875rem + env(safe-area-inset-top)) 1.625rem 1.875rem;
+}
+
+.glowSmall {
+  position: absolute;
+  top: -3.75rem;
+  right: -3.125rem;
+  width: 12.5rem;
+  height: 12.5rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  filter: blur(8px);
+}
+
+.heroHeadline {
+  position: relative;
+  z-index: 1;
+  margin: 1.125rem 0 0;
+  font-size: 1.625rem;
+  font-weight: 800;
+  letter-spacing: -0.4px;
+  line-height: 1.18;
+}
+
+.heroLede {
+  position: relative;
+  z-index: 1;
+  margin: 0.625rem 0 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.mobileCard {
+  flex: 1;
+  margin-top: -1rem;
+  border-top-left-radius: 1.25rem;
+  border-top-right-radius: 1.25rem;
+  background: var(--login-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem 1.625rem calc(2.5rem + env(safe-area-inset-bottom));
+}
+
+.spacer {
+  flex: 1;
+  min-height: 0.5rem;
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,13 +1,28 @@
-import { Stack, Title, Text, Button, Box } from '@mantine/core'
+import { useState } from 'react'
 import { useSearch } from '@tanstack/react-router'
-import { FeatureItem } from '@/components/login/FeatureItem'
-import { GoogleIcon } from '@/components/login/GoogleIcon'
+import { BrandLogo } from '@/components/login/BrandLogo'
+import { GoogleButton } from '@/components/login/GoogleButton'
+import { LoginFeatureList } from '@/components/login/LoginFeatureList'
+import { ProductPeek } from '@/components/login/ProductPeek'
+import { TrustLine } from '@/components/login/TrustLine'
+import { LoginTestIds } from '@/testIds'
 import classes from './LoginPage.module.css'
+
+const HEADLINE = 'As finanças do casal, num lugar só.'
+
+const HIGHLIGHTS = [
+  'Visão compartilhada das despesas',
+  'Transações recorrentes automáticas',
+  'Controle de metas juntos',
+]
 
 export function LoginPage() {
   const { redirect: redirectTo } = useSearch({ from: '/login' })
+  const [loading, setLoading] = useState(false)
 
   function handleGoogleLogin() {
+    if (loading) return
+    setLoading(true)
     const apiUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:8080'
     const url = new URL(`${apiUrl}/auth/google`, window.location.origin)
     if (redirectTo) url.searchParams.set('redirect', redirectTo)
@@ -15,36 +30,79 @@ export function LoginPage() {
     window.location.href = url.toString()
   }
 
+  const brand = (size: number) => (
+    <div className={classes.brandRow}>
+      <BrandLogo size={size} />
+      <span className={classes.wordmark}>FinanceApp</span>
+    </div>
+  )
+
+  const actions = (
+    <div className={classes.actions}>
+      <GoogleButton loading={loading} onClick={handleGoogleLogin} />
+      <TrustLine />
+    </div>
+  )
+
   return (
-    <Box className={classes.container}>
-      <Stack align="center" gap="xl" className={classes.content}>
-        <Stack align="center" gap="xs">
-          <Text className={classes.emoji}>💰</Text>
-          <Title order={1} className={classes.title}>
-            Finança a dois
-          </Title>
-          <Text className={classes.subtitle}>
-            Gerencie as finanças do casal de forma simples e transparente
-          </Text>
-        </Stack>
+    <div className={classes.root} data-testid={LoginTestIds.Page}>
+      {/* Desktop — split marketing showcase + login card */}
+      <div className={classes.desktop}>
+        <section className={classes.marketing}>
+          <div className={classes.glow} aria-hidden="true" />
+          {brand(30)}
+          <div className={classes.marketingBody}>
+            <h1 className={classes.headline}>{HEADLINE}</h1>
+            <p className={classes.lede}>
+              Despesas, transferências e acertos compartilhados — simples e
+              transparente, a dois.
+            </p>
+            <div className={classes.peekWrap}>
+              <ProductPeek />
+            </div>
+          </div>
+          <div className={classes.highlights}>
+            {HIGHLIGHTS.map((text) => (
+              <span key={text} className={classes.highlight}>
+                <span className={classes.highlightDot} aria-hidden="true" />
+                {text}
+              </span>
+            ))}
+          </div>
+        </section>
 
-        <Stack align="center" gap="md" className={classes.features}>
-          <FeatureItem emoji="📊" text="Visão compartilhada das despesas" />
-          <FeatureItem emoji="🔄" text="Transações recorrentes automáticas" />
-          <FeatureItem emoji="🎯" text="Controle de metas juntos" />
-        </Stack>
+        <section className={classes.card}>
+          <div className={classes.cardInner}>
+            <div>
+              <h2 className={classes.cardTitle}>Bem-vindo de volta</h2>
+              <p className={classes.cardSub}>
+                Entre para continuar de onde vocês pararam.
+              </p>
+            </div>
+            <LoginFeatureList />
+            {actions}
+            <p className={classes.terms}>
+              Ao continuar, você concorda com os Termos de uso e a Política de
+              privacidade.
+            </p>
+          </div>
+        </section>
+      </div>
 
-        <Button
-          size="lg"
-          variant="default"
-          leftSection={<GoogleIcon />}
-          onClick={handleGoogleLogin}
-          className={classes.googleButton}
-          fullWidth
-        >
-          Entrar com Google
-        </Button>
-      </Stack>
-    </Box>
+      {/* Mobile — gradient hero band with the card pulled up over it */}
+      <div className={classes.mobile}>
+        <div className={classes.hero}>
+          <div className={classes.glowSmall} aria-hidden="true" />
+          {brand(28)}
+          <h1 className={classes.heroHeadline}>{HEADLINE}</h1>
+          <p className={classes.heroLede}>Simples e transparente, a dois.</p>
+        </div>
+        <div className={classes.mobileCard}>
+          <LoginFeatureList />
+          <div className={classes.spacer} />
+          {actions}
+        </div>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/testIds/index.ts
+++ b/frontend/src/testIds/index.ts
@@ -35,3 +35,4 @@ export {
 export { RecurrenceTestIds, type RecurrenceType } from "./recurrence";
 export { OnboardingTestIds } from "./onboarding";
 export { MobileNavTestIds } from "./mobileNav";
+export { LoginTestIds } from "./login";

--- a/frontend/src/testIds/login.ts
+++ b/frontend/src/testIds/login.ts
@@ -1,0 +1,11 @@
+/**
+ * Login screen testids.
+ *
+ * Mirrors the registry-wide convention (see testIds/index.ts):
+ * static keys are plain strings, parametric keys are factory functions.
+ */
+export const LoginTestIds = {
+  Page: 'login_page',
+  GoogleButton: 'btn_google_login',
+  Showcase: 'login_showcase',
+} as const


### PR DESCRIPTION
## Summary

Completely redesigns the login page with a modern, responsive layout that showcases the product's core value proposition. The new design features a split-screen desktop layout (marketing panel + login card) and a mobile-optimized hero band with a pulled-up card, along with an interactive product preview component.

## Key Changes

- **LoginPage redesign**: Replaced simple centered layout with responsive desktop/mobile variants
  - Desktop: Split-screen with gradient marketing panel (left) and login card (right)
  - Mobile: Gradient hero band with card pulled up over it
  - Added interactive `ProductPeek` component showcasing shared expense examples
  - Integrated new `LoginFeatureList` component with icon-based feature descriptions

- **New components**:
  - `ProductPeek`: Interactive carousel of shared expense examples with animated split bars and dot indicators
  - `LoginFeatureList`: Icon-based feature list (shared visibility, recurring transactions, goal tracking)
  - `GoogleButton`: Extracted Google login button with loading state
  - `BrandLogo`: Logo component using the PWA icon
  - `TrustLine`: Security badge below login button

- **Design tokens system**: Introduced CSS custom properties in `LoginPage.module.css` for consistent theming across login components
  - Supports light/dark mode via `light-dark()` function
  - Includes brand gradient, surface colors, borders, and semantic color tokens

- **Styling**: 
  - Comprehensive CSS modules for all new components with responsive design
  - Uses Mantine's `light-dark()` for theme-aware colors
  - Includes decorative gradient glows and smooth transitions
  - Respects safe area insets for mobile notches

- **Test IDs**: Added `LoginTestIds` registry for testing login page elements (page, Google button, showcase)

## Implementation Details

- The `ProductPeek` component cycles through three realistic expense examples (grocery shopping, rent, restaurant) with different split ratios, demonstrating the "a dois" (together) thesis
- Design uses Portuguese copy throughout, matching the app's target audience
- Responsive breakpoint at 64em (1024px) switches between desktop and mobile layouts
- Mobile layout uses negative margin to pull the card up over the hero band for visual continuity
- All interactive elements include proper keyboard support (Enter/Space for ProductPeek)

https://claude.ai/code/session_0127EG6ADC8dEKtx9zDwifTZ