### PR TITLE
fix(notifications): strip mailto: prefix before webpush to fix Apple BadJwtToken

### DIFF
--- a/backend/internal/service/notification_service.go
+++ b/backend/internal/service/notification_service.go
@@ -134,6 +134,18 @@ func (r pushResult) delivered() bool {
 	return r.err == nil && r.status >= 200 && r.status < 300
 }
 
+// webpushSubscriber normalizes the VAPID subject for webpush-go's JWT builder,
+// which prepends "mailto:" to any value that does not already start with
+// "https:". Passing an already "mailto:"-prefixed subject (the RFC 8292 /
+// operator-friendly form, and the one our startup guard enforces) would produce
+// a double "mailto:mailto:..." `sub` claim that Apple Push rejects with
+// BadJwtToken — silently, since Chrome/FCM ignore `sub`. Strip a leading
+// "mailto:" so webpush-go re-adds exactly one; "https:" subjects pass through
+// untouched.
+func webpushSubscriber(subject string) string {
+	return strings.TrimPrefix(subject, "mailto:")
+}
+
 // sendOne delivers rawPayload to a single subscription and reports the outcome.
 // It prunes the subscription when the push service reports it as gone (404/410)
 // and logs any non-2xx status, so a misconfiguration (e.g. a VAPID subject that
@@ -143,7 +155,7 @@ func (s *notificationService) sendOne(ctx context.Context, sub *domain.PushSubsc
 		Endpoint: sub.Endpoint,
 		Keys:     webpush.Keys{Auth: sub.Auth, P256dh: sub.P256dh},
 	}, &webpush.Options{
-		Subscriber:      s.vapid.Subject,
+		Subscriber:      webpushSubscriber(s.vapid.Subject),
 		VAPIDPublicKey:  s.vapid.PublicKey,
 		VAPIDPrivateKey: s.vapid.PrivateKey,
 		TTL:             pushTTLSeconds,

--- a/backend/internal/service/notification_subject_test.go
+++ b/backend/internal/service/notification_subject_test.go
@@ -1,0 +1,27 @@
+package service
+
+import "testing"
+
+// TestWebpushSubscriber guards against the Apple BadJwtToken regression: a
+// "mailto:"-prefixed VAPID subject must be handed to webpush-go without the
+// prefix, because webpush-go re-adds it. A double "mailto:mailto:" `sub` claim
+// is rejected by Apple Push with HTTP 403 BadJwtToken.
+func TestWebpushSubscriber(t *testing.T) {
+	cases := []struct {
+		name    string
+		subject string
+		want    string
+	}{
+		{"mailto prefix stripped", "mailto:user@example.com", "user@example.com"},
+		{"bare email untouched", "user@example.com", "user@example.com"},
+		{"https url untouched", "https://example.com/contact", "https://example.com/contact"},
+		{"only leading mailto stripped", "mailto:mailto:weird", "mailto:weird"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := webpushSubscriber(tc.subject); got != tc.want {
+				t.Fatalf("webpushSubscriber(%q) = %q, want %q", tc.subject, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 🎯 Causa raiz encontrada

O log com a captura de motivo (do #188) deu a resposta exata da Apple:

```
push rejected endpoint=https://web.push.apple.com/… status=403 reason="{\"reason\":\"BadJwtToken\"}"
```

**Bug:** o `webpush-go` v1.4.0 prefixa `mailto:` em qualquer subject que **não** comece com `https:`:

```go
// Unless subscriber is an HTTPS URL, assume an e-mail address
if !strings.HasPrefix(subscriber, "https:") {
    subscriber = "mailto:" + subscriber
}
```

Então um `VAPID_SUBJECT` **correto** no formato RFC 8292 — `mailto:foo@bar.com`, que é inclusive o que o guard de startup do #187 exige — vira `mailto:mailto:foo@bar.com`. Esse claim `sub` é inválido → **Apple responde 403 `BadJwtToken`**. Chrome/FCM ignoram o `sub`, por isso só quebrava no iPhone.

## Correção

`webpushSubscriber()` remove um `mailto:` inicial antes de passar o subject pro webpush-go, que então re-adiciona exatamente um. Subjects `https:` passam intactos.

| `VAPID_SUBJECT` | passado ao webpush-go | `sub` final |
|---|---|---|
| `mailto:foo@bar.com` | `foo@bar.com` | `mailto:foo@bar.com` ✅ |
| `foo@bar.com` | `foo@bar.com` | `mailto:foo@bar.com` ✅ |
| `https://x.com` | `https://x.com` | `https://x.com` ✅ |

Antes desta correção, o caso do meio (`mailto:…`) gerava `mailto:mailto:…` ❌.

## Testes
- Novo teste unitário `TestWebpushSubscriber` cobre todos os formatos de entrada.
- `go build` / `go vet` / `go test -short ./internal/service/...` ✅

Sem mudança de env var necessária — depois do deploy, o push deve **funcionar no iPhone**.

https://claude.ai/code/session_014YbgGCSLhB7F46v7dnHVTj

---
_Generated by [Claude Code](https://claude.ai/code/session_014YbgGCSLhB7F46v7dnHVTj)_