### PR TITLE
fix(notifications): surface push delivery failures and harden iOS delivery

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/finance_app/backend/internal/config"
@@ -48,6 +49,13 @@ func main() {
 	// push delivery to fail in production (T-22-STARTUP mitigation).
 	if cfg.VAPID.PublicKey == "" || cfg.VAPID.PrivateKey == "" || cfg.VAPID.Subject == "" {
 		log.Fatalf("VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY, and VAPID_SUBJECT are required")
+	}
+	// Per RFC 8292 the VAPID JWT `sub` claim must be a "mailto:" or "https:" URI.
+	// Chrome/FCM tolerates a malformed subject, but Apple Push rejects the request
+	// with 400/403 — the classic "works on Android, silent on iPhone" failure.
+	// Fail fast so the misconfiguration is caught at deploy time, not at send time.
+	if !strings.HasPrefix(cfg.VAPID.Subject, "mailto:") && !strings.HasPrefix(cfg.VAPID.Subject, "https://") {
+		log.Fatalf("VAPID_SUBJECT must be a \"mailto:\" or \"https://\" URI (RFC 8292), got %q", cfg.VAPID.Subject)
 	}
 
 	loc, err := time.LoadLocation("UTC")

--- a/backend/internal/service/notification_service.go
+++ b/backend/internal/service/notification_service.go
@@ -113,34 +113,70 @@ func (s *notificationService) Dispatch(ctx context.Context, events []domain.Noti
 	}
 }
 
-// pushToSubscriptions delivers rawPayload to each of the given subscriptions
-// best-effort, logging send errors and pruning any subscription the push
-// service reports as gone (404/410). Shared by Dispatch and SendTest.
-func (s *notificationService) pushToSubscriptions(ctx context.Context, subs []*domain.PushSubscription, rawPayload []byte) {
-	for _, sub := range subs {
-		resp, sendErr := s.sender.Send(rawPayload, &webpush.Subscription{
-			Endpoint: sub.Endpoint,
-			Keys:     webpush.Keys{Auth: sub.Auth, P256dh: sub.P256dh},
-		}, &webpush.Options{
-			Subscriber:      s.vapid.Subject,
-			VAPIDPublicKey:  s.vapid.PublicKey,
-			VAPIDPrivateKey: s.vapid.PrivateKey,
-			TTL:             30,
-		})
-		if sendErr != nil {
-			log.Printf("[notification] push send error endpoint=%s err=%v", sub.Endpoint, sendErr)
-			continue
-		}
-		if resp != nil {
-			status := resp.StatusCode
-			_ = resp.Body.Close() // close immediately, not deferred — defer is function-scoped and would accumulate across loop iterations
-			if status == http.StatusNotFound || status == http.StatusGone {
-				if pruneErr := s.pushSubRepo.DeleteByEndpointAdmin(ctx, sub.Endpoint); pruneErr != nil {
-					log.Printf("[notification] failed to prune stale subscription endpoint=%s err=%v", sub.Endpoint, pruneErr)
-				}
-			}
-		}
+// pushTTLSeconds is the TTL the push service keeps a message queued for offline
+// devices. Kept modest but above the old 30s so a briefly-locked phone (a common
+// iOS case) still receives the notification when it wakes.
+const pushTTLSeconds = 60
+
+// pushResult captures the outcome of a single push send for diagnostics and for
+// SendTest to report a real delivery result back to the user.
+type pushResult struct {
+	endpoint string
+	status   int   // HTTP status from the push service (0 if the send errored before a response)
+	err      error // transport error, if any
+}
+
+// delivered reports whether the push service accepted the message (2xx).
+func (r pushResult) delivered() bool {
+	return r.err == nil && r.status >= 200 && r.status < 300
+}
+
+// sendOne delivers rawPayload to a single subscription and reports the outcome.
+// It prunes the subscription when the push service reports it as gone (404/410)
+// and logs any non-2xx status, so a misconfiguration (e.g. a VAPID subject that
+// Apple Push rejects with 400/403) is visible instead of being silently dropped.
+func (s *notificationService) sendOne(ctx context.Context, sub *domain.PushSubscription, rawPayload []byte) pushResult {
+	resp, sendErr := s.sender.Send(rawPayload, &webpush.Subscription{
+		Endpoint: sub.Endpoint,
+		Keys:     webpush.Keys{Auth: sub.Auth, P256dh: sub.P256dh},
+	}, &webpush.Options{
+		Subscriber:      s.vapid.Subject,
+		VAPIDPublicKey:  s.vapid.PublicKey,
+		VAPIDPrivateKey: s.vapid.PrivateKey,
+		TTL:             pushTTLSeconds,
+		// User-visible notifications must reach the device even on low battery;
+		// without an explicit Urgency, Apple Push may deprioritise/drop them.
+		Urgency: webpush.UrgencyHigh,
+	})
+	if sendErr != nil {
+		log.Printf("[notification] push send error endpoint=%s err=%v", sub.Endpoint, sendErr)
+		return pushResult{endpoint: sub.Endpoint, err: sendErr}
 	}
+	if resp == nil {
+		return pushResult{endpoint: sub.Endpoint}
+	}
+	status := resp.StatusCode
+	_ = resp.Body.Close() // close immediately, not deferred — defer is function-scoped and would accumulate across loop iterations
+	switch {
+	case status == http.StatusNotFound || status == http.StatusGone:
+		if pruneErr := s.pushSubRepo.DeleteByEndpointAdmin(ctx, sub.Endpoint); pruneErr != nil {
+			log.Printf("[notification] failed to prune stale subscription endpoint=%s err=%v", sub.Endpoint, pruneErr)
+		}
+	case status < 200 || status >= 300:
+		log.Printf("[notification] push rejected endpoint=%s status=%d", sub.Endpoint, status)
+	}
+	return pushResult{endpoint: sub.Endpoint, status: status}
+}
+
+// pushToSubscriptions delivers rawPayload to each of the given subscriptions
+// best-effort and returns a per-subscription outcome. Shared by Dispatch (which
+// ignores the results) and SendTest (which reports them to the user).
+func (s *notificationService) pushToSubscriptions(ctx context.Context, subs []*domain.PushSubscription, rawPayload []byte) []pushResult {
+	results := make([]pushResult, 0, len(subs))
+	for _, sub := range subs {
+		results = append(results, s.sendOne(ctx, sub, rawPayload))
+	}
+	return results
 }
 
 // SendTest delivers a sample push notification to every push subscription the
@@ -171,7 +207,22 @@ func (s *notificationService) SendTest(ctx context.Context, userID int) error {
 		return pkgErrors.Internal("failed to marshal test notification payload", err)
 	}
 
-	s.pushToSubscriptions(ctx, subs, rawPayload)
+	// Unlike Dispatch (best-effort), SendTest is a diagnostic: surface whether the
+	// push service actually accepted the message so the user isn't told "sent" when
+	// Apple/FCM rejected it. Report the last non-2xx upstream status to aid debugging.
+	results := s.pushToSubscriptions(ctx, subs, rawPayload)
+	delivered := 0
+	lastStatus := 0
+	for _, r := range results {
+		if r.delivered() {
+			delivered++
+		} else if r.status != 0 {
+			lastStatus = r.status
+		}
+	}
+	if delivered == 0 {
+		return pkgErrors.ErrPushDeliveryFailed(lastStatus)
+	}
 	return nil
 }
 

--- a/backend/internal/service/notification_service_test.go
+++ b/backend/internal/service/notification_service_test.go
@@ -1227,7 +1227,7 @@ func (suite *NotificationServiceWithDBSuite) TestSendTestNoSubscriptionReturnsTa
 	suite.Empty(mockSender.calls, "no push should be attempted without a subscription")
 }
 
-func (suite *NotificationServiceWithDBSuite) TestSendTestPrunesStaleSubscription() {
+func (suite *NotificationServiceWithDBSuite) TestSendTestPrunesStaleSubscriptionAndReportsFailure() {
 	ctx := context.Background()
 
 	user, err := suite.createTestUser(ctx)
@@ -1240,12 +1240,39 @@ func (suite *NotificationServiceWithDBSuite) TestSendTestPrunesStaleSubscription
 	restore := injectMockSender(suite.Services.Notification, mockSender)
 	defer restore()
 
+	// The only subscription was gone, so nothing was delivered — SendTest must
+	// report the failure rather than claim success.
 	err = suite.Services.Notification.SendTest(ctx, user.ID)
-	suite.Require().NoError(err)
+	suite.Require().Error(err, "SendTest must error when no subscription accepted the push")
+	svcErr, ok := pkgErrors.AsServiceError(err)
+	suite.Require().True(ok, "error should be a *ServiceError, got: %v", err)
+	suite.Contains(svcErr.Tags, string(pkgErrors.ErrorTagPushDeliveryFailed))
 
+	// ...and the stale subscription must still have been pruned.
 	status, err := suite.Services.PushSubscription.Status(ctx, user.ID, endpoint)
 	suite.Require().NoError(err)
 	suite.False(status.Subscribed, "stale subscription should be pruned after a 410 from a test push")
+}
+
+func (suite *NotificationServiceWithDBSuite) TestSendTestReportsUpstreamRejection() {
+	ctx := context.Background()
+
+	user, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	suite.subscribeUser(ctx, user.ID)
+
+	// Apple Push rejecting a malformed VAPID JWT looks like a 403 — SendTest must
+	// surface it instead of silently reporting success.
+	mockSender := &mockPushSender{status: http.StatusForbidden}
+	restore := injectMockSender(suite.Services.Notification, mockSender)
+	defer restore()
+
+	err = suite.Services.Notification.SendTest(ctx, user.ID)
+	suite.Require().Error(err, "SendTest must error when the push service rejects the message")
+	svcErr, ok := pkgErrors.AsServiceError(err)
+	suite.Require().True(ok, "error should be a *ServiceError, got: %v", err)
+	suite.Contains(svcErr.Tags, string(pkgErrors.ErrorTagPushDeliveryFailed))
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -80,6 +80,7 @@ const (
 	ErrorTagSettlementDateIsRequired ErrorTag = "SETTLEMENT.DATE_IS_REQUIRED"
 
 	ErrorTagNoActivePushSubscription ErrorTag = "NOTIFICATION.NO_ACTIVE_PUSH_SUBSCRIPTION"
+	ErrorTagPushDeliveryFailed       ErrorTag = "NOTIFICATION.PUSH_DELIVERY_FAILED"
 )
 
 var (
@@ -144,6 +145,9 @@ var (
 	ErrSettlementDateIsRequired                    = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSettlementDateIsRequired)}, "date is required")
 
 	ErrNoActivePushSubscription = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagNoActivePushSubscription)}, "no active push subscription for this user")
+	ErrPushDeliveryFailed       = func(status int) *ServiceError {
+		return NewWithTag(ErrCodeInternal, []string{string(ErrorTagPushDeliveryFailed)}, fmt.Sprintf("push delivery failed (upstream status %d)", status))
+	}
 )
 
 // ServiceError represents a service-level error with a code and message

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -30,7 +30,15 @@ export async function sendTestNotification(): Promise<void> {
     method: 'POST',
     credentials: 'include',
   })
-  if (!res.ok) throw new Error('Failed to send test notification')
+  if (!res.ok) {
+    // Surface the backend's reason (e.g. upstream push status) so the toast is
+    // diagnostic instead of generic — this endpoint exists to debug delivery.
+    const message = await res
+      .json()
+      .then((body: { message?: string }) => body?.message)
+      .catch(() => undefined)
+    throw new Error(message ?? 'Failed to send test notification')
+  }
 }
 
 export async function markNotificationRead(id: number): Promise<void> {

--- a/frontend/src/components/notifications/NotificationToggleRow.tsx
+++ b/frontend/src/components/notifications/NotificationToggleRow.tsx
@@ -37,12 +37,12 @@ export function NotificationToggleRow({ variant }: NotificationToggleRowProps) {
         message: 'Veja como ela aparece no seu dispositivo.',
         autoClose: 3000,
       }),
-    onError: () =>
+    onError: (error: Error) =>
       notifications.show({
         color: 'red',
         title: 'Erro ao enviar',
-        message: 'Não foi possível enviar a notificação de teste. Tente novamente.',
-        autoClose: 3000,
+        message: error.message || 'Não foi possível enviar a notificação de teste. Tente novamente.',
+        autoClose: 5000,
       }),
   })
 

--- a/frontend/src/hooks/useSendTestNotification.ts
+++ b/frontend/src/hooks/useSendTestNotification.ts
@@ -16,12 +16,12 @@ import { sendTestNotification } from '@/api/notifications'
  */
 export function useSendTestNotification(options?: {
   onSuccess?: () => void
-  onError?: () => void
+  onError?: (error: Error) => void
 }) {
   const mutation = useMutation({
     mutationFn: () => sendTestNotification(),
     onSuccess: options?.onSuccess,
-    onError: options?.onError,
+    onError: (error: Error) => options?.onError?.(error),
   })
 
   return { mutation }


### PR DESCRIPTION
## Contexto

Após o #186 mergear a feature de notificação de teste, o teste no iPhone confirmou que **o push não aparece** mesmo com permissão concedida. A feature reportava "enviada" mesmo quando o serviço de push descartava a mensagem — escondendo a causa.

## Causa raiz

**Apple Push é estrito onde o Chrome/FCM é tolerante.** O `sub` do JWT VAPID precisa ser uma URI `mailto:` ou `https:` (RFC 8292). Um `VAPID_SUBJECT` malformado (ex.: e-mail puro `admin@x.com`) faz a Apple rejeitar com **400/403**, enquanto o Chrome ignora — exatamente o padrão "funciona no Android, silencioso no iPhone".

E o backend **engolia respostas não-2xx** (só tratava 404/410), então a rejeição da Apple não aparecia em lugar nenhum e o toast do teste mostrava sucesso.

## Mudanças

**Guard de causa raiz + diagnóstico**
- ✅ Valida o **formato do `VAPID_SUBJECT`** no startup (`mailto:`/`https:`). Fail-fast no deploy, não na hora do envio.
- ✅ `sendOne` agora **loga qualquer status não-2xx** do push (antes só 404/410 eram tratados).
- ✅ `SendTest` agrega o resultado por subscription e retorna erro tagueado `NOTIFICATION.PUSH_DELIVERY_FAILED` com o **status upstream** quando nada foi entregue — o toast passa a mostrar o motivo real em vez de um "enviada" falso.

**Robustez de entrega (ajuda iOS)**
- ✅ `Urgency: high` no web push (notificações user-visible precisam chegar mesmo com bateria baixa; sem isso a Apple pode despriorizar/descartar).
- ✅ TTL 30s → 60s (telefone brevemente bloqueado ainda recebe).

**Frontend**
- `sendTestNotification` lê o corpo de erro do backend; o toast mostra a mensagem; hook encaminha o erro para `onError`.

## Como isso te ajuda a debugar agora

Depois deste deploy, toque em **"Enviar notificação de teste"** no iPhone:
- Se o `VAPID_SUBJECT` estiver malformado, o **app nem sobe** (log claro no deploy) → corrigir a env var.
- Se a Apple rejeitar por outro motivo, o **toast mostra o status upstream** (ex.: "push delivery failed (upstream status 403)") e o **log do backend** registra `push rejected ... status=403`. Me mande esse número que eu fecho o diagnóstico.

## Testes
- Backend (integração): `SendTest` reporta falha em rejeição upstream (403) e em subscription obsoleta (410), ainda fazendo o prune.
- `go build` / `go vet` / `go test -short` ✅ · `tsc` / `eslint` / `vitest` ✅

> ⚠️ Os checks de iOS de ponta a ponta dependem de um device real; aqui validei o caminho de servidor/tipo/lint. Os testes de integração usam testcontainers (Docker) e não rodaram neste ambiente, mas compilam com `-tags=integration`.

https://claude.ai/code/session_014YbgGCSLhB7F46v7dnHVTj

---
_Generated by [Claude Code](https://claude.ai/code/session_014YbgGCSLhB7F46v7dnHVTj)_