### PR TITLE
feat(notifications): add test notification trigger

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -271,6 +271,7 @@ func registerAPIRoutes(api *echo.Group, services *service.Services, h apiHandler
 	notifications := api.Group("/notifications")
 	notifications.GET("", h.notification.List)
 	notifications.GET("/unread-count", h.notification.UnreadCount)
+	notifications.POST("/test", h.notification.SendTest)
 	notifications.POST("/read-all", h.notification.MarkAllRead)
 	notifications.POST("/:id/read", h.notification.MarkRead)
 	// Static "/read" MUST be registered before "/:id" so "read" is not captured as :id.

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -967,6 +967,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/notifications/test": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Sends a sample push notification to the authenticated user's own subscriptions so they can preview how notifications render. Does not persist an inbox row.",
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Send a test notification",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/notifications/unread-count": {
             "get": {
                 "security": [

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -961,6 +961,40 @@
                 }
             }
         },
+        "/api/notifications/test": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Sends a sample push notification to the authenticated user's own subscriptions so they can preview how notifications render. Does not persist an inbox row.",
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "Send a test notification",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/notifications/unread-count": {
             "get": {
                 "security": [

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1357,6 +1357,28 @@ paths:
       summary: Mark all notifications as read
       tags:
       - notifications
+  /api/notifications/test:
+    post:
+      description: Sends a sample push notification to the authenticated user's own
+        subscriptions so they can preview how notifications render. Does not persist
+        an inbox row.
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/middleware.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/middleware.ErrorResponse'
+      security:
+      - CookieAuth: []
+      - BearerAuth: []
+      summary: Send a test notification
+      tags:
+      - notifications
   /api/notifications/unread-count:
     get:
       produces:

--- a/backend/internal/handler/notification_handler.go
+++ b/backend/internal/handler/notification_handler.go
@@ -70,6 +70,24 @@ func (h *NotificationHandler) UnreadCount(c echo.Context) error {
 	return c.JSON(http.StatusOK, domain.NotificationUnreadCountResponse{Count: count})
 }
 
+// SendTest godoc
+// @Summary      Send a test notification
+// @Description  Sends a sample push notification to the authenticated user's own subscriptions so they can preview how notifications render. Does not persist an inbox row.
+// @Tags         notifications
+// @Security     CookieAuth
+// @Security     BearerAuth
+// @Success      204
+// @Failure      400  {object}  middleware.ErrorResponse
+// @Failure      401  {object}  middleware.ErrorResponse
+// @Router       /api/notifications/test [post]
+func (h *NotificationHandler) SendTest(c echo.Context) error {
+	userID := appcontext.GetUserIDFromContext(c.Request().Context())
+	if err := h.notifService.SendTest(c.Request().Context(), userID); err != nil {
+		return HandleServiceError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
 // MarkRead godoc
 // @Summary      Mark a notification as read
 // @Tags         notifications

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -98,6 +98,10 @@ type NotificationService interface {
 	// Dispatch persists inbox rows and sends push notifications best-effort.
 	// Always called in a goroutine with context.Background() — never the request ctx.
 	Dispatch(ctx context.Context, events []domain.NotificationEvent)
+	// SendTest delivers a sample push notification to the user's own
+	// subscriptions so they can preview how notifications render. Display-only:
+	// no inbox row is persisted.
+	SendTest(ctx context.Context, userID int) error
 	List(ctx context.Context, userID int, filter domain.NotificationFilter) (*domain.NotificationListResult, error)
 	UnreadCount(ctx context.Context, userID int) (int64, error)
 	MarkRead(ctx context.Context, userID, notificationID int) error

--- a/backend/internal/service/notification_service.go
+++ b/backend/internal/service/notification_service.go
@@ -109,31 +109,70 @@ func (s *notificationService) Dispatch(ctx context.Context, events []domain.Noti
 			continue
 		}
 
-		for _, sub := range subs {
-			resp, sendErr := s.sender.Send(rawPayload, &webpush.Subscription{
-				Endpoint: sub.Endpoint,
-				Keys:     webpush.Keys{Auth: sub.Auth, P256dh: sub.P256dh},
-			}, &webpush.Options{
-				Subscriber:      s.vapid.Subject,
-				VAPIDPublicKey:  s.vapid.PublicKey,
-				VAPIDPrivateKey: s.vapid.PrivateKey,
-				TTL:             30,
-			})
-			if sendErr != nil {
-				log.Printf("[notification] push send error endpoint=%s err=%v", sub.Endpoint, sendErr)
-				continue
-			}
-			if resp != nil {
-				status := resp.StatusCode
-				_ = resp.Body.Close() // close immediately, not deferred — defer is function-scoped and would accumulate across loop iterations
-				if status == http.StatusNotFound || status == http.StatusGone {
-					if pruneErr := s.pushSubRepo.DeleteByEndpointAdmin(ctx, sub.Endpoint); pruneErr != nil {
-						log.Printf("[notification] failed to prune stale subscription endpoint=%s err=%v", sub.Endpoint, pruneErr)
-					}
+		s.pushToSubscriptions(ctx, subs, rawPayload)
+	}
+}
+
+// pushToSubscriptions delivers rawPayload to each of the given subscriptions
+// best-effort, logging send errors and pruning any subscription the push
+// service reports as gone (404/410). Shared by Dispatch and SendTest.
+func (s *notificationService) pushToSubscriptions(ctx context.Context, subs []*domain.PushSubscription, rawPayload []byte) {
+	for _, sub := range subs {
+		resp, sendErr := s.sender.Send(rawPayload, &webpush.Subscription{
+			Endpoint: sub.Endpoint,
+			Keys:     webpush.Keys{Auth: sub.Auth, P256dh: sub.P256dh},
+		}, &webpush.Options{
+			Subscriber:      s.vapid.Subject,
+			VAPIDPublicKey:  s.vapid.PublicKey,
+			VAPIDPrivateKey: s.vapid.PrivateKey,
+			TTL:             30,
+		})
+		if sendErr != nil {
+			log.Printf("[notification] push send error endpoint=%s err=%v", sub.Endpoint, sendErr)
+			continue
+		}
+		if resp != nil {
+			status := resp.StatusCode
+			_ = resp.Body.Close() // close immediately, not deferred — defer is function-scoped and would accumulate across loop iterations
+			if status == http.StatusNotFound || status == http.StatusGone {
+				if pruneErr := s.pushSubRepo.DeleteByEndpointAdmin(ctx, sub.Endpoint); pruneErr != nil {
+					log.Printf("[notification] failed to prune stale subscription endpoint=%s err=%v", sub.Endpoint, pruneErr)
 				}
 			}
 		}
 	}
+}
+
+// SendTest delivers a sample push notification to every push subscription the
+// authenticated user owns, so they can preview how a real notification renders
+// on their device. It is display-only: no inbox row is persisted. Returns a
+// tagged validation error (NOTIFICATION.NO_ACTIVE_PUSH_SUBSCRIPTION) when the
+// user has not enabled push on any device, so the frontend can prompt them.
+func (s *notificationService) SendTest(ctx context.Context, userID int) error {
+	subs, err := s.pushSubRepo.ListByUserID(ctx, userID)
+	if err != nil {
+		return pkgErrors.Internal("failed to list push subscriptions", err)
+	}
+	if len(subs) == 0 {
+		return pkgErrors.ErrNoActivePushSubscription
+	}
+
+	payload := pushPayload{
+		Title: "Notificação de teste",
+		Body:  "Tudo certo! É assim que as notificações vão aparecer no seu dispositivo. 🎉",
+		Data: pushPayloadData{
+			Type:       "test",
+			EntityType: "transaction",
+			EntityID:   0,
+		},
+	}
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		return pkgErrors.Internal("failed to marshal test notification payload", err)
+	}
+
+	s.pushToSubscriptions(ctx, subs, rawPayload)
+	return nil
 }
 
 // pushPayload is the JSON structure sent to the browser push service.

--- a/backend/internal/service/notification_service_test.go
+++ b/backend/internal/service/notification_service_test.go
@@ -1179,6 +1179,76 @@ func (suite *NotificationServiceWithDBSuite) TestPush410PrunesSubscription() {
 }
 
 // ---------------------------------------------------------------------------
+// SendTest: delivers a sample push to the user's own subscriptions
+// ---------------------------------------------------------------------------
+
+func (suite *NotificationServiceWithDBSuite) TestSendTestDeliversToSubscriptions() {
+	ctx := context.Background()
+
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	// Subscribe the user on two devices.
+	ep1 := suite.subscribeUser(ctx, user.ID)
+	ep2 := suite.subscribeUser(ctx, user.ID)
+
+	// Inject a mock sender that accepts (201 Created).
+	mockSender := &mockPushSender{status: http.StatusCreated}
+	restore := injectMockSender(suite.Services.Notification, mockSender)
+	defer restore()
+
+	err = suite.Services.Notification.SendTest(ctx, user.ID)
+	suite.Require().NoError(err)
+
+	// The push must have been sent to both endpoints.
+	suite.ElementsMatch([]string{ep1, ep2}, mockSender.calls, "test push should reach every subscription")
+
+	// SendTest is display-only — it must NOT persist an inbox row.
+	suite.Equal(0, suite.countNotifications(ctx, user.ID), "SendTest must not persist an inbox row")
+}
+
+func (suite *NotificationServiceWithDBSuite) TestSendTestNoSubscriptionReturnsTaggedError() {
+	ctx := context.Background()
+
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	// Guard: even if a stray sender were invoked, this records it.
+	mockSender := &mockPushSender{status: http.StatusCreated}
+	restore := injectMockSender(suite.Services.Notification, mockSender)
+	defer restore()
+
+	err = suite.Services.Notification.SendTest(ctx, user.ID)
+	suite.Require().Error(err, "SendTest must error when the user has no subscription")
+
+	svcErr, ok := pkgErrors.AsServiceError(err)
+	suite.Require().True(ok, "error should be a *ServiceError, got: %v", err)
+	suite.Contains(svcErr.Tags, string(pkgErrors.ErrorTagNoActivePushSubscription))
+	suite.Empty(mockSender.calls, "no push should be attempted without a subscription")
+}
+
+func (suite *NotificationServiceWithDBSuite) TestSendTestPrunesStaleSubscription() {
+	ctx := context.Background()
+
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	endpoint := suite.subscribeUser(ctx, user.ID)
+
+	// Mock sender reports the endpoint as gone (410).
+	mockSender := &mockPushSender{status: http.StatusGone}
+	restore := injectMockSender(suite.Services.Notification, mockSender)
+	defer restore()
+
+	err = suite.Services.Notification.SendTest(ctx, user.ID)
+	suite.Require().NoError(err)
+
+	status, err := suite.Services.PushSubscription.Status(ctx, user.ID, endpoint)
+	suite.Require().NoError(err)
+	suite.False(status.Subscribed, "stale subscription should be pruned after a 410 from a test push")
+}
+
+// ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 

--- a/backend/mocks/mock_NotificationService.go
+++ b/backend/mocks/mock_NotificationService.go
@@ -306,6 +306,53 @@ func (_c *MockNotificationService_MarkRead_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
+// SendTest provides a mock function with given fields: ctx, userID
+func (_m *MockNotificationService) SendTest(ctx context.Context, userID int) error {
+	ret := _m.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SendTest")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int) error); ok {
+		r0 = rf(ctx, userID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockNotificationService_SendTest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendTest'
+type MockNotificationService_SendTest_Call struct {
+	*mock.Call
+}
+
+// SendTest is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID int
+func (_e *MockNotificationService_Expecter) SendTest(ctx interface{}, userID interface{}) *MockNotificationService_SendTest_Call {
+	return &MockNotificationService_SendTest_Call{Call: _e.mock.On("SendTest", ctx, userID)}
+}
+
+func (_c *MockNotificationService_SendTest_Call) Run(run func(ctx context.Context, userID int)) *MockNotificationService_SendTest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int))
+	})
+	return _c
+}
+
+func (_c *MockNotificationService_SendTest_Call) Return(_a0 error) *MockNotificationService_SendTest_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockNotificationService_SendTest_Call) RunAndReturn(run func(context.Context, int) error) *MockNotificationService_SendTest_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UnreadCount provides a mock function with given fields: ctx, userID
 func (_m *MockNotificationService) UnreadCount(ctx context.Context, userID int) (int64, error) {
 	ret := _m.Called(ctx, userID)

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -78,6 +78,8 @@ const (
 
 	ErrorTagSettlementForbidden      ErrorTag = "SETTLEMENT.FORBIDDEN"
 	ErrorTagSettlementDateIsRequired ErrorTag = "SETTLEMENT.DATE_IS_REQUIRED"
+
+	ErrorTagNoActivePushSubscription ErrorTag = "NOTIFICATION.NO_ACTIVE_PUSH_SUBSCRIPTION"
 )
 
 var (
@@ -140,6 +142,8 @@ var (
 	ErrChargeTransactionRecurrenceNotAllowed       = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagChargeTransactionRecurrenceNotAllowed)}, "recurrence cannot be added to a transaction linked to a charge")
 	ErrSettlementForbidden                         = NewWithTag(ErrCodeForbidden, []string{string(ErrorTagSettlementForbidden)}, "settlement belongs to another user")
 	ErrSettlementDateIsRequired                    = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSettlementDateIsRequired)}, "date is required")
+
+	ErrNoActivePushSubscription = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagNoActivePushSubscription)}, "no active push subscription for this user")
 )
 
 // ServiceError represents a service-level error with a code and message

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -25,6 +25,14 @@ export async function fetchNotificationUnreadCount(): Promise<Notifications.Unre
   return res.json()
 }
 
+export async function sendTestNotification(): Promise<void> {
+  const res = await fetch(`${apiUrl}/api/notifications/test`, {
+    method: 'POST',
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Failed to send test notification')
+}
+
 export async function markNotificationRead(id: number): Promise<void> {
   const res = await fetch(`${apiUrl}/api/notifications/${id}/read`, {
     method: 'POST',

--- a/frontend/src/components/notifications/NotificationToggleRow.tsx
+++ b/frontend/src/components/notifications/NotificationToggleRow.tsx
@@ -1,6 +1,8 @@
-import { Group, Loader, Stack, Switch, Text } from '@mantine/core'
-import { IconBell, IconBellOff } from '@tabler/icons-react'
+import { Button, Group, Loader, Stack, Switch, Text } from '@mantine/core'
+import { IconBell, IconBellOff, IconSend } from '@tabler/icons-react'
+import { notifications } from '@mantine/notifications'
 import { usePushSubscription } from '@/hooks/usePushSubscription'
+import { useSendTestNotification } from '@/hooks/useSendTestNotification'
 import { NotificationsTestIds } from '@/testIds'
 import classes from './NotificationToggleRow.module.css'
 
@@ -27,6 +29,22 @@ const helperId = 'notification-helper-text'
  */
 export function NotificationToggleRow({ variant }: NotificationToggleRowProps) {
   const { state, onToggle, helperText } = usePushSubscription()
+  const { mutation: testMutation } = useSendTestNotification({
+    onSuccess: () =>
+      notifications.show({
+        color: 'teal',
+        title: 'Notificação de teste enviada',
+        message: 'Veja como ela aparece no seu dispositivo.',
+        autoClose: 3000,
+      }),
+    onError: () =>
+      notifications.show({
+        color: 'red',
+        title: 'Erro ao enviar',
+        message: 'Não foi possível enviar a notificação de teste. Tente novamente.',
+        autoClose: 3000,
+      }),
+  })
 
   const isChecked = state === 'enabled'
   const isDisabled = state === 'requesting' || state === 'denied' || state === 'unsupported'
@@ -56,43 +74,61 @@ export function NotificationToggleRow({ variant }: NotificationToggleRowProps) {
   })()
 
   return (
-    <Group
-      justify="space-between"
-      align="center"
-      wrap="nowrap"
-      gap="md"
-      className={classes.row}
-      data-testid={NotificationsTestIds.RowNotifications}
-    >
-      {/* Left: icon column (fixed 20px width) */}
-      <div className={classes.iconCol}>{leftIcon}</div>
+    <Stack gap="xs">
+      <Group
+        justify="space-between"
+        align="center"
+        wrap="nowrap"
+        gap="md"
+        className={classes.row}
+        data-testid={NotificationsTestIds.RowNotifications}
+      >
+        {/* Left: icon column (fixed 20px width) */}
+        <div className={classes.iconCol}>{leftIcon}</div>
 
-      {/* Centre: label + helper */}
-      <Stack gap={1} style={{ flex: 1, minWidth: 0 }}>
-        <Text size="sm" fw={500}>
-          Notificações
-        </Text>
-        <Text
+        {/* Centre: label + helper */}
+        <Stack gap={1} style={{ flex: 1, minWidth: 0 }}>
+          <Text size="sm" fw={500}>
+            Notificações
+          </Text>
+          <Text
+            size="xs"
+            c={helperColor}
+            id={helperId}
+            data-testid={NotificationsTestIds.HelperNotifications}
+          >
+            {helperText(variant)}
+          </Text>
+        </Stack>
+
+        {/* Right: Switch */}
+        <Switch
+          size="md"
+          checked={isChecked}
+          disabled={isDisabled}
+          onChange={() => onToggle()}
+          color="blue"
+          aria-label={isChecked ? 'Desativar notificações' : 'Ativar notificações'}
+          aria-describedby={helperId}
+          data-testid={NotificationsTestIds.SwitchNotifications}
+        />
+      </Group>
+
+      {/* Test-notification trigger — only when push is enabled on this device.
+          Round-trips through the backend so the preview matches a real push. */}
+      {isChecked && (
+        <Button
+          variant="light"
+          color="blue"
           size="xs"
-          c={helperColor}
-          id={helperId}
-          data-testid={NotificationsTestIds.HelperNotifications}
+          leftSection={<IconSend size={16} stroke={1.8} />}
+          loading={testMutation.isPending}
+          onClick={() => testMutation.mutate()}
+          data-testid={NotificationsTestIds.BtnSendTest}
         >
-          {helperText(variant)}
-        </Text>
-      </Stack>
-
-      {/* Right: Switch */}
-      <Switch
-        size="md"
-        checked={isChecked}
-        disabled={isDisabled}
-        onChange={() => onToggle()}
-        color="blue"
-        aria-label={isChecked ? 'Desativar notificações' : 'Ativar notificações'}
-        aria-describedby={helperId}
-        data-testid={NotificationsTestIds.SwitchNotifications}
-      />
-    </Group>
+          Enviar notificação de teste
+        </Button>
+      )}
+    </Stack>
   )
 }

--- a/frontend/src/hooks/useSendTestNotification.test.tsx
+++ b/frontend/src/hooks/useSendTestNotification.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for useSendTestNotification
+ *
+ * Mirrors useDeleteNotification.test.tsx (renderHook + QueryClient harness).
+ * The mutationFn (sendTestNotification) is mocked so no real fetch is made.
+ *
+ * Key invariants:
+ * - mutate() calls the backend sendTestNotification endpoint exactly once
+ * - onSuccess delegates to the caller-supplied callback
+ * - onError delegates to the caller-supplied callback
+ * - returns { mutation } with a mutate function
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+vi.mock('@/api/notifications', () => ({
+  sendTestNotification: vi.fn(),
+  deleteNotification: vi.fn(),
+  deleteReadNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+  fetchNotifications: vi.fn(),
+  fetchNotificationUnreadCount: vi.fn(),
+}))
+
+import * as notificationsApi from '@/api/notifications'
+import { useSendTestNotification } from './useSendTestNotification'
+
+function makeWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useSendTestNotification', () => {
+  it('calls the backend endpoint once when mutate fires', async () => {
+    const queryClient = makeQueryClient()
+    vi.mocked(notificationsApi.sendTestNotification).mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useSendTestNotification(), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutation.mutate()
+    })
+
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true))
+
+    expect(notificationsApi.sendTestNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls options.onSuccess when the test push succeeds', async () => {
+    const queryClient = makeQueryClient()
+    vi.mocked(notificationsApi.sendTestNotification).mockResolvedValue(undefined)
+
+    const onSuccess = vi.fn()
+    const { result } = renderHook(() => useSendTestNotification({ onSuccess }), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutation.mutate()
+    })
+
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true))
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls options.onError when the test push fails', async () => {
+    const queryClient = makeQueryClient()
+    vi.mocked(notificationsApi.sendTestNotification).mockRejectedValue(new Error('fail'))
+
+    const onError = vi.fn()
+    const onSuccess = vi.fn()
+    const { result } = renderHook(() => useSendTestNotification({ onSuccess, onError }), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    await act(async () => {
+      result.current.mutation.mutate()
+    })
+
+    await waitFor(() => expect(result.current.mutation.isError).toBe(true))
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('exposes mutation object with mutate function', () => {
+    const queryClient = makeQueryClient()
+    vi.mocked(notificationsApi.sendTestNotification).mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useSendTestNotification(), {
+      wrapper: makeWrapper(queryClient),
+    })
+
+    expect(result.current).toHaveProperty('mutation')
+    expect(typeof result.current.mutation.mutate).toBe('function')
+  })
+})

--- a/frontend/src/hooks/useSendTestNotification.ts
+++ b/frontend/src/hooks/useSendTestNotification.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query'
+import { sendTestNotification } from '@/api/notifications'
+
+/**
+ * Fires a backend-delivered test push notification to the current user's own
+ * subscriptions so they can preview how a real notification renders on this
+ * device.
+ *
+ * The push round-trips through the backend (POST /api/notifications/test) — it
+ * is NOT a locally-faked `showNotification`, so what the user sees matches a
+ * genuine notification end-to-end. No inbox row is persisted server-side, so
+ * there is nothing to invalidate here.
+ *
+ * Returns { mutation } only — the caller owns the toast (per CLAUDE.md
+ * "caller handles side effects" convention).
+ */
+export function useSendTestNotification(options?: {
+  onSuccess?: () => void
+  onError?: () => void
+}) {
+  const mutation = useMutation({
+    mutationFn: () => sendTestNotification(),
+    onSuccess: options?.onSuccess,
+    onError: options?.onError,
+  })
+
+  return { mutation }
+}

--- a/frontend/src/testIds/notifications.ts
+++ b/frontend/src/testIds/notifications.ts
@@ -2,6 +2,7 @@ export const NotificationsTestIds = {
   SwitchNotifications: 'switch_notifications',
   RowNotifications: 'row_notifications',
   HelperNotifications: 'text_notifications_helper',
+  BtnSendTest: 'btn_send_test_notification',
   Drawer: 'drawer_notifications',
   DrawerClose: 'btn_notifications_close',
   BtnMarkAllRead: 'btn_mark_all_read',


### PR DESCRIPTION
## O que

Adiciona uma funcionalidade para **disparar uma notificação de teste** e ver como ela aparece no dispositivo. O push passa pelo **backend** (não é um `showNotification` fake local), então o preview é idêntico a uma notificação real ponta a ponta.

## Por quê

Permite ao usuário verificar, depois de ativar as notificações, como elas vão se apresentar — sem precisar esperar um evento real (cobrança, split, transferência).

## Como funciona

- Na linha de toggle de notificações (mobile e desktop), quando as notificações estão **ativadas neste dispositivo**, aparece o botão **"Enviar notificação de teste"**.
- O clique chama `POST /api/notifications/test`, que entrega um push de exemplo para **todas as subscriptions do próprio usuário** autenticado.
- É **display-only**: nenhuma linha de inbox é persistida.

## Mudanças

**Backend**
- `NotificationService.SendTest(ctx, userID)` — entrega o push de teste às subscriptions do usuário.
- Extrai o loop de envio/prune para `pushToSubscriptions`, agora reusado por `Dispatch` e `SendTest` (sem duplicação).
- Retorna erro tagueado `NOTIFICATION.NO_ACTIVE_PUSH_SUBSCRIPTION` quando o usuário não tem subscription.
- Nova rota `POST /api/notifications/test`; mocks e Swagger regenerados (`mockery` / `swag`).

**Frontend**
- `sendTestNotification` (api) + `useSendTestNotification` (mutation hook, padrão `{ mutation }`).
- Botão "Enviar notificação de teste" na `NotificationToggleRow`, visível só com push ativo, com toasts de sucesso/erro.
- Novo `testId` `BtnSendTest`.

## Testes

- **Backend (integração):** entrega a todas as subscriptions, erro tagueado sem subscription, prune de subscription obsoleta (410).
- **Frontend (unit):** cobertura do novo hook (sucesso, erro, chamada única).
- `go build` / `go vet` / `go test -short` ✅ · `tsc --noEmit` / `eslint` / `vitest` (hook) ✅

> Nota: os testes de integração do backend usam testcontainers (Docker) e não foram executados neste ambiente; compilam com `-tags=integration`.

https://claude.ai/code/session_014YbgGCSLhB7F46v7dnHVTj

---
_Generated by [Claude Code](https://claude.ai/code/session_014YbgGCSLhB7F46v7dnHVTj)_