### PR TITLE
fix(frontend): make mobile toasts readable and tappable

### DIFF
--- a/frontend/src/components/AppNotifications.tsx
+++ b/frontend/src/components/AppNotifications.tsx
@@ -1,0 +1,18 @@
+import { Notifications } from '@mantine/notifications'
+import { useIsMobile } from '@/hooks/useIsMobile'
+
+// Mantine's `position` is a single prop, not responsive. On phones, top-center
+// keeps toasts under the notch and one-handed-readable; on desktop top-right
+// stays out of the content's way. Safe-area offset and message contrast are
+// handled globally in index.css.
+export function AppNotifications() {
+  const isMobile = useIsMobile()
+
+  return (
+    <Notifications
+      position={isMobile ? 'top-center' : 'top-right'}
+      autoClose={4000}
+      limit={3}
+    />
+  )
+}

--- a/frontend/src/components/PWAUpdateNotifier.tsx
+++ b/frontend/src/components/PWAUpdateNotifier.tsx
@@ -42,12 +42,12 @@ export function PWAUpdateNotifier() {
       id: NOTIFICATION_ID,
       title: 'Nova versão disponível',
       message: (
-        <Stack gap="xs" mt={4}>
+        <Stack gap="sm" mt={4}>
           <Text size="sm">Atualize para ver as novidades.</Text>
-          <Group justify="flex-end">
+          <Group grow gap="sm">
             <Button
-              size="xs"
-              variant="subtle"
+              size="sm"
+              variant="default"
               onClick={() => {
                 notifications.hide(NOTIFICATION_ID)
                 setNeedRefresh(false)
@@ -56,7 +56,7 @@ export function PWAUpdateNotifier() {
               Depois
             </Button>
             <Button
-              size="xs"
+              size="sm"
               onClick={() => {
                 void updateServiceWorker(true)
               }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -90,6 +90,25 @@ select {
   z-index: var(--mb-z-index);
 }
 
+/* ─── Notifications: notch clearance + readable message text ──────────── */
+/* Mantine positions the notifications container with `top: spacing-md` via a
+   zero-specificity `:where([data-position])` selector, so these plain-class
+   overrides win on cascade order (index.css loads after the package styles).
+
+   1. Push top-anchored toasts below the iOS notch/status bar in PWA standalone
+      mode — without this the title collides with the clock/battery row. No-op
+      on browsers where env(safe-area-inset-top) resolves to 0. */
+.mantine-Notifications-root[data-position^='top-'] {
+  top: calc(env(safe-area-inset-top) + var(--mantine-spacing-md));
+}
+
+/* 2. Mantine dims the message text to dark-2 when a title is present, which is
+      hard to read on the dark scheme. Raise it to full body-text contrast.
+      Matches the package's own specificity (0,3,0) and wins by load order. */
+.mantine-Notification-root[data-with-title] .mantine-Notification-description {
+  color: var(--mantine-color-text);
+}
+
 /* ─── GPU-composited active states ──────────────────────────────────────── */
 button:active,
 a:active,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { MantineProvider } from '@mantine/core'
 import { DatesProvider } from '@mantine/dates'
-import { Notifications } from '@mantine/notifications'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 import 'dayjs/locale/pt-br'
@@ -12,6 +11,7 @@ import '@mantine/dates/styles.css'
 import '@mantine/notifications/styles.css'
 import './index.css'
 import App from './App'
+import { AppNotifications } from './components/AppNotifications'
 import { theme } from './theme'
 import { queryClient } from './queryClient'
 
@@ -26,7 +26,7 @@ createRoot(document.getElementById('root')!).render(
     <QueryClientProvider client={queryClient}>
       <MantineProvider theme={theme} defaultColorScheme="auto">
         <DatesProvider settings={{ locale: 'pt-br', firstDayOfWeek: 0 }}>
-          <Notifications position="top-right" autoClose={3000} />
+          <AppNotifications />
           <App />
         </DatesProvider>
       </MantineProvider>


### PR DESCRIPTION
- Notifications use top-center on mobile (via useIsMobile), top-right on
  desktop, so toasts sit under the notch and read one-handed.
- Offset the notifications container by env(safe-area-inset-top) so PWA
  standalone toasts clear the iOS status bar instead of colliding with it.
- Raise dimmed notification message text to full body contrast on the dark
  scheme.
- Enlarge the PWA update toast action buttons (sm, full-width) for easier
  tapping; cap concurrent toasts at 3.

https://claude.ai/code/session_01Mnr9jhAvYLbbpXAZGxZNZY