### PR TITLE
ci: manual workflow to publish latest draft release + chained deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,10 @@ on:
         description: "Skip pending migrations check (emergency use only)"
         type: boolean
         default: false
+      release_tag:
+        description: "Release tag to deploy (set by the Publish Release workflow; enables release-style change detection)"
+        type: string
+        default: ""
 
 jobs:
   detect-changes:
@@ -38,10 +42,10 @@ jobs:
           echo "frontend=${{ inputs.force_frontend || false }}" >> $GITHUB_OUTPUT
 
       - name: Get previous tag
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.release_tag != ''
         id: prev-tag
         run: |
-          CURRENT_TAG=${{ github.event.release.tag_name }}
+          CURRENT_TAG=${{ github.event.release.tag_name || inputs.release_tag }}
           PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${CURRENT_TAG}$" | head -1)
           echo "prev_tag=${PREV_TAG}" >> $GITHUB_OUTPUT
           echo "current_tag=${CURRENT_TAG}" >> $GITHUB_OUTPUT
@@ -59,8 +63,10 @@ jobs:
             FORCE_FRONTEND=true
           fi
 
-          # On workflow_dispatch without force flags, deploy nothing (require explicit choice)
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # Manual workflow_dispatch without a release tag: deploy nothing unless forced.
+          # When release_tag is provided (Publish Release workflow), fall through to
+          # release-style tag-based change detection below.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -z "${{ inputs.release_tag }}" ]; then
             echo "backend=${FORCE_BACKEND:-false}" >> $GITHUB_OUTPUT
             echo "frontend=${FORCE_FRONTEND:-false}" >> $GITHUB_OUTPUT
             exit 0
@@ -104,6 +110,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -137,12 +145,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
 
       - name: Set image tag
         id: tag
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "value=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          RELEASE_TAG="${{ github.event.release.tag_name || inputs.release_tag }}"
+          if [ -n "$RELEASE_TAG" ]; then
+            echo "value=${RELEASE_TAG}" >> $GITHUB_OUTPUT
           else
             echo "value=manual-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
           fi
@@ -187,6 +198,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  actions: write # required to dispatch the Deploy workflow after publishing
 
 jobs:
   publish:
@@ -52,7 +53,22 @@ jobs:
             });
 
             core.notice(`Published release ${published.tag_name}: ${published.html_url}`);
+
+            // Publishing with GITHUB_TOKEN does not trigger workflows listening on
+            // `release: published` (GitHub prevents recursive runs). Explicitly dispatch
+            // the Deploy workflow, which handles `release_tag` with release-style change detection.
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: "deploy.yml",
+              ref: context.payload.repository.default_branch,
+              inputs: { release_tag: published.tag_name },
+            });
+            core.notice(`Dispatched Deploy workflow for tag ${published.tag_name}.`);
+
             await core.summary
               .addHeading("Release published")
               .addRaw(`**${published.name || published.tag_name}** — ${published.html_url}`)
+              .addBreak()
+              .addRaw(`Deploy workflow dispatched for \`${published.tag_name}\`.`)
               .write();

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,58 @@
+name: Publish Release
+
+# Manually publish the latest draft release (created by Draft Release / release-drafter).
+# Useful because the GitHub mobile app cannot publish draft releases.
+
+on:
+  workflow_dispatch:
+    inputs:
+      make_latest:
+        description: "Mark this release as the latest release"
+        type: boolean
+        default: true
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish latest draft release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            // Find the most recent draft release.
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const draft = releases.find((r) => r.draft);
+
+            if (!draft) {
+              core.setFailed("No draft release found to publish.");
+              return;
+            }
+
+            core.info(`Publishing draft release "${draft.name || draft.tag_name}" (id: ${draft.id}).`);
+
+            const makeLatest = context.payload.inputs.make_latest !== "false";
+
+            const { data: published } = await github.rest.repos.updateRelease({
+              owner,
+              repo,
+              release_id: draft.id,
+              draft: false,
+              make_latest: makeLatest ? "true" : "false",
+            });
+
+            core.notice(`Published release ${published.tag_name}: ${published.html_url}`);
+            await core.summary
+              .addHeading("Release published")
+              .addRaw(`**${published.name || published.tag_name}** — ${published.html_url}`)
+              .write();


### PR DESCRIPTION
## Why

The GitHub mobile app can't publish draft releases, so there was no way to ship a release from a phone. This adds a manually-triggered **Publish Release** workflow that publishes the latest draft (created by release-drafter).

It also fixes a follow-on problem: publishing a release with the default `GITHUB_TOKEN` does **not** emit a `release: published` event that triggers other workflows (GitHub suppresses it to prevent recursive runs), so the **Deploy** workflow never ran.

## What

**`publish-release.yml`** (new)
- `workflow_dispatch` with a `make_latest` input (default `true`).
- Finds the most recent draft release and publishes it; fails clearly if none exists.
- After publishing, explicitly dispatches the Deploy workflow with the released tag (`workflow_dispatch` is the documented exception that works with `GITHUB_TOKEN`). Adds `actions: write` for this.

**`deploy.yml`**
- New `release_tag` input.
- When `release_tag` is provided, runs the same tag-based change detection (`git diff prev..current`) as the `release` event — so it still deploys only what changed, instead of requiring the `force_*` flags.
- Backend image tag uses the release tag (not `manual-<sha>`).
- The three build jobs (migrations check, backend, frontend) check out the **release tag** rather than `main` HEAD, in case `main` advanced past the release commit.

The original `release: published` path and the "pure" manual dispatch (no tag, requires `force_*`) behave exactly as before.

## How it works from mobile

1. Actions → **Publish Release** → Run workflow.
2. Publishes the latest draft → creates the tag → dispatches **Deploy** with that tag → Deploy runs change detection and ships only what changed.

> Note: takes effect in production only after this is merged to `main`, since the dispatch reads `deploy.yml` from the default branch.

https://claude.ai/code/session_01CcSb4ugPgrqxe3jYTp8zfz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcSb4ugPgrqxe3jYTp8zfz)_