### PR TITLE
fix(notifications): log push service rejection reason on non-2xx

### DIFF
--- a/backend/internal/service/notification_service.go
+++ b/backend/internal/service/notification_service.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"unicode"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
@@ -122,8 +124,9 @@ const pushTTLSeconds = 60
 // SendTest to report a real delivery result back to the user.
 type pushResult struct {
 	endpoint string
-	status   int   // HTTP status from the push service (0 if the send errored before a response)
-	err      error // transport error, if any
+	status   int    // HTTP status from the push service (0 if the send errored before a response)
+	body     string // truncated response body on non-2xx (push services return a machine-readable reason)
+	err      error  // transport error, if any
 }
 
 // delivered reports whether the push service accepted the message (2xx).
@@ -156,6 +159,14 @@ func (s *notificationService) sendOne(ctx context.Context, sub *domain.PushSubsc
 		return pushResult{endpoint: sub.Endpoint}
 	}
 	status := resp.StatusCode
+	// On any non-2xx, read a snippet of the push service's response body. Apple and
+	// FCM return a machine-readable reason (e.g. {"reason":"BadJwtToken"}) that is
+	// the only way to tell *why* a 403/400 happened — status alone is ambiguous.
+	var reason string
+	if status < 200 || status >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		reason = strings.TrimSpace(string(b))
+	}
 	_ = resp.Body.Close() // close immediately, not deferred — defer is function-scoped and would accumulate across loop iterations
 	switch {
 	case status == http.StatusNotFound || status == http.StatusGone:
@@ -163,9 +174,9 @@ func (s *notificationService) sendOne(ctx context.Context, sub *domain.PushSubsc
 			log.Printf("[notification] failed to prune stale subscription endpoint=%s err=%v", sub.Endpoint, pruneErr)
 		}
 	case status < 200 || status >= 300:
-		log.Printf("[notification] push rejected endpoint=%s status=%d", sub.Endpoint, status)
+		log.Printf("[notification] push rejected endpoint=%s status=%d reason=%q", sub.Endpoint, status, reason)
 	}
-	return pushResult{endpoint: sub.Endpoint, status: status}
+	return pushResult{endpoint: sub.Endpoint, status: status, body: reason}
 }
 
 // pushToSubscriptions delivers rawPayload to each of the given subscriptions
@@ -213,15 +224,17 @@ func (s *notificationService) SendTest(ctx context.Context, userID int) error {
 	results := s.pushToSubscriptions(ctx, subs, rawPayload)
 	delivered := 0
 	lastStatus := 0
+	lastReason := ""
 	for _, r := range results {
 		if r.delivered() {
 			delivered++
 		} else if r.status != 0 {
 			lastStatus = r.status
+			lastReason = r.body
 		}
 	}
 	if delivered == 0 {
-		return pkgErrors.ErrPushDeliveryFailed(lastStatus)
+		return pkgErrors.ErrPushDeliveryFailed(lastStatus, lastReason)
 	}
 	return nil
 }

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -145,8 +145,12 @@ var (
 	ErrSettlementDateIsRequired                    = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSettlementDateIsRequired)}, "date is required")
 
 	ErrNoActivePushSubscription = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagNoActivePushSubscription)}, "no active push subscription for this user")
-	ErrPushDeliveryFailed       = func(status int) *ServiceError {
-		return NewWithTag(ErrCodeInternal, []string{string(ErrorTagPushDeliveryFailed)}, fmt.Sprintf("push delivery failed (upstream status %d)", status))
+	ErrPushDeliveryFailed       = func(status int, reason string) *ServiceError {
+		msg := fmt.Sprintf("push delivery failed (upstream status %d)", status)
+		if reason != "" {
+			msg = fmt.Sprintf("%s: %s", msg, reason)
+		}
+		return NewWithTag(ErrCodeInternal, []string{string(ErrorTagPushDeliveryFailed)}, msg)
 	}
 )
 


### PR DESCRIPTION
## Contexto

Diagnóstico do push no iPhone (continuação do #186/#187). Já descartamos as duas causas mais comuns do 403 da Apple:

- ✅ **Par de chaves VAPID válido** — confirmado rodando o backend local com as chaves de prod (`VAPID key pair verified`).
- ✅ **Subscription nova** — o device foi removido e re-inscrito.

E **ainda dá 403**. Logo, a Apple está rejeitando o **conteúdo do JWT** (motivo em `sub`/`exp`/`aud`/assinatura) — e até agora só logávamos o status, descartando o corpo da resposta onde a Apple explica o motivo.

## Mudança

`sendOne` agora lê até 512 bytes do corpo da resposta em qualquer status não-2xx e expõe a razão:

- **Log**: `[notification] push rejected endpoint=… status=403 reason="{\"reason\":\"BadJwtToken\"}"`
- **Toast / erro do `SendTest`**: a razão entra na mensagem (`ErrPushDeliveryFailed` agora recebe o `reason`), então o botão de teste mostra o motivo direto no iPhone.

Apple/FCM retornam uma razão legível (ex.: `BadJwtToken`, `InvalidProviderToken`, `ExpiredProviderToken`) que aponta exatamente por que o JWT é rejeitado — encerrando o chute.

> A verificação de par de chaves (`VerifyKeyPair`) que existia numa versão anterior deste PR foi **removida** a pedido — ela já cumpriu o papel de confirmar que as env vars são um par válido, e não é mais necessária.

## Testes
- `go build` / `go vet` / `go test -short ./internal/service/...` ✅
- Testes de integração de `SendTest` (entrega, sem-subscription, rejeição upstream, prune) compilam com `-tags=integration`.

https://claude.ai/code/session_014YbgGCSLhB7F46v7dnHVTj