### PR TITLE
Remove configurable preview channel expiration

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,10 +7,6 @@ on:
         description: "PR number to deploy as preview"
         type: string
         required: true
-      expires:
-        description: "Preview channel TTL (e.g. 7d, 30d)"
-        type: string
-        default: "7d"
 
 permissions:
   contents: read
@@ -57,7 +53,7 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           projectId: ${{ vars.FIREBASE_PROJECT_ID }}
           channelId: pr-${{ inputs.pr_number }}
-          expires: ${{ inputs.expires }}
+          expires: 1d
           entryPoint: frontend
 
       - name: Comment preview URL on PR
@@ -65,9 +61,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ inputs.pr_number }}
           URLS: ${{ steps.deploy.outputs.urls }}
-          EXPIRES: ${{ inputs.expires }}
         run: |
           URL=$(echo "$URLS" | jq -r '.[0]')
           gh pr comment "$PR_NUMBER" --body "Preview frontend (apontando para o backend de prod): $URL
 
-          Channel: \`pr-$PR_NUMBER\` — expira em $EXPIRES."
+          Channel: \`pr-$PR_NUMBER\` — expira em 1d."


### PR DESCRIPTION
## Summary
Simplifies the Firebase preview deployment workflow by removing the configurable `expires` input parameter and hardcoding the preview channel TTL to 1 day.

## Changes
- Removed the `expires` workflow input parameter from the `preview.yml` workflow definition
- Hardcoded the preview channel expiration to `1d` in the Firebase deployment step
- Updated the PR comment template to reflect the fixed 1-day expiration instead of using the dynamic input value

## Rationale
This change reduces workflow complexity by eliminating the need to specify preview channel expiration on each deployment. A fixed 1-day TTL provides a reasonable default that balances preview availability with resource cleanup, removing the operational overhead of managing variable expiration times.

https://claude.ai/code/session_01DuGSr9PtdeHn6EjWeTPKgR