### PR TITLE
fix(transactions): full-width mobile form header with right-aligned Salvar

### DIFF
--- a/frontend/src/components/transactions/CreateTransactionDrawer.tsx
+++ b/frontend/src/components/transactions/CreateTransactionDrawer.tsx
@@ -132,6 +132,10 @@ export function CreateTransactionDrawer() {
       }
       withCloseButton={!isMobile}
       size="lg"
+      // On mobile the header bar (MobileFormHeader) must span the full width so
+      // "Salvar" sits flush right; Mantine's Drawer.Title otherwise shrinks to
+      // its content. flex:1 lets it fill the header row.
+      styles={isMobile ? { title: { flex: 1 } } : undefined}
       data-testid={TransactionsTestIds.DrawerCreate}
     >
       <FormProvider {...methods}>

--- a/frontend/src/components/transactions/UpdateTransactionDrawer.tsx
+++ b/frontend/src/components/transactions/UpdateTransactionDrawer.tsx
@@ -224,6 +224,10 @@ export function UpdateTransactionDrawer({ transaction, focusField }: Props) {
       }
       withCloseButton={!isMobile}
       size="lg"
+      // On mobile the header bar (MobileFormHeader) must span the full width so
+      // "Salvar" sits flush right; Mantine's Drawer.Title otherwise shrinks to
+      // its content. flex:1 lets it fill the header row.
+      styles={isMobile ? { title: { flex: 1 } } : undefined}
       data-testid={TransactionsTestIds.DrawerUpdate}
     >
       <FormProvider {...methods}>


### PR DESCRIPTION
## Problem

On mobile, the transaction create/edit drawer header (`MobileFormHeader`) renders the `[ Cancelar ]  {title}  [ Salvar ]` bar with `w="100%"`, but it lives inside Mantine's `Drawer.Title`, which shrinks to its content width. As a result the bar wasn't spanning the full header and **Salvar** wasn't flush against the right edge.

## Fix

Make the `Drawer.Title` wrapper grow to fill the header row on mobile by passing `styles={{ title: { flex: 1 } }}` to the `ResponsiveDrawer` (mobile only, so desktop is untouched). With the container now full width, the existing `justify="space-between"` layout places **Cancelar** on the left, the centered title in the middle, and **Salvar** aligned right.

Applied to both:
- `CreateTransactionDrawer.tsx`
- `UpdateTransactionDrawer.tsx`

No behavior change on desktop (`styles` is `undefined` when not mobile).

https://claude.ai/code/session_015fVtpCBdU78m6YeS8LMU8G

---
_Generated by [Claude Code](https://claude.ai/code/session_015fVtpCBdU78m6YeS8LMU8G)_