### PR TITLE
fix(ci): pick previous release tag correctly in deploy change detection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,14 @@ jobs:
         id: prev-tag
         run: |
           CURRENT_TAG=${{ github.event.release.tag_name || inputs.release_tag }}
-          PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${CURRENT_TAG}$" | head -1)
+          # Previous *release* tag for the changed-paths diff. Restrict to vX.Y.Z
+          # release tags (milestone tags like v1.1/v1.2 sort highest by version and
+          # were being picked as the predecessor, producing a bogus diff against an
+          # unrelated tag), and select the immediate predecessor of CURRENT_TAG in
+          # version order rather than the globally-highest tag.
+          PREV_TAG=$(git tag --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | awk -v cur="${CURRENT_TAG}" 'found { print; exit } $0 == cur { found = 1 }')
           echo "prev_tag=${PREV_TAG}" >> $GITHUB_OUTPUT
           echo "current_tag=${CURRENT_TAG}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Problema

O job **Detect Changed Paths** do `deploy.yml` escolhia a tag anterior assim:

```bash
PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${CURRENT_TAG}$" | head -1)
```

Isso pega a tag de **maior versão** no repositório. Como existem tags de **milestone** (`v1.1`, `v1.2`) misturadas com as de **release** (`v0.1.xx`), e `v1.2` ordena acima de qualquer `v0.1.x`, uma release como `v0.1.77` acabava comparada contra `v1.2`:

```
PREV_TAG=v1.2
CURRENT_TAG=v0.1.77
git diff --name-only v1.2..v0.1.77   # diff contra tag não relacionada → enorme
```

→ a detecção de paths dá **falso positivo** (deploya backend e/ou frontend que não mudaram).

## Correção

Restringir os candidatos a tags de release `vX.Y.Z` e pegar a **predecessora imediata** de `CURRENT_TAG` na ordem de versão, em vez da maior tag global:

```bash
PREV_TAG=$(git tag --sort=-version:refname \
  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
  | awk -v cur="${CURRENT_TAG}" 'found { print; exit } $0 == cur { found = 1 }')
```

## Validação (contra as tags reais do repo)

| CURRENT_TAG | PREV_TAG antes (bug) | PREV_TAG depois |
|---|---|---|
| `v0.1.77` | `v1.2` ❌ | `v0.1.76` ✅ |
| `v0.1.75` | `v1.2` ❌ | `v0.1.74` ✅ |

Com `v0.1.76..v0.1.77`, o diff mostra exatamente os arquivos de backend da última release — então `frontend` corretamente fica `false`. YAML validado.

https://claude.ai/code/session_014YbgGCSLhB7F46v7dnHVTj

---
_Generated by [Claude Code](https://claude.ai/code/session_014YbgGCSLhB7F46v7dnHVTj)_