### PR TITLE
feat(connections): add Editar conexão drawer (name + default split)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -157,6 +157,7 @@ func main() {
 	userConnections.POST("/accept-invite", userConnectionHandler.AcceptInvite)
 	userConnections.GET("/invite-info/:external_id", userConnectionHandler.GetInviteInfo)
 	userConnections.PATCH("/:id/:status", userConnectionHandler.UpdateStatus)
+	userConnections.PUT("/:id", userConnectionHandler.UpdateSettings)
 	userConnections.DELETE("/:id", userConnectionHandler.Delete)
 	userConnections.GET("", userConnectionHandler.Search)
 

--- a/backend/internal/handler/user_connection_handler.go
+++ b/backend/internal/handler/user_connection_handler.go
@@ -82,6 +82,42 @@ func (h *UserConnectionHandler) UpdateStatus(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// UpdateSettings godoc
+// @Summary      Update connection settings (account name + default split)
+// @Tags         user-connections
+// @Accept       json
+// @Produce      json
+// @Security     CookieAuth
+// @Security     BearerAuth
+// @Param        id       path  int                              true  "Connection ID"
+// @Param        request  body  UpdateConnectionSettingsRequest  true  "Connection settings"
+// @Success      200  {object}  domain.UserConnection
+// @Failure      400  {object}  middleware.ErrorResponse
+// @Failure      401  {object}  middleware.ErrorResponse
+// @Failure      403  {object}  middleware.ErrorResponse
+// @Failure      404  {object}  middleware.ErrorResponse
+// @Router       /api/user-connections/{id} [put]
+func (h *UserConnectionHandler) UpdateSettings(c echo.Context) error {
+	userID := appcontext.GetUserIDFromContext(c.Request().Context())
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid user connection ID")
+	}
+
+	var req UpdateConnectionSettingsRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+
+	conn, err := h.userConnectionService.UpdateSettings(c.Request().Context(), userID, id, req.AccountName, req.DefaultSplitPercentage)
+	if err != nil {
+		return HandleServiceError(err)
+	}
+
+	return c.JSON(http.StatusOK, conn)
+}
+
 // Delete godoc
 // @Summary      Delete user connection
 // @Tags         user-connections
@@ -195,4 +231,9 @@ func (h *UserConnectionHandler) AcceptInvite(c echo.Context) error {
 type AcceptInviteRequest struct {
 	ExternalID                 string `json:"external_id"`
 	FromDefaultSplitPercentage int    `json:"from_default_split_percentage"`
+}
+
+type UpdateConnectionSettingsRequest struct {
+	AccountName            string `json:"account_name"`
+	DefaultSplitPercentage int    `json:"default_split_percentage"`
 }

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -59,6 +59,7 @@ type UserConnectionService interface {
 	Create(ctx context.Context, fromUserID, toUserID, fromDefaultSplitPercentage int) (*domain.UserConnection, error)
 	AcceptInviteByExternalID(ctx context.Context, currentUserID int, inviterExternalID string, fromDefaultSplitPercentage int) (*domain.UserConnection, error)
 	UpdateStatus(ctx context.Context, userID int, id int, status domain.UserConnectionStatusEnum) error
+	UpdateSettings(ctx context.Context, userID, id int, accountName string, defaultSplitPercentage int) (*domain.UserConnection, error)
 	Delete(ctx context.Context, userID, id int) error
 	Search(ctx context.Context, options domain.UserConnectionSearchOptions) ([]*domain.UserConnection, error)
 	SearchOne(ctx context.Context, options domain.UserConnectionSearchOptions) (*domain.UserConnection, error)

--- a/backend/internal/service/user_connection_service.go
+++ b/backend/internal/service/user_connection_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/finance_app/backend/internal/domain"
 	"github.com/finance_app/backend/internal/repository"
@@ -15,6 +16,7 @@ type userConnectionService struct {
 	dbTransaction      repository.DBTransaction
 	userConnectionRepo repository.UserConnectionRepository
 	userRepo           repository.UserRepository
+	accountRepo        repository.AccountRepository
 	services           *Services
 }
 
@@ -23,6 +25,7 @@ func NewUserConnectionService(repos *repository.Repositories, services *Services
 		dbTransaction:      repos.DBTransaction,
 		userConnectionRepo: repos.UserConnection,
 		userRepo:           repos.User,
+		accountRepo:        repos.Account,
 		services:           services,
 	}
 }
@@ -189,6 +192,75 @@ func (s *userConnectionService) UpdateStatus(ctx context.Context, userID int, id
 	}
 
 	return nil
+}
+
+// UpdateSettings lets a participant edit, for their own side of the connection,
+// the name shown on their connection account and the default split percentage.
+// The split is stored complementarily (the other side becomes 100 - value).
+func (s *userConnectionService) UpdateSettings(ctx context.Context, userID, id int, accountName string, defaultSplitPercentage int) (*domain.UserConnection, error) {
+	if strings.TrimSpace(accountName) == "" {
+		return nil, apperrors.BadRequest("account name is required")
+	}
+	if defaultSplitPercentage < 0 || defaultSplitPercentage > 100 {
+		return nil, apperrors.BadRequest("default split percentage must be between 0 and 100")
+	}
+
+	ctx, err := s.dbTransaction.Begin(ctx)
+	if err != nil {
+		return nil, apperrors.Internal("failed to begin transaction", err)
+	}
+	defer s.dbTransaction.Rollback(ctx)
+
+	existing, err := s.userConnectionRepo.Search(ctx, domain.UserConnectionSearchOptions{
+		IDs: []int{id},
+	})
+	if err != nil {
+		return nil, apperrors.Internal("failed to search user connection", err)
+	}
+	if len(existing) == 0 {
+		return nil, apperrors.NotFound("user connection")
+	}
+
+	conn := existing[0]
+
+	// Resolve the caller's side of the connection. The default split is stored
+	// from the "from" user's perspective, so map the caller onto the right field.
+	var accountID int
+	switch userID {
+	case conn.FromUserID:
+		conn.FromDefaultSplitPercentage = defaultSplitPercentage
+		conn.ToDefaultSplitPercentage = 100 - defaultSplitPercentage
+		accountID = conn.FromAccountID
+	case conn.ToUserID:
+		conn.ToDefaultSplitPercentage = defaultSplitPercentage
+		conn.FromDefaultSplitPercentage = 100 - defaultSplitPercentage
+		accountID = conn.ToAccountID
+	default:
+		return nil, apperrors.Forbidden("only a participant can update this connection")
+	}
+
+	// Rename the caller's own connection account (only affects what they see).
+	account, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return nil, apperrors.Internal("failed to get connection account", err)
+	}
+	if account == nil {
+		return nil, apperrors.NotFound("connection account")
+	}
+	account.Name = accountName
+	if err := s.accountRepo.Update(ctx, account); err != nil {
+		return nil, apperrors.Internal("failed to update connection account", err)
+	}
+
+	if err := s.userConnectionRepo.Update(ctx, conn); err != nil {
+		return nil, apperrors.Internal("failed to update user connection", err)
+	}
+
+	if err := s.dbTransaction.Commit(ctx); err != nil {
+		return nil, apperrors.Internal("failed to commit transaction", err)
+	}
+
+	return conn, nil
 }
 
 func (s *userConnectionService) Delete(ctx context.Context, userID, id int) error {

--- a/frontend/src/api/userConnections.ts
+++ b/frontend/src/api/userConnections.ts
@@ -35,6 +35,27 @@ export async function fetchUserConnections(): Promise<UserConnections.Connection
   return res.json()
 }
 
+export interface UpdateConnectionPayload {
+  account_name: string
+  default_split_percentage: number
+}
+
+export async function updateConnection(
+  id: number,
+  payload: UpdateConnectionPayload,
+): Promise<void> {
+  const res = await fetch(`${apiUrl}/api/user-connections/${id}`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error(err.message ?? 'Failed to update connection')
+  }
+}
+
 export type AcceptInviteResult = {
   alreadyConnected: boolean
   connection: UserConnections.Connection

--- a/frontend/src/components/DesktopSidebar.module.css
+++ b/frontend/src/components/DesktopSidebar.module.css
@@ -94,6 +94,19 @@
   gap: 10px;
   padding: 6px 12px;
   border-radius: 8px;
+  background: transparent;
+  border: none;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  -webkit-tap-highlight-color: transparent;
+  transition: background-color 120ms ease;
+}
+
+.connectionItem:hover {
+  background: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
 }
 
 .connectionName {

--- a/frontend/src/components/DesktopSidebar.tsx
+++ b/frontend/src/components/DesktopSidebar.tsx
@@ -17,6 +17,7 @@ import { useChargesPendingCount } from "@/hooks/useChargesPendingCount";
 import { UserAvatar } from "@/components/UserAvatar";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { InviteDrawer } from "@/components/InviteDrawer";
+import { EditConnectionDrawer } from "@/components/connections/EditConnectionDrawer";
 import { renderDrawer } from "@/utils/renderDrawer";
 import { CommonTestIds } from "@/testIds";
 import { Transactions } from "@/types/transactions";
@@ -39,6 +40,8 @@ type Connection = {
   id: number;
   name: string;
   avatarUrl?: string;
+  /** The caller's own shared account for this connection (carries `user_connection`). */
+  account: Transactions.Account;
 };
 
 function selectAcceptedConnections(meId: number | undefined) {
@@ -55,6 +58,7 @@ function selectAcceptedConnections(meId: number | undefined) {
         id: c.id,
         name: (isFrom ? c.to_user_name : c.from_user_name) ?? "?",
         avatarUrl: isFrom ? c.to_user_avatar_url : c.from_user_avatar_url,
+        account: acc,
       });
     }
     return out;
@@ -75,6 +79,10 @@ export function DesktopSidebar() {
 
   const openInvite = () => {
     void renderDrawer(() => <InviteDrawer />).catch(() => {});
+  };
+
+  const openEditConnection = (account: Transactions.Account) => {
+    void renderDrawer(() => <EditConnectionDrawer account={account} />).catch(() => {});
   };
 
   return (
@@ -107,10 +115,16 @@ export function DesktopSidebar() {
       <div className={classes.sectionLabel}>Conexões</div>
       <div className={classes.navGroup}>
         {connections.map((c) => (
-          <div key={c.id} className={classes.connectionItem} data-testid={CommonTestIds.NavConnection(c.id)}>
+          <button
+            type="button"
+            key={c.id}
+            className={classes.connectionItem}
+            onClick={() => openEditConnection(c.account)}
+            data-testid={CommonTestIds.NavConnection(c.id)}
+          >
             <UserAvatar name={c.name} avatarUrl={c.avatarUrl} size="sm" />
             <span className={classes.connectionName}>{c.name}</span>
-          </div>
+          </button>
         ))}
         <button
           type="button"

--- a/frontend/src/components/accounts/AccountCard.tsx
+++ b/frontend/src/components/accounts/AccountCard.tsx
@@ -50,6 +50,12 @@ export function AccountCard({ account, onEdit, onDelete }: Props) {
             </ActionIcon>
           </Group>
         )}
+
+        {isShared && account.is_active && (
+          <ActionIcon variant="subtle" color="gray" onClick={() => onEdit(account)} data-testid={AccountsTestIds.BtnEdit}>
+            <IconPencil size={16} />
+          </ActionIcon>
+        )}
       </Group>
     </Card>
   )

--- a/frontend/src/components/connections/EditConnectionDrawer.tsx
+++ b/frontend/src/components/connections/EditConnectionDrawer.tsx
@@ -1,0 +1,247 @@
+import { useState } from 'react'
+import { useForm, useWatch } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Divider,
+  Group,
+  Stack,
+  Text,
+  TextInput,
+  ThemeIcon,
+} from '@mantine/core'
+import { IconCheck } from '@tabler/icons-react'
+import { useMe } from '@/hooks/useMe'
+import { useAccounts } from '@/hooks/useAccounts'
+import { useUserConnections } from '@/hooks/useUserConnections'
+import { useUpdateConnection } from '@/hooks/useUpdateConnection'
+import { useDrawerContext } from '@/utils/renderDrawer'
+import { ResponsiveDrawer } from '@/components/ResponsiveDrawer'
+import { UserAvatar } from '@/components/UserAvatar'
+import { SplitSelector } from '@/components/connections/SplitSelector'
+import { SplitFlowDiagram } from '@/components/connections/SplitFlowDiagram'
+import { Transactions } from '@/types/transactions'
+import { CommonTestIds } from '@/testIds'
+
+const PRESETS = [50, 60, 70, 80]
+
+const schema = z.object({
+  account_name: z.string().trim().min(1, 'Nome é obrigatório'),
+})
+
+type EditConnectionFormValues = z.infer<typeof schema>
+
+interface Props {
+  /** The caller's own shared account (the one carrying `user_connection`). */
+  account: Transactions.Account
+}
+
+export function EditConnectionDrawer({ account }: Props) {
+  const { opened, close, reject } = useDrawerContext<void>()
+  const { query: meQuery } = useMe()
+  const user = meQuery.data
+  const { invalidate: invalidateAccounts } = useAccounts()
+  const { invalidate: invalidateConnections } = useUserConnections()
+
+  const connection = account.user_connection
+  const isFrom = connection?.from_user_id === user?.id
+  const currentSplit = connection
+    ? isFrom
+      ? connection.from_default_split_percentage
+      : connection.to_default_split_percentage
+    : 50
+  const partnerAvatarUrl = isFrom
+    ? connection?.to_user_avatar_url
+    : connection?.from_user_avatar_url
+
+  const [splitMode, setSplitMode] = useState<number | 'custom'>(
+    PRESETS.includes(currentSplit) ? currentSplit : 'custom',
+  )
+  const [customValue, setCustomValue] = useState(
+    PRESETS.includes(currentSplit) ? 65 : currentSplit,
+  )
+  const effectiveSplit = splitMode === 'custom' ? customValue : splitMode
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<EditConnectionFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { account_name: account.name },
+  })
+
+  const nameValue = useWatch({ control, name: 'account_name' }) ?? account.name
+  const partnerName = nameValue.trim() || account.name
+  const userName = user?.name?.split(' ')[0] ?? 'Você'
+
+  const { mutation } = useUpdateConnection({
+    onSuccess: async () => {
+      await Promise.all([invalidateAccounts(), invalidateConnections()])
+      close()
+    },
+  })
+
+  const dirty =
+    nameValue.trim() !== account.name || effectiveSplit !== currentSplit
+
+  function onSubmit(values: EditConnectionFormValues) {
+    if (!connection) return
+    mutation.mutate({
+      id: connection.id,
+      payload: {
+        account_name: values.account_name.trim(),
+        default_split_percentage: effectiveSplit,
+      },
+    })
+  }
+
+  const submit = handleSubmit(onSubmit)
+
+  function handleFormKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault()
+      void submit()
+    }
+  }
+
+  return (
+    <ResponsiveDrawer
+      opened={opened}
+      onClose={reject}
+      title="Editar conexão"
+      data-testid={CommonTestIds.DrawerEditConnection}
+      styles={{ body: { padding: 0 } }}
+    >
+      <form onSubmit={submit} onKeyDown={handleFormKeyDown} noValidate>
+        <Stack gap={0} style={{ minHeight: '100%' }}>
+          <Box
+            px="lg"
+            py="md"
+            style={{
+              borderBottom: '1px solid var(--mantine-color-default-border)',
+              background:
+                'linear-gradient(180deg, var(--mantine-color-blue-light) 0%, transparent 100%)',
+            }}
+          >
+            <Group gap="sm" wrap="nowrap">
+              <Box style={{ display: 'flex', alignItems: 'center' }}>
+                <UserAvatar name={userName} avatarUrl={user?.avatar_url} size="md" color="blue" />
+                <ThemeIcon
+                  size={22}
+                  radius="xl"
+                  variant="filled"
+                  color="teal"
+                  style={{
+                    marginInline: -8,
+                    border: '2px solid var(--mantine-color-body)',
+                    zIndex: 1,
+                  }}
+                >
+                  <IconCheck size={12} />
+                </ThemeIcon>
+                <Avatar
+                  size="md"
+                  radius="xl"
+                  color="grape"
+                  variant="filled"
+                  src={partnerAvatarUrl}
+                >
+                  {partnerName.charAt(0).toUpperCase()}
+                </Avatar>
+              </Box>
+              <Box style={{ minWidth: 0 }}>
+                <Text fw={700} size="sm" truncate>
+                  Conectado com {partnerName}
+                </Text>
+                <Text size="xs" c="dimmed">
+                  As alterações valem para as próximas transações
+                </Text>
+              </Box>
+            </Group>
+          </Box>
+
+          <Stack gap="lg" p="md">
+            {mutation.error && (
+              <Alert color="red" title="Erro" variant="light">
+                {mutation.error.message}
+              </Alert>
+            )}
+
+            <Box>
+              <TextInput
+                label="Nome da conta da conexão"
+                required
+                {...register('account_name')}
+                error={errors.account_name?.message}
+                placeholder="Ex.: Amanda, conta do casal…"
+                maxLength={40}
+                data-testid={CommonTestIds.EditConnectionNameInput}
+              />
+              <Text size="xs" c="dimmed" mt={6}>
+                É assim que essa conta aparece nas suas transações e listas. Só muda
+                no seu app — não afeta o que {partnerName} vê.
+              </Text>
+            </Box>
+
+            <Divider />
+
+            <SplitSelector
+              value={splitMode}
+              customValue={customValue}
+              userName={userName}
+              userAvatarUrl={user?.avatar_url}
+              partnerName={partnerName}
+              partnerHasName
+              onChange={setSplitMode}
+              onCustomChange={setCustomValue}
+            />
+
+            <SplitFlowDiagram
+              split={effectiveSplit}
+              userName={userName}
+              userAvatarUrl={user?.avatar_url}
+              partnerName={partnerName}
+              partnerHasName
+            />
+          </Stack>
+
+          <Box
+            mt="auto"
+            p="md"
+            style={{
+              borderTop: '1px solid var(--mantine-color-default-border)',
+              background: 'var(--mantine-color-body)',
+              position: 'sticky',
+              bottom: 0,
+            }}
+          >
+            <Group justify="space-between">
+              <Button
+                variant="default"
+                onClick={() => reject()}
+                data-testid={CommonTestIds.EditConnectionCancel}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                loading={mutation.isPending}
+                disabled={!dirty}
+                leftSection={<IconCheck size={16} />}
+                data-testid={CommonTestIds.EditConnectionSave}
+              >
+                Salvar alterações
+              </Button>
+            </Group>
+          </Box>
+        </Stack>
+      </form>
+    </ResponsiveDrawer>
+  )
+}

--- a/frontend/src/hooks/useUpdateConnection.ts
+++ b/frontend/src/hooks/useUpdateConnection.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query'
+import { updateConnection, UpdateConnectionPayload } from '@/api/userConnections'
+
+interface Options {
+  onSuccess?: () => void
+}
+
+export function useUpdateConnection({ onSuccess }: Options = {}) {
+  const mutation = useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: UpdateConnectionPayload }) =>
+      updateConnection(id, payload),
+    onSuccess,
+  })
+  return { mutation }
+}

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -6,6 +6,7 @@ import { useDeleteAccount } from '@/hooks/useDeleteAccount'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useHotkey } from '@/hooks/useHotkey'
 import { AccountDrawer } from '@/components/accounts/AccountDrawer'
+import { EditConnectionDrawer } from '@/components/connections/EditConnectionDrawer'
 import { AccountSection } from '@/components/accounts/AccountSection'
 import { Fab } from '@/components/Fab'
 import { PullToRefresh } from '@/components/PullToRefresh'
@@ -30,7 +31,11 @@ export function AccountsPage() {
   const { mutation: activateMutation } = useActivateAccount({ onSuccess: invalidate })
 
   function handleEdit(account: Transactions.Account) {
-    void renderDrawer(() => <AccountDrawer account={account} />)
+    if (account.user_connection) {
+      void renderDrawer(() => <EditConnectionDrawer account={account} />)
+    } else {
+      void renderDrawer(() => <AccountDrawer account={account} />)
+    }
   }
 
   function handleAdd() {

--- a/frontend/src/testIds/common.ts
+++ b/frontend/src/testIds/common.ts
@@ -25,6 +25,12 @@ export const CommonTestIds = {
   NavCreateConnection: 'nav_create_connection',
   NavConnection: (connectionId: number) => `nav_connection_${connectionId}` as const,
 
+  /* Edit connection drawer */
+  DrawerEditConnection: 'drawer_edit_connection',
+  EditConnectionNameInput: 'input_connection_name',
+  EditConnectionSave: 'btn_save_connection',
+  EditConnectionCancel: 'btn_cancel_connection',
+
   /* Invite drawer + accept-invite flow */
   InvitePartnerNameInput: 'input_invite_partner_name',
   InviteSplitChip: (pct: number) => `chip_invite_split_${pct}` as const,


### PR DESCRIPTION
Implements issue #171. Users can now edit, per their own side of a connection, the connection account's name and the default split percentage, reusing the split selector from the create-connection flow.

Backend:
- UserConnectionService.UpdateSettings: resolves the caller's side, renames their connection account and stores the split complementarily (other side = 100 - value), all in one DB transaction; participant-only with input validation.
- New PUT /api/user-connections/:id route + handler + DTO; regenerated mocks and Swagger docs.
- Integration tests for from/to user, non-participant (403) and invalid input (400).

Frontend:
- EditConnectionDrawer reusing SplitSelector + SplitFlowDiagram, with the account-name field and pt-BR copy from the design.
- updateConnection API fn + useUpdateConnection hook.
- Opens on sidebar connection click and from the shared account card on the Accounts page; invalidates accounts + connections on save.

https://claude.ai/code/session_018hfMEsAQ5dSWgNHT5uADYq