### PR TITLE
style(transactions): native-style header buttons in form drawer

### DIFF
--- a/frontend/src/components/transactions/form/MobileFormHeader.tsx
+++ b/frontend/src/components/transactions/form/MobileFormHeader.tsx
@@ -25,13 +25,15 @@ export function MobileFormHeader({ title, onCancel, formId, loading }: Props) {
       <Button variant="subtle" size="compact-sm" onClick={onCancel}>
         Cancelar
       </Button>
-      <Text fw={600} size="sm" truncate>
+      <Text fw={600} size="sm" truncate style={{ flex: 1, textAlign: "center" }}>
         {title}
       </Text>
       <Button
         type="submit"
         form={formId}
+        variant="subtle"
         size="compact-sm"
+        fw={700}
         loading={loading}
         data-testid={TransactionsTestIds.BtnSave}
       >


### PR DESCRIPTION
Pin Cancelar/Salvar to the header corners with a truly centered title,
and switch Salvar to the same subtle variant as Cancelar (kept bold as
the primary action) so the bar reads like a native mobile app header.