### PR TITLE
feat(connections): configurable day-of-month for split linked transactions

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: Push Notifications
 status: verifying
-last_updated: "2026-05-30T16:53:02.540Z"
-last_activity: 2026-05-30
+last_updated: "2026-06-07T00:00:00.000Z"
+last_activity: 2026-06-07
 progress:
   total_phases: 9
   completed_phases: 2
@@ -18,7 +18,13 @@ progress:
 Phase: 25 (frontend-notification-inbox) — VERIFIED — v1.6 milestone COMPLETE
 Plan: 5 of 5
 Status: PASS (code-complete, e2e-deferred-to-CI) — all v1.6 phases (22-25) verified
-Last activity: 2026-05-30
+Last activity: 2026-06-07 - Completed quick task 260607-001: configurable day-of-month for split linked transactions
+
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 260607-001 | Configurable day-of-month for linked transactions on split | 2026-06-07 | ee27c80 | [260607-001-connection-linked-tx-day](./quick/260607-001-connection-linked-tx-day/) |
 
 ## Project Reference
 

--- a/.planning/quick/260607-001-connection-linked-tx-day/260607-001-PLAN.md
+++ b/.planning/quick/260607-001-connection-linked-tx-day/260607-001-PLAN.md
@@ -1,0 +1,76 @@
+---
+quick_id: 260607-001
+slug: connection-linked-tx-day
+date: 2026-06-07
+mode: quick
+status: in-progress
+---
+
+# Quick Task 260607-001: Configurable day-of-month for linked transactions
+
+## Goal
+
+Allow each user to configure, on their `UserConnection`, the **day of month** on
+which their linked transaction is created when the *other* connected user splits a
+transaction with them.
+
+Example: User A splits R$100 with their partner (User B) on 08/07. User B configured
+their side of the connection to "always create on day 10". → User B's R$50 linked
+expense is dated **10/07** (same month, day forced to 10).
+
+## Design decisions
+
+- **Preference is per-side**, stored on the single connection row as two nullable
+  columns: `from_linked_transaction_day_of_month` and `to_linked_transaction_day_of_month`
+  (1–31, `NULL` = no preference, inherit source date).
+- `UserConnection.SwapIfNeeded` already flips user/account IDs so the author is always
+  "from". The two new day fields are **swapped alongside** them, so after swap the
+  partner's preference always lives on the `To*` side — exactly where the partner's
+  linked transaction is created.
+- The adjustment only changes the **day**; year/month come from the source
+  transaction's date (per installment for recurrences). Days past month-end clamp to the
+  last day (reusing the `clampToEndOfMonth` style helper).
+- Scope: **shared expense/income linked transactions only**. Transfers are NOT adjusted
+  (they represent real money movement on a specific date). Settlements keep their current
+  date logic (unchanged).
+- Applied on both **create** (`transaction_create.go`) and **split rebuild on update**
+  (`transaction_update.go`) so editing a split keeps the preference.
+
+## Tasks
+
+### Task 1 — Backend
+- `migrations/`: new goose migration adding the two nullable SMALLINT columns with a
+  `CHECK (between 1 and 31)` constraint (hand-written; `goose` CLI unavailable here).
+- `domain/user_connection.go`: add `FromLinkedTransactionDayOfMonth`,
+  `ToLinkedTransactionDayOfMonth *int`; swap them in `SwapIfNeeded`.
+- `entity/user_connection.go`: mirror fields + `ToDomain`/`FromDomain`.
+- `service/interfaces.go` + `service/user_connection_service.go`: extend `UpdateSettings`
+  to accept `linkedTransactionDayOfMonth *int`, validate (nil or 1–31), set on caller's side.
+- `handler/user_connection_handler.go`: add field to `UpdateConnectionSettingsRequest`,
+  pass through, update Swagger annotation.
+- `service/transaction_create.go`: add `adjustLinkedTransactionDay` helper; apply to the
+  shared-account linked tx and the split `toTransaction` (non-transfer).
+- `service/transaction_update.go`: apply the same adjustment at the two split-rebuild spots.
+- `mocks/mock_UserConnectionService.go`: update `UpdateSettings` signature (mockery unavailable).
+- Tests: update existing `UpdateSettings` callers; add coverage for the day-of-month behavior.
+- Regenerate swagger docs if `swag` is installable; otherwise note for CI.
+
+**verify:** `go build ./...`, `go vet ./...`, `go test ./internal/service/... ./internal/handler/...`
+
+### Task 2 — Frontend
+- `types/transactions.ts` `UserConnection`: add optional `from_/to_linked_transaction_day_of_month`.
+- `api/userConnections.ts`: add to `Connection` type and `UpdateConnectionPayload`.
+- `components/connections/EditConnectionDrawer.tsx`: add an optional NumberInput (1–31)
+  for "day of month", read the caller's current side, include in submit payload.
+- `testIds/common.ts`: add `EditConnectionDayInput`.
+
+**verify:** `npm run lint`, `npx tsc --noEmit`, `npm run build`
+
+## must_haves
+- truths:
+  - Partner's linked transaction lands on the configured day-of-month of the source month.
+  - Day clamps to month-end; `NULL` preference leaves the source date untouched.
+  - Transfers and settlements are unaffected.
+- artifacts:
+  - migration file, day fields on domain+entity, `UpdateSettings` day param,
+    `adjustLinkedTransactionDay` helper, drawer NumberInput.

--- a/.planning/quick/260607-001-connection-linked-tx-day/260607-001-SUMMARY.md
+++ b/.planning/quick/260607-001-connection-linked-tx-day/260607-001-SUMMARY.md
@@ -1,0 +1,70 @@
+---
+quick_id: 260607-001
+slug: connection-linked-tx-day
+date: 2026-06-07
+mode: quick
+status: complete
+commits:
+  - ee27c80  # backend
+  - e383d2e  # frontend
+---
+
+# Quick Task 260607-001 — Summary
+
+## What was built
+
+Each participant can now configure, on their side of a `UserConnection`, the
+**day of month** on which their linked transaction is created when the *other*
+connected user splits a transaction with them.
+
+> Example: User A splits R$100 with User B on 08/07. User B set their side to
+> "day 10". → User B's R$50 expense is dated **10/07** (same month, day = 10).
+
+## Changes
+
+### Backend (commit ee27c80)
+- **Migration** `20260607000000_add_linked_transaction_day_of_month_to_user_connections.sql`
+  — two nullable `SMALLINT` columns (`from_`/`to_linked_transaction_day_of_month`)
+  with a `CHECK (BETWEEN 1 AND 31)`. *Hand-written in goose format — `goose` CLI
+  is not installed in this environment.*
+- **Domain** `user_connection.go` — added the two `*int` fields; `SwapIfNeeded`
+  swaps them with the user/account ids so the partner's preference always lands
+  on the `To*` side at split time.
+- **Entity** — mirrored fields + `ToDomain`/`FromDomain`.
+- **Service** `UpdateSettings(..., linkedTransactionDayOfMonth *int)` — validates
+  (nil or 1–31) and writes the caller's side only (other side preserved).
+- **Handler** — new `linked_transaction_day_of_month` field on
+  `UpdateConnectionSettingsRequest`; Swagger regenerated.
+- **Linked-tx date** — new helper `adjustLinkedTransactionDay` (clamps to
+  month-end). Applied to the partner's linked tx in:
+  - `transaction_create.go`: shared-account path + split `toTransaction` (non-transfer).
+  - `transaction_update.go`: both split-rebuild spots (AddedSplit + SplitHasChanged).
+  - **Transfers and settlements are intentionally unaffected.**
+- **Mock** `mock_UserConnectionService.go` updated by hand (mockery not installed).
+- **Tests** — new `TestUpdateSettingsPersistsLinkedTransactionDayPerSide`,
+  `TestUpdateSettingsRejectsInvalidLinkedTransactionDay`, and
+  `TestCreateSharedExpenseHonorsPartnerLinkedTransactionDay`.
+
+### Frontend (commit e383d2e)
+- `types/transactions.ts` + `api/userConnections.ts` — new optional fields on the
+  connection types and `linked_transaction_day_of_month` on `UpdateConnectionPayload`.
+- `EditConnectionDrawer.tsx` — optional NumberInput (1–31) "Dia do mês para suas
+  transações"; reads the caller's own side; blank clears the preference; included
+  in the dirty check + submit payload.
+- `testIds/common.ts` — `EditConnectionDayInput`.
+
+## Verification
+- `go build ./...` ✅  `go vet ./...` ✅
+- `go test -short ./internal/service/... ./internal/handler/...` ✅ (compiles +
+  runs all unit tests, including the new integration test code)
+- Frontend: `tsc --noEmit` ✅, `eslint` (touched files) ✅, `npm run build` ✅
+- Swagger docs regenerated (`swag v1.16.2`); new fields present.
+
+## Known limitations / follow-ups
+- **DB integration tests not executed here.** testcontainers needs to pull
+  `postgres:15-alpine`, which this environment's network policy blocks (registry
+  CDN returns 403). The new integration tests compile and will run in CI / locally
+  where Docker image pulls are allowed.
+- Editing a transaction's **date** (without changing the split) does not
+  re-apply the day preference — the linked tx date only re-derives on add/change
+  of split, matching the existing rebuild behavior. Out of scope for this task.

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -666,8 +666,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "integer",
-                                "format": "int64"
+                                "type": "integer"
                             }
                         }
                     },
@@ -2522,7 +2521,7 @@ const docTemplate = `{
                 "tags": [
                     "user-connections"
                 ],
-                "summary": "Update connection settings (account name + default split)",
+                "summary": "Update connection settings (account name + default split + linked tx day)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -3761,6 +3760,10 @@ const docTemplate = `{
                 "from_default_split_percentage": {
                     "type": "integer"
                 },
+                "from_linked_transaction_day_of_month": {
+                    "description": "Optional day-of-month (1–31) on which each side wants their linked transaction\nto be created when the other participant splits a transaction with them. nil\nmeans \"no preference\" — the linked transaction inherits the source date.",
+                    "type": "integer"
+                },
                 "from_user_avatar_url": {
                     "type": "string"
                 },
@@ -3777,6 +3780,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "to_default_split_percentage": {
+                    "type": "integer"
+                },
+                "to_linked_transaction_day_of_month": {
                     "type": "integer"
                 },
                 "to_user_avatar_url": {
@@ -3832,6 +3838,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "default_split_percentage": {
+                    "type": "integer"
+                },
+                "linked_transaction_day_of_month": {
+                    "description": "Optional day-of-month (1–31) on which the caller's linked transactions are\ncreated when the other participant splits a transaction with them. nil clears\nthe preference (the linked transaction inherits the source transaction date).",
                     "type": "integer"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -660,8 +660,7 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "integer",
-                                "format": "int64"
+                                "type": "integer"
                             }
                         }
                     },
@@ -2516,7 +2515,7 @@
                 "tags": [
                     "user-connections"
                 ],
-                "summary": "Update connection settings (account name + default split)",
+                "summary": "Update connection settings (account name + default split + linked tx day)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -3755,6 +3754,10 @@
                 "from_default_split_percentage": {
                     "type": "integer"
                 },
+                "from_linked_transaction_day_of_month": {
+                    "description": "Optional day-of-month (1–31) on which each side wants their linked transaction\nto be created when the other participant splits a transaction with them. nil\nmeans \"no preference\" — the linked transaction inherits the source date.",
+                    "type": "integer"
+                },
                 "from_user_avatar_url": {
                     "type": "string"
                 },
@@ -3771,6 +3774,9 @@
                     "type": "integer"
                 },
                 "to_default_split_percentage": {
+                    "type": "integer"
+                },
+                "to_linked_transaction_day_of_month": {
                     "type": "integer"
                 },
                 "to_user_avatar_url": {
@@ -3826,6 +3832,10 @@
                     "type": "string"
                 },
                 "default_split_percentage": {
+                    "type": "integer"
+                },
+                "linked_transaction_day_of_month": {
+                    "description": "Optional day-of-month (1–31) on which the caller's linked transactions are\ncreated when the other participant splits a transaction with them. nil clears\nthe preference (the linked transaction inherits the source transaction date).",
                     "type": "integer"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -649,6 +649,12 @@ definitions:
         type: integer
       from_default_split_percentage:
         type: integer
+      from_linked_transaction_day_of_month:
+        description: |-
+          Optional day-of-month (1–31) on which each side wants their linked transaction
+          to be created when the other participant splits a transaction with them. nil
+          means "no preference" — the linked transaction inherits the source date.
+        type: integer
       from_user_avatar_url:
         type: string
       from_user_id:
@@ -660,6 +666,8 @@ definitions:
       to_account_id:
         type: integer
       to_default_split_percentage:
+        type: integer
+      to_linked_transaction_day_of_month:
         type: integer
       to_user_avatar_url:
         type: string
@@ -697,6 +705,12 @@ definitions:
       account_name:
         type: string
       default_split_percentage:
+        type: integer
+      linked_transaction_day_of_month:
+        description: |-
+          Optional day-of-month (1–31) on which the caller's linked transactions are
+          created when the other participant splits a transaction with them. nil clears
+          the preference (the linked transaction inherits the source transaction date).
         type: integer
     type: object
   handler.testLoginRequest:
@@ -1231,7 +1245,6 @@ paths:
           description: OK
           schema:
             additionalProperties:
-              format: int64
               type: integer
             type: object
         "401":
@@ -2279,7 +2292,8 @@ paths:
       security:
       - CookieAuth: []
       - BearerAuth: []
-      summary: Update connection settings (account name + default split)
+      summary: Update connection settings (account name + default split + linked tx
+        day)
       tags:
       - user-connections
   /api/user-connections/{id}/{status}:

--- a/backend/internal/domain/user_connection.go
+++ b/backend/internal/domain/user_connection.go
@@ -29,6 +29,11 @@ type UserConnection struct {
 	FromUserName               *string                  `json:"from_user_name,omitempty"`
 	ToUserAvatarURL            *string                  `json:"to_user_avatar_url,omitempty"`
 	ToUserName                 *string                  `json:"to_user_name,omitempty"`
+	// Optional day-of-month (1–31) on which each side wants their linked transaction
+	// to be created when the other participant splits a transaction with them. nil
+	// means "no preference" — the linked transaction inherits the source date.
+	FromLinkedTransactionDayOfMonth *int `json:"from_linked_transaction_day_of_month,omitempty"`
+	ToLinkedTransactionDayOfMonth   *int `json:"to_linked_transaction_day_of_month,omitempty"`
 }
 
 // inverte os ids da connection para que o user atual sempre seja o from
@@ -36,6 +41,9 @@ type UserConnection struct {
 func (c *UserConnection) SwapIfNeeded(currentUserID int) {
 	if c.ToUserID == currentUserID {
 		c.FromUserID, c.FromAccountID, c.ToUserID, c.ToAccountID = c.ToUserID, c.ToAccountID, c.FromUserID, c.FromAccountID
+		// Keep the day-of-month preference attached to its side so the partner's
+		// preference always lands on the To* side (where their linked tx is created).
+		c.FromLinkedTransactionDayOfMonth, c.ToLinkedTransactionDayOfMonth = c.ToLinkedTransactionDayOfMonth, c.FromLinkedTransactionDayOfMonth
 	}
 }
 

--- a/backend/internal/domain/user_connection_test.go
+++ b/backend/internal/domain/user_connection_test.go
@@ -1,0 +1,72 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUserConnectionSwapIfNeeded verifies that SwapIfNeeded orients the connection
+// so the current user is always the "from" side, and — critically — that the
+// per-side linked-transaction day-of-month preference travels with its side. This
+// keeps the partner's (recipient's) preference on the To* side regardless of which
+// participant authors the split.
+func TestUserConnectionSwapIfNeeded(t *testing.T) {
+	fromDay := 5
+	toDay := 20
+
+	newConn := func() *UserConnection {
+		return &UserConnection{
+			FromUserID:                      1,
+			FromAccountID:                   10,
+			ToUserID:                        2,
+			ToAccountID:                     20,
+			FromLinkedTransactionDayOfMonth: &fromDay,
+			ToLinkedTransactionDayOfMonth:   &toDay,
+		}
+	}
+
+	t.Run("current user is already the from side → no swap", func(t *testing.T) {
+		conn := newConn()
+		conn.SwapIfNeeded(1)
+
+		assert.Equal(t, 1, conn.FromUserID)
+		assert.Equal(t, 10, conn.FromAccountID)
+		assert.Equal(t, 2, conn.ToUserID)
+		assert.Equal(t, 20, conn.ToAccountID)
+		// The recipient (user 2, To side) keeps their own day-of-month preference.
+		assert.Equal(t, 5, *conn.FromLinkedTransactionDayOfMonth)
+		assert.Equal(t, 20, *conn.ToLinkedTransactionDayOfMonth)
+	})
+
+	t.Run("current user is the to side → swap moves the partner's day to the To side", func(t *testing.T) {
+		conn := newConn()
+		conn.SwapIfNeeded(2)
+
+		// ids flipped so the author (user 2) is now "from"
+		assert.Equal(t, 2, conn.FromUserID)
+		assert.Equal(t, 20, conn.FromAccountID)
+		assert.Equal(t, 1, conn.ToUserID)
+		assert.Equal(t, 10, conn.ToAccountID)
+		// The recipient is now user 1 (the To side) — their configured day (5) must
+		// land on ToLinkedTransactionDayOfMonth, where the linked tx date is derived.
+		assert.Equal(t, 20, *conn.FromLinkedTransactionDayOfMonth)
+		assert.Equal(t, 5, *conn.ToLinkedTransactionDayOfMonth)
+	})
+
+	t.Run("nil preferences swap cleanly", func(t *testing.T) {
+		conn := &UserConnection{
+			FromUserID:                      1,
+			FromAccountID:                   10,
+			ToUserID:                        2,
+			ToAccountID:                     20,
+			ToLinkedTransactionDayOfMonth:   &toDay,
+			FromLinkedTransactionDayOfMonth: nil,
+		}
+		conn.SwapIfNeeded(2)
+
+		// after swap the (originally nil) from-side preference is on the To side
+		assert.Nil(t, conn.ToLinkedTransactionDayOfMonth)
+		assert.Equal(t, 20, *conn.FromLinkedTransactionDayOfMonth)
+	})
+}

--- a/backend/internal/entity/user_connection.go
+++ b/backend/internal/entity/user_connection.go
@@ -22,39 +22,46 @@ type UserConnection struct {
 	FromUserName               *string                         `gorm:"-"                             json:"from_user_name"`
 	ToUserAvatarURL            *string                         `gorm:"-"                             json:"to_user_avatar_url"`
 	ToUserName                 *string                         `gorm:"-"                             json:"to_user_name"`
+
+	FromLinkedTransactionDayOfMonth *int `json:"from_linked_transaction_day_of_month"`
+	ToLinkedTransactionDayOfMonth   *int `json:"to_linked_transaction_day_of_month"`
 }
 
 func (a *UserConnection) ToDomain() *domain.UserConnection {
 	return &domain.UserConnection{
-		ID:                         a.ID,
-		FromUserID:                 a.FromUserID,
-		FromAccountID:              a.FromAccountID,
-		FromDefaultSplitPercentage: a.FromDefaultSplitPercentage,
-		ToUserID:                   a.ToUserID,
-		ToAccountID:                a.ToAccountID,
-		ToDefaultSplitPercentage:   a.ToDefaultSplitPercentage,
-		ConnectionStatus:           a.ConnectionStatus,
-		CreatedAt:                  a.CreatedAt,
-		UpdatedAt:                  a.UpdatedAt,
-		FromUserAvatarURL:          a.FromUserAvatarURL,
-		FromUserName:               a.FromUserName,
-		ToUserAvatarURL:            a.ToUserAvatarURL,
-		ToUserName:                 a.ToUserName,
+		ID:                              a.ID,
+		FromUserID:                      a.FromUserID,
+		FromAccountID:                   a.FromAccountID,
+		FromDefaultSplitPercentage:      a.FromDefaultSplitPercentage,
+		ToUserID:                        a.ToUserID,
+		ToAccountID:                     a.ToAccountID,
+		ToDefaultSplitPercentage:        a.ToDefaultSplitPercentage,
+		ConnectionStatus:                a.ConnectionStatus,
+		CreatedAt:                       a.CreatedAt,
+		UpdatedAt:                       a.UpdatedAt,
+		FromUserAvatarURL:               a.FromUserAvatarURL,
+		FromUserName:                    a.FromUserName,
+		ToUserAvatarURL:                 a.ToUserAvatarURL,
+		ToUserName:                      a.ToUserName,
+		FromLinkedTransactionDayOfMonth: a.FromLinkedTransactionDayOfMonth,
+		ToLinkedTransactionDayOfMonth:   a.ToLinkedTransactionDayOfMonth,
 	}
 }
 
 func UserConnectionFromDomain(d *domain.UserConnection) *UserConnection {
 	return &UserConnection{
-		ID:                         d.ID,
-		FromUserID:                 d.FromUserID,
-		FromAccountID:              d.FromAccountID,
-		FromDefaultSplitPercentage: d.FromDefaultSplitPercentage,
-		ToUserID:                   d.ToUserID,
-		ToAccountID:                d.ToAccountID,
-		ToDefaultSplitPercentage:   d.ToDefaultSplitPercentage,
-		ConnectionStatus:           d.ConnectionStatus,
-		CreatedAt:                  d.CreatedAt,
-		UpdatedAt:                  d.UpdatedAt,
+		ID:                              d.ID,
+		FromUserID:                      d.FromUserID,
+		FromAccountID:                   d.FromAccountID,
+		FromDefaultSplitPercentage:      d.FromDefaultSplitPercentage,
+		ToUserID:                        d.ToUserID,
+		ToAccountID:                     d.ToAccountID,
+		ToDefaultSplitPercentage:        d.ToDefaultSplitPercentage,
+		ConnectionStatus:                d.ConnectionStatus,
+		CreatedAt:                       d.CreatedAt,
+		UpdatedAt:                       d.UpdatedAt,
+		FromLinkedTransactionDayOfMonth: d.FromLinkedTransactionDayOfMonth,
+		ToLinkedTransactionDayOfMonth:   d.ToLinkedTransactionDayOfMonth,
 	}
 }
 

--- a/backend/internal/handler/user_connection_handler.go
+++ b/backend/internal/handler/user_connection_handler.go
@@ -83,7 +83,7 @@ func (h *UserConnectionHandler) UpdateStatus(c echo.Context) error {
 }
 
 // UpdateSettings godoc
-// @Summary      Update connection settings (account name + default split)
+// @Summary      Update connection settings (account name + default split + linked tx day)
 // @Tags         user-connections
 // @Accept       json
 // @Produce      json
@@ -110,7 +110,7 @@ func (h *UserConnectionHandler) UpdateSettings(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
 	}
 
-	conn, err := h.userConnectionService.UpdateSettings(c.Request().Context(), userID, id, req.AccountName, req.DefaultSplitPercentage)
+	conn, err := h.userConnectionService.UpdateSettings(c.Request().Context(), userID, id, req.AccountName, req.DefaultSplitPercentage, req.LinkedTransactionDayOfMonth)
 	if err != nil {
 		return HandleServiceError(err)
 	}
@@ -236,4 +236,8 @@ type AcceptInviteRequest struct {
 type UpdateConnectionSettingsRequest struct {
 	AccountName            string `json:"account_name"`
 	DefaultSplitPercentage int    `json:"default_split_percentage"`
+	// Optional day-of-month (1–31) on which the caller's linked transactions are
+	// created when the other participant splits a transaction with them. nil clears
+	// the preference (the linked transaction inherits the source transaction date).
+	LinkedTransactionDayOfMonth *int `json:"linked_transaction_day_of_month"`
 }

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -59,7 +59,7 @@ type UserConnectionService interface {
 	Create(ctx context.Context, fromUserID, toUserID, fromDefaultSplitPercentage int) (*domain.UserConnection, error)
 	AcceptInviteByExternalID(ctx context.Context, currentUserID int, inviterExternalID string, fromDefaultSplitPercentage int) (*domain.UserConnection, error)
 	UpdateStatus(ctx context.Context, userID int, id int, status domain.UserConnectionStatusEnum) error
-	UpdateSettings(ctx context.Context, userID, id int, accountName string, defaultSplitPercentage int) (*domain.UserConnection, error)
+	UpdateSettings(ctx context.Context, userID, id int, accountName string, defaultSplitPercentage int, linkedTransactionDayOfMonth *int) (*domain.UserConnection, error)
 	Delete(ctx context.Context, userID, id int) error
 	Search(ctx context.Context, options domain.UserConnectionSearchOptions) ([]*domain.UserConnection, error)
 	SearchOne(ctx context.Context, options domain.UserConnectionSearchOptions) (*domain.UserConnection, error)

--- a/backend/internal/service/transaction_create.go
+++ b/backend/internal/service/transaction_create.go
@@ -466,7 +466,7 @@ func (s *transactionService) injectLinkedTransactions(
 		linkedTx := domain.Transaction{
 			ID:                      0,
 			InstallmentNumber:       transaction.InstallmentNumber,
-			Date:                    transaction.Date,
+			Date:                    adjustLinkedTransactionDay(transaction.Date, conn.ToLinkedTransactionDayOfMonth),
 			Description:             transaction.Description,
 			UserID:                  conn.ToUserID,
 			OriginalUserID:          &userID,
@@ -582,7 +582,7 @@ func (s *transactionService) injectLinkedTransactions(
 				OriginalUserID:          &userID,
 				Type:                    transaction.Type,
 				OperationType:           transaction.OperationType.Invert(),
-				AccountID:              connection.FromAccountID,
+				AccountID:               connection.FromAccountID,
 				CategoryID:              nil,
 				Amount:                  amount,
 				Tags:                    nil,
@@ -594,10 +594,18 @@ func (s *transactionService) injectLinkedTransactions(
 			transaction.LinkedTransactions = append(transaction.LinkedTransactions, fromTransaction)
 		}
 
+		// For shared expenses/income, honor the partner's configured day-of-month for
+		// their linked transaction. Transfers represent real money movement on a
+		// specific date, so they keep the source date verbatim.
+		toDate := transaction.Date
+		if req.TransactionType != domain.TransactionTypeTransfer {
+			toDate = adjustLinkedTransactionDay(transaction.Date, connection.ToLinkedTransactionDayOfMonth)
+		}
+
 		toTransaction := domain.Transaction{
 			ID:                0,
 			InstallmentNumber: transaction.InstallmentNumber,
-			Date:              transaction.Date,
+			Date:              toDate,
 			Description:       transaction.Description,
 			UserID:            connection.ToUserID,
 			OriginalUserID:    &userID,
@@ -666,6 +674,20 @@ func (s *transactionService) incrementInstallmentDate(baseDate time.Time, recurr
 		return clampToEndOfMonth(baseDate, baseDate.Year()+increment, baseDate.Month())
 	}
 	return baseDate
+}
+
+// adjustLinkedTransactionDay returns baseDate with its day-of-month replaced by the
+// participant's configured dayOfMonth, clamped to the last day of baseDate's month.
+// When dayOfMonth is nil (no preference) baseDate is returned unchanged. Only the day
+// changes — the year/month (and the per-installment date for recurrences) are preserved.
+func adjustLinkedTransactionDay(baseDate time.Time, dayOfMonth *int) time.Time {
+	if dayOfMonth == nil {
+		return baseDate
+	}
+	lastDay := time.Date(baseDate.Year(), baseDate.Month()+1, 0, 0, 0, 0, 0, baseDate.Location()).Day()
+	day := min(*dayOfMonth, lastDay)
+	return time.Date(baseDate.Year(), baseDate.Month(), day,
+		baseDate.Hour(), baseDate.Minute(), baseDate.Second(), baseDate.Nanosecond(), baseDate.Location())
 }
 
 // clampToEndOfMonth builds a date in the target year/month using the original day from

--- a/backend/internal/service/transaction_create_adjust_day_test.go
+++ b/backend/internal/service/transaction_create_adjust_day_test.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAdjustLinkedTransactionDay locks the day-of-month clamping behavior for the
+// partner's linked transaction date — in particular the month-end edge cases
+// (February and day 31 on 30-day months). Pure logic, no DB required.
+func TestAdjustLinkedTransactionDay(t *testing.T) {
+	utc := func(y int, m time.Month, d int) time.Time {
+		return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+	}
+	ptr := func(i int) *int { return &i }
+
+	tests := []struct {
+		name     string
+		base     time.Time
+		day      *int
+		expected time.Time
+	}{
+		{
+			name:     "nil preference keeps the source date untouched",
+			base:     utc(2026, time.July, 8),
+			day:      nil,
+			expected: utc(2026, time.July, 8),
+		},
+		{
+			name:     "day within the month is applied as-is",
+			base:     utc(2026, time.July, 8),
+			day:      ptr(10),
+			expected: utc(2026, time.July, 10),
+		},
+		{
+			name:     "day 30 in February (non-leap) clamps to the 28th",
+			base:     utc(2026, time.February, 8),
+			day:      ptr(30),
+			expected: utc(2026, time.February, 28),
+		},
+		{
+			name:     "day 30 in February (leap year) clamps to the 29th",
+			base:     utc(2028, time.February, 8),
+			day:      ptr(30),
+			expected: utc(2028, time.February, 29),
+		},
+		{
+			name:     "day 31 in February (non-leap) clamps to the 28th",
+			base:     utc(2026, time.February, 1),
+			day:      ptr(31),
+			expected: utc(2026, time.February, 28),
+		},
+		{
+			name:     "day 31 in April (30 days) clamps to the 30th",
+			base:     utc(2026, time.April, 5),
+			day:      ptr(31),
+			expected: utc(2026, time.April, 30),
+		},
+		{
+			name:     "day 31 in June (30 days) clamps to the 30th",
+			base:     utc(2026, time.June, 15),
+			day:      ptr(31),
+			expected: utc(2026, time.June, 30),
+		},
+		{
+			name:     "day 31 in July (31 days) is applied as-is",
+			base:     utc(2026, time.July, 1),
+			day:      ptr(31),
+			expected: utc(2026, time.July, 31),
+		},
+		{
+			name:     "day 30 in November (30 days) is applied as-is",
+			base:     utc(2026, time.November, 8),
+			day:      ptr(30),
+			expected: utc(2026, time.November, 30),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adjustLinkedTransactionDay(tt.base, tt.day)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestAdjustLinkedTransactionDayPreservesTimeAndLocation ensures only the day is
+// changed — the time-of-day components and location of the source date are kept.
+func TestAdjustLinkedTransactionDayPreservesTimeAndLocation(t *testing.T) {
+	base := time.Date(2026, time.February, 8, 13, 45, 30, 123, time.UTC)
+	day := 31
+
+	got := adjustLinkedTransactionDay(base, &day)
+
+	assert.Equal(t, 2026, got.Year())
+	assert.Equal(t, time.February, got.Month())
+	assert.Equal(t, 28, got.Day(), "Feb clamps day 31 to 28 in 2026")
+	assert.Equal(t, 13, got.Hour())
+	assert.Equal(t, 45, got.Minute())
+	assert.Equal(t, 30, got.Second())
+	assert.Equal(t, 123, got.Nanosecond())
+	assert.Equal(t, time.UTC, got.Location())
+}

--- a/backend/internal/service/transaction_create_test.go
+++ b/backend/internal/service/transaction_create_test.go
@@ -1665,6 +1665,91 @@ func (suite *TransactionCreateWithDBTestSuite) TestCreateSharedExpenseHonorsPart
 	suite.Assert().Equal(expectedLinkedDate, txUser2[0].Date)
 }
 
+// TestCreateSharedExpenseHonorsConfiguredDayForBothDirections verifies that when
+// BOTH participants configure a day-of-month, the day applied to a split is always
+// the RECIPIENT's preference — regardless of who authors the expense. This exercises
+// the SwapIfNeeded path in both directions (author = From side, and author = To side).
+func (suite *TransactionCreateWithDBTestSuite) TestCreateSharedExpenseHonorsConfiguredDayForBothDirections() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	account1, err := suite.createTestAccount(ctx, user1)
+	suite.Require().NoError(err)
+	category1, err := suite.createTestCategory(ctx, user1)
+	suite.Require().NoError(err)
+	account2, err := suite.createTestAccount(ctx, user2)
+	suite.Require().NoError(err)
+	category2, err := suite.createTestCategory(ctx, user2)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	// Both sides configure a day: user1 (From side) -> 5, user2 (To side) -> 20.
+	day5, day20 := 5, 20
+	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, conn.ID, "Conta user1", 50, &day5)
+	suite.Require().NoError(err)
+	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user2.ID, conn.ID, "Conta user2", 50, &day20)
+	suite.Require().NoError(err)
+
+	baseDate := time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC)
+
+	// Direction A: user1 authors -> recipient is user2, whose configured day is 20.
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		AccountID:       account1.ID,
+		CategoryID:      category1.ID,
+		Amount:          100,
+		Date:            domain.Date{Time: baseDate},
+		Description:     "user1 authors",
+		TransactionType: domain.TransactionTypeExpense,
+		SplitSettings:   []domain.SplitSettings{{ConnectionID: conn.ID, Percentage: lo.ToPtr(50)}},
+	})
+	suite.Require().NoError(err)
+
+	txA, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user1.ID, AccountIDs: []int{account1.ID},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(txA, 1)
+	suite.Assert().Equal(baseDate, txA[0].Date, "author tx keeps original date")
+	suite.Require().Len(txA[0].LinkedTransactions, 1)
+	suite.Assert().Equal(user2.ID, txA[0].LinkedTransactions[0].UserID)
+	suite.Assert().Equal(
+		time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
+		txA[0].LinkedTransactions[0].Date,
+		"recipient user2's linked tx should land on user2's configured day (20)",
+	)
+
+	// Direction B: user2 authors -> recipient is user1, whose configured day is 5.
+	_, err = suite.Services.Transaction.Create(ctx, user2.ID, &domain.TransactionCreateRequest{
+		AccountID:       account2.ID,
+		CategoryID:      category2.ID,
+		Amount:          100,
+		Date:            domain.Date{Time: baseDate},
+		Description:     "user2 authors",
+		TransactionType: domain.TransactionTypeExpense,
+		SplitSettings:   []domain.SplitSettings{{ConnectionID: conn.ID, Percentage: lo.ToPtr(50)}},
+	})
+	suite.Require().NoError(err)
+
+	txB, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID: &user2.ID, AccountIDs: []int{account2.ID},
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(txB, 1)
+	suite.Assert().Equal(baseDate, txB[0].Date, "author tx keeps original date")
+	suite.Require().Len(txB[0].LinkedTransactions, 1)
+	suite.Assert().Equal(user1.ID, txB[0].LinkedTransactions[0].UserID)
+	suite.Assert().Equal(
+		time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC),
+		txB[0].LinkedTransactions[0].Date,
+		"recipient user1's linked tx should land on user1's configured day (5)",
+	)
+}
+
 func now() time.Time {
 	now := time.Now().UTC()
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())

--- a/backend/internal/service/transaction_create_test.go
+++ b/backend/internal/service/transaction_create_test.go
@@ -1598,6 +1598,73 @@ func (suite *TransactionCreateWithDBTestSuite) TestCreateRecurringExpenseFrom3of
 	suite.Assert().Equal(10, recurrences[0].Installments, "TransactionRecurrence.Installments should be 10 (total_installments)")
 }
 
+// TestCreateSharedExpenseHonorsPartnerLinkedTransactionDay verifies that when the
+// partner (the To side of the connection) has configured a day-of-month, their linked
+// transaction is created on that day of the source month, while the author's own
+// transaction and the settlement keep the original date.
+func (suite *TransactionCreateWithDBTestSuite) TestCreateSharedExpenseHonorsPartnerLinkedTransactionDay() {
+	ctx := context.Background()
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	account, err := suite.createTestAccount(ctx, user1)
+	suite.Require().NoError(err)
+	category, err := suite.createTestCategory(ctx, user1)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	// user2 (the To side) wants their linked transactions created on day 10
+	day10 := 10
+	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user2.ID, conn.ID, "Parceiro", 50, &day10)
+	suite.Require().NoError(err)
+
+	baseDate := time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC)
+	expectedLinkedDate := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+
+	_, err = suite.Services.Transaction.Create(ctx, user1.ID, &domain.TransactionCreateRequest{
+		AccountID:       account.ID,
+		CategoryID:      category.ID,
+		Amount:          100,
+		Date:            domain.Date{Time: baseDate},
+		Description:     "shared expense with partner day pref",
+		TransactionType: domain.TransactionTypeExpense,
+		SplitSettings: []domain.SplitSettings{
+			{ConnectionID: conn.ID, Percentage: lo.ToPtr(50)},
+		},
+	})
+	suite.Require().NoError(err)
+
+	// author's own transaction keeps the original date
+	txUser1, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
+		UserID:          &user1.ID,
+		AccountIDs:      []int{account.ID},
+		WithSettlements: true,
+	})
+	suite.Require().NoError(err)
+	suite.Require().Len(txUser1, 1)
+	suite.Assert().Equal(baseDate, txUser1[0].Date)
+
+	// the partner's linked transaction lands on the configured day
+	suite.Require().Len(txUser1[0].LinkedTransactions, 1)
+	suite.Assert().Equal(expectedLinkedDate, txUser1[0].LinkedTransactions[0].Date)
+	suite.Assert().Equal(user2.ID, txUser1[0].LinkedTransactions[0].UserID)
+
+	// the settlement (author's side) keeps the original date — only the partner's
+	// linked transaction is shifted
+	suite.Require().Len(txUser1[0].SettlementsFromSource, 1)
+	suite.Assert().Equal(baseDate, txUser1[0].SettlementsFromSource[0].Date)
+
+	// from user2's perspective the expense is dated on day 10
+	txUser2, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{UserID: &user2.ID})
+	suite.Require().NoError(err)
+	suite.Require().Len(txUser2, 1)
+	suite.Assert().Equal(expectedLinkedDate, txUser2[0].Date)
+}
+
 func now() time.Time {
 	now := time.Now().UTC()
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())

--- a/backend/internal/service/transaction_update.go
+++ b/backend/internal/service/transaction_update.go
@@ -534,7 +534,7 @@ func (s *transactionService) rebuildTransactions(
 
 				lt := domain.Transaction{
 					ID:                0,
-					Date:              data.transactions[i].Date,
+					Date:              adjustLinkedTransactionDay(data.transactions[i].Date, conn.ToLinkedTransactionDayOfMonth),
 					Description:       data.transactions[i].Description,
 					UserID:            conn.ToUserID,
 					OriginalUserID:    &data.userID,
@@ -620,7 +620,7 @@ func (s *transactionService) rebuildTransactions(
 
 				data.transactions[i].LinkedTransactions = append(data.transactions[i].LinkedTransactions, domain.Transaction{
 					ID:             0,
-					Date:           data.transactions[i].Date,
+					Date:           adjustLinkedTransactionDay(data.transactions[i].Date, conn.ToLinkedTransactionDayOfMonth),
 					Description:    data.transactions[i].Description,
 					UserID:         conn.ToUserID,
 					OriginalUserID: &data.userID,

--- a/backend/internal/service/user_connection_service.go
+++ b/backend/internal/service/user_connection_service.go
@@ -197,12 +197,15 @@ func (s *userConnectionService) UpdateStatus(ctx context.Context, userID int, id
 // UpdateSettings lets a participant edit, for their own side of the connection,
 // the name shown on their connection account and the default split percentage.
 // The split is stored complementarily (the other side becomes 100 - value).
-func (s *userConnectionService) UpdateSettings(ctx context.Context, userID, id int, accountName string, defaultSplitPercentage int) (*domain.UserConnection, error) {
+func (s *userConnectionService) UpdateSettings(ctx context.Context, userID, id int, accountName string, defaultSplitPercentage int, linkedTransactionDayOfMonth *int) (*domain.UserConnection, error) {
 	if strings.TrimSpace(accountName) == "" {
 		return nil, apperrors.BadRequest("account name is required")
 	}
 	if defaultSplitPercentage < 0 || defaultSplitPercentage > 100 {
 		return nil, apperrors.BadRequest("default split percentage must be between 0 and 100")
+	}
+	if linkedTransactionDayOfMonth != nil && (*linkedTransactionDayOfMonth < 1 || *linkedTransactionDayOfMonth > 31) {
+		return nil, apperrors.BadRequest("linked transaction day of month must be between 1 and 31")
 	}
 
 	ctx, err := s.dbTransaction.Begin(ctx)
@@ -230,10 +233,12 @@ func (s *userConnectionService) UpdateSettings(ctx context.Context, userID, id i
 	case conn.FromUserID:
 		conn.FromDefaultSplitPercentage = defaultSplitPercentage
 		conn.ToDefaultSplitPercentage = 100 - defaultSplitPercentage
+		conn.FromLinkedTransactionDayOfMonth = linkedTransactionDayOfMonth
 		accountID = conn.FromAccountID
 	case conn.ToUserID:
 		conn.ToDefaultSplitPercentage = defaultSplitPercentage
 		conn.FromDefaultSplitPercentage = 100 - defaultSplitPercentage
+		conn.ToLinkedTransactionDayOfMonth = linkedTransactionDayOfMonth
 		accountID = conn.ToAccountID
 	default:
 		return nil, apperrors.Forbidden("only a participant can update this connection")

--- a/backend/internal/service/user_connection_service_test.go
+++ b/backend/internal/service/user_connection_service_test.go
@@ -32,7 +32,7 @@ func (suite *UserConnectionServiceWithDBTestSuite) TestUpdateSettingsAsFromUser(
 	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 60)
 	suite.Require().NoError(err)
 
-	updated, err := suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, conn.ID, "Conta do casal", 70)
+	updated, err := suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, conn.ID, "Conta do casal", 70, nil)
 	suite.Require().NoError(err)
 	suite.Equal(70, updated.FromDefaultSplitPercentage)
 	suite.Equal(30, updated.ToDefaultSplitPercentage)
@@ -60,7 +60,7 @@ func (suite *UserConnectionServiceWithDBTestSuite) TestUpdateSettingsAsToUser() 
 	suite.Require().NoError(err)
 
 	// the invited user sets their own side to 70 → from becomes 30
-	updated, err := suite.Services.UserConnection.UpdateSettings(ctx, user2.ID, conn.ID, "Parceiro", 70)
+	updated, err := suite.Services.UserConnection.UpdateSettings(ctx, user2.ID, conn.ID, "Parceiro", 70, nil)
 	suite.Require().NoError(err)
 	suite.Equal(70, updated.ToDefaultSplitPercentage)
 	suite.Equal(30, updated.FromDefaultSplitPercentage)
@@ -83,7 +83,7 @@ func (suite *UserConnectionServiceWithDBTestSuite) TestUpdateSettingsForbiddenFo
 	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 60)
 	suite.Require().NoError(err)
 
-	_, err = suite.Services.UserConnection.UpdateSettings(ctx, stranger.ID, conn.ID, "x", 50)
+	_, err = suite.Services.UserConnection.UpdateSettings(ctx, stranger.ID, conn.ID, "x", 50, nil)
 	suite.Require().Error(err)
 	se, ok := pkgErrors.AsServiceError(err)
 	suite.Require().True(ok)
@@ -102,14 +102,14 @@ func (suite *UserConnectionServiceWithDBTestSuite) TestUpdateSettingsValidatesIn
 	suite.Require().NoError(err)
 
 	// blank name → bad request
-	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, conn.ID, "   ", 50)
+	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, conn.ID, "   ", 50, nil)
 	suite.Require().Error(err)
 	se, ok := pkgErrors.AsServiceError(err)
 	suite.Require().True(ok)
 	suite.Equal(pkgErrors.ErrCodeBadRequest, se.Code)
 
 	// out-of-range split → bad request
-	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, conn.ID, "Valid", 150)
+	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, conn.ID, "Valid", 150, nil)
 	suite.Require().Error(err)
 	se, ok = pkgErrors.AsServiceError(err)
 	suite.Require().True(ok)
@@ -122,11 +122,65 @@ func (suite *UserConnectionServiceWithDBTestSuite) TestUpdateSettingsNotFound() 
 	user1, err := suite.createTestUser(ctx)
 	suite.Require().NoError(err)
 
-	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, 999999, "Valid", 50)
+	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, 999999, "Valid", 50, nil)
 	suite.Require().Error(err)
 	se, ok := pkgErrors.AsServiceError(err)
 	suite.Require().True(ok)
 	suite.Equal(pkgErrors.ErrCodeNotFound, se.Code)
+}
+
+func (suite *UserConnectionServiceWithDBTestSuite) TestUpdateSettingsPersistsLinkedTransactionDayPerSide() {
+	ctx := context.Background()
+
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	day10 := 10
+	// the invited user (To side) configures day 10 for their linked transactions
+	updated, err := suite.Services.UserConnection.UpdateSettings(ctx, user2.ID, conn.ID, "Parceiro", 50, &day10)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(updated.ToLinkedTransactionDayOfMonth)
+	suite.Equal(10, *updated.ToLinkedTransactionDayOfMonth)
+	suite.Nil(updated.FromLinkedTransactionDayOfMonth)
+
+	reloaded := suite.getConnectionByID(ctx, conn.ID)
+	suite.Require().NotNil(reloaded.ToLinkedTransactionDayOfMonth)
+	suite.Equal(10, *reloaded.ToLinkedTransactionDayOfMonth)
+	suite.Nil(reloaded.FromLinkedTransactionDayOfMonth)
+
+	// the From user can clear their preference (nil) without touching the To side
+	_, err = suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, conn.ID, "Conta", 50, nil)
+	suite.Require().NoError(err)
+	reloaded = suite.getConnectionByID(ctx, conn.ID)
+	suite.Nil(reloaded.FromLinkedTransactionDayOfMonth)
+	suite.Require().NotNil(reloaded.ToLinkedTransactionDayOfMonth, "To side preference must be preserved")
+	suite.Equal(10, *reloaded.ToLinkedTransactionDayOfMonth)
+}
+
+func (suite *UserConnectionServiceWithDBTestSuite) TestUpdateSettingsRejectsInvalidLinkedTransactionDay() {
+	ctx := context.Background()
+
+	user1, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+	user2, err := suite.createTestUser(ctx)
+	suite.Require().NoError(err)
+
+	conn, err := suite.createAcceptedTestUserConnection(ctx, user1.ID, user2.ID, 50)
+	suite.Require().NoError(err)
+
+	for _, invalid := range []int{0, 32, -1} {
+		d := invalid
+		_, err = suite.Services.UserConnection.UpdateSettings(ctx, user1.ID, conn.ID, "Valid", 50, &d)
+		suite.Require().Error(err, "day %d should be rejected", invalid)
+		se, ok := pkgErrors.AsServiceError(err)
+		suite.Require().True(ok)
+		suite.Equal(pkgErrors.ErrCodeBadRequest, se.Code)
+	}
 }
 
 func TestUserConnectionServiceWithDB(t *testing.T) {

--- a/backend/migrations/20260607000000_add_linked_transaction_day_of_month_to_user_connections.sql
+++ b/backend/migrations/20260607000000_add_linked_transaction_day_of_month_to_user_connections.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+ALTER TABLE user_connections
+    ADD COLUMN from_linked_transaction_day_of_month SMALLINT
+        CHECK (from_linked_transaction_day_of_month BETWEEN 1 AND 31),
+    ADD COLUMN to_linked_transaction_day_of_month SMALLINT
+        CHECK (to_linked_transaction_day_of_month BETWEEN 1 AND 31);
+
+-- +goose Down
+ALTER TABLE user_connections
+    DROP COLUMN from_linked_transaction_day_of_month,
+    DROP COLUMN to_linked_transaction_day_of_month;

--- a/backend/mocks/mock_UserConnectionService.go
+++ b/backend/mocks/mock_UserConnectionService.go
@@ -310,9 +310,9 @@ func (_c *MockUserConnectionService_SearchOne_Call) RunAndReturn(run func(contex
 	return _c
 }
 
-// UpdateSettings provides a mock function with given fields: ctx, userID, id, accountName, defaultSplitPercentage
-func (_m *MockUserConnectionService) UpdateSettings(ctx context.Context, userID int, id int, accountName string, defaultSplitPercentage int) (*domain.UserConnection, error) {
-	ret := _m.Called(ctx, userID, id, accountName, defaultSplitPercentage)
+// UpdateSettings provides a mock function with given fields: ctx, userID, id, accountName, defaultSplitPercentage, linkedTransactionDayOfMonth
+func (_m *MockUserConnectionService) UpdateSettings(ctx context.Context, userID int, id int, accountName string, defaultSplitPercentage int, linkedTransactionDayOfMonth *int) (*domain.UserConnection, error) {
+	ret := _m.Called(ctx, userID, id, accountName, defaultSplitPercentage, linkedTransactionDayOfMonth)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateSettings")
@@ -320,19 +320,19 @@ func (_m *MockUserConnectionService) UpdateSettings(ctx context.Context, userID 
 
 	var r0 *domain.UserConnection
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int, int, string, int) (*domain.UserConnection, error)); ok {
-		return rf(ctx, userID, id, accountName, defaultSplitPercentage)
+	if rf, ok := ret.Get(0).(func(context.Context, int, int, string, int, *int) (*domain.UserConnection, error)); ok {
+		return rf(ctx, userID, id, accountName, defaultSplitPercentage, linkedTransactionDayOfMonth)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int, int, string, int) *domain.UserConnection); ok {
-		r0 = rf(ctx, userID, id, accountName, defaultSplitPercentage)
+	if rf, ok := ret.Get(0).(func(context.Context, int, int, string, int, *int) *domain.UserConnection); ok {
+		r0 = rf(ctx, userID, id, accountName, defaultSplitPercentage, linkedTransactionDayOfMonth)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*domain.UserConnection)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int, int, string, int) error); ok {
-		r1 = rf(ctx, userID, id, accountName, defaultSplitPercentage)
+	if rf, ok := ret.Get(1).(func(context.Context, int, int, string, int, *int) error); ok {
+		r1 = rf(ctx, userID, id, accountName, defaultSplitPercentage, linkedTransactionDayOfMonth)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -351,13 +351,18 @@ type MockUserConnectionService_UpdateSettings_Call struct {
 //   - id int
 //   - accountName string
 //   - defaultSplitPercentage int
-func (_e *MockUserConnectionService_Expecter) UpdateSettings(ctx interface{}, userID interface{}, id interface{}, accountName interface{}, defaultSplitPercentage interface{}) *MockUserConnectionService_UpdateSettings_Call {
-	return &MockUserConnectionService_UpdateSettings_Call{Call: _e.mock.On("UpdateSettings", ctx, userID, id, accountName, defaultSplitPercentage)}
+//   - linkedTransactionDayOfMonth *int
+func (_e *MockUserConnectionService_Expecter) UpdateSettings(ctx interface{}, userID interface{}, id interface{}, accountName interface{}, defaultSplitPercentage interface{}, linkedTransactionDayOfMonth interface{}) *MockUserConnectionService_UpdateSettings_Call {
+	return &MockUserConnectionService_UpdateSettings_Call{Call: _e.mock.On("UpdateSettings", ctx, userID, id, accountName, defaultSplitPercentage, linkedTransactionDayOfMonth)}
 }
 
-func (_c *MockUserConnectionService_UpdateSettings_Call) Run(run func(ctx context.Context, userID int, id int, accountName string, defaultSplitPercentage int)) *MockUserConnectionService_UpdateSettings_Call {
+func (_c *MockUserConnectionService_UpdateSettings_Call) Run(run func(ctx context.Context, userID int, id int, accountName string, defaultSplitPercentage int, linkedTransactionDayOfMonth *int)) *MockUserConnectionService_UpdateSettings_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int), args[2].(int), args[3].(string), args[4].(int))
+		var _p5 *int
+		if args[5] != nil {
+			_p5 = args[5].(*int)
+		}
+		run(args[0].(context.Context), args[1].(int), args[2].(int), args[3].(string), args[4].(int), _p5)
 	})
 	return _c
 }
@@ -367,7 +372,7 @@ func (_c *MockUserConnectionService_UpdateSettings_Call) Return(_a0 *domain.User
 	return _c
 }
 
-func (_c *MockUserConnectionService_UpdateSettings_Call) RunAndReturn(run func(context.Context, int, int, string, int) (*domain.UserConnection, error)) *MockUserConnectionService_UpdateSettings_Call {
+func (_c *MockUserConnectionService_UpdateSettings_Call) RunAndReturn(run func(context.Context, int, int, string, int, *int) (*domain.UserConnection, error)) *MockUserConnectionService_UpdateSettings_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/frontend/src/api/userConnections.ts
+++ b/frontend/src/api/userConnections.ts
@@ -18,6 +18,8 @@ export namespace UserConnections {
     connection_status: 'pending' | 'accepted' | 'rejected'
     created_at: string
     updated_at: string
+    from_linked_transaction_day_of_month?: number | null
+    to_linked_transaction_day_of_month?: number | null
   }
 }
 
@@ -38,6 +40,8 @@ export async function fetchUserConnections(): Promise<UserConnections.Connection
 export interface UpdateConnectionPayload {
   account_name: string
   default_split_percentage: number
+  /** Day of month (1–31) for the caller's linked transactions; null clears the preference. */
+  linked_transaction_day_of_month: number | null
 }
 
 export async function updateConnection(

--- a/frontend/src/components/connections/EditConnectionDrawer.tsx
+++ b/frontend/src/components/connections/EditConnectionDrawer.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Divider,
   Group,
+  NumberInput,
   Stack,
   Text,
   TextInput,
@@ -58,12 +59,19 @@ export function EditConnectionDrawer({ account }: Props) {
     ? connection?.to_user_avatar_url
     : connection?.from_user_avatar_url
 
+  // The day-of-month preference is stored per side; show the caller's own side.
+  const currentDay =
+    (isFrom
+      ? connection?.from_linked_transaction_day_of_month
+      : connection?.to_linked_transaction_day_of_month) ?? null
+
   const [splitMode, setSplitMode] = useState<number | 'custom'>(
     PRESETS.includes(currentSplit) ? currentSplit : 'custom',
   )
   const [customValue, setCustomValue] = useState(
     PRESETS.includes(currentSplit) ? 65 : currentSplit,
   )
+  const [dayOfMonth, setDayOfMonth] = useState<number | ''>(currentDay ?? '')
   const effectiveSplit = splitMode === 'custom' ? customValue : splitMode
 
   const {
@@ -88,7 +96,9 @@ export function EditConnectionDrawer({ account }: Props) {
   })
 
   const dirty =
-    nameValue.trim() !== account.name || effectiveSplit !== currentSplit
+    nameValue.trim() !== account.name ||
+    effectiveSplit !== currentSplit ||
+    (dayOfMonth === '' ? null : dayOfMonth) !== currentDay
 
   function onSubmit(values: EditConnectionFormValues) {
     if (!connection) return
@@ -97,6 +107,7 @@ export function EditConnectionDrawer({ account }: Props) {
       payload: {
         account_name: values.account_name.trim(),
         default_split_percentage: effectiveSplit,
+        linked_transaction_day_of_month: dayOfMonth === '' ? null : dayOfMonth,
       },
     })
   }
@@ -210,6 +221,30 @@ export function EditConnectionDrawer({ account }: Props) {
             partnerName={partnerName}
             partnerHasName
           />
+
+          <Divider />
+
+          <Box>
+            <NumberInput
+              label="Dia do mês para suas transações"
+              placeholder="Manter a data original"
+              min={1}
+              max={31}
+              clampBehavior="strict"
+              allowDecimal={false}
+              allowNegative={false}
+              value={dayOfMonth}
+              onChange={(value) =>
+                setDayOfMonth(typeof value === 'number' ? value : '')
+              }
+              data-testid={CommonTestIds.EditConnectionDayInput}
+            />
+            <Text size="xs" c="dimmed" mt={6}>
+              Quando {partnerName} dividir uma despesa com você, sua parte será
+              criada nesse dia do mês. Deixe em branco para usar a data original
+              da transação.
+            </Text>
+          </Box>
         </Stack>
 
         {/* Sticky footer — solid background, top border, safe-area aware. */}

--- a/frontend/src/testIds/common.ts
+++ b/frontend/src/testIds/common.ts
@@ -28,6 +28,7 @@ export const CommonTestIds = {
   /* Edit connection drawer */
   DrawerEditConnection: 'drawer_edit_connection',
   EditConnectionNameInput: 'input_connection_name',
+  EditConnectionDayInput: 'input_connection_linked_tx_day',
   EditConnectionSave: 'btn_save_connection',
   EditConnectionCancel: 'btn_cancel_connection',
 

--- a/frontend/src/types/transactions.ts
+++ b/frontend/src/types/transactions.ts
@@ -27,6 +27,10 @@ export namespace Transactions {
     from_user_name?: string;
     to_user_avatar_url?: string;
     to_user_name?: string;
+    /** Day of month (1–31) on which the From side's linked transactions are created. */
+    from_linked_transaction_day_of_month?: number | null;
+    /** Day of month (1–31) on which the To side's linked transactions are created. */
+    to_linked_transaction_day_of_month?: number | null;
   }
 
   export interface Account {


### PR DESCRIPTION
## What & why

Each participant can now configure, **on their side of a `UserConnection`**, the day of month on which their linked transaction is created when the *other* connected user splits a transaction with them.

> Example: User A splits R$100 with User B on **08/07**. User B set their side to "day 10". → User B's R$50 expense is dated **10/07** (same month, day forced to 10, clamped to month-end).

## Backend

- **Migration** — two nullable `SMALLINT` columns `from_/to_linked_transaction_day_of_month` on `user_connections` with `CHECK (BETWEEN 1 AND 31)`. *(Hand-written in goose format — `goose` CLI isn't available in the web env.)*
- **Domain** — new `*int` fields; `SwapIfNeeded` swaps them alongside the user/account ids, so the partner's preference always lands on the `To*` side at split time.
- **Service** `UpdateSettings(..., linkedTransactionDayOfMonth *int)` — validates (nil or 1–31), writes only the caller's side (other side preserved).
- **Linked-tx date** — new `adjustLinkedTransactionDay` helper (clamps to month-end), applied to the partner's linked tx on **create** (shared-account + split `toTransaction`) and on **split-rebuild during update**. Transfers and settlements are intentionally untouched.
- Handler DTO + Swagger regenerated; `UserConnectionService` mock updated by hand (mockery unavailable).

## Frontend

- Optional day-of-month NumberInput (1–31) in the edit-connection drawer — reads the caller's own side; blank clears the preference.
- Types (`UserConnection`, `Connection`, `UpdateConnectionPayload`) + new testid.

## Verification

- `go build` ✅ · `go vet` ✅ · `go test -short` (service + handler) ✅ — compiles the new integration tests too.
- Frontend `tsc --noEmit` ✅ · `eslint` (touched) ✅ · `npm run build` ✅.

## Notes / follow-ups

- **DB integration tests not run in this env**: testcontainers needs to pull `postgres:15-alpine`, which the web env's network policy blocks (registry CDN 403). The new integration tests compile and will run in CI.
- Editing only a transaction's **date** (no split change) doesn't re-apply the day preference — linked-tx date re-derives only on add/change of split, matching existing rebuild behavior. Out of scope here.

Added new tests: `TestUpdateSettingsPersistsLinkedTransactionDayPerSide`, `TestUpdateSettingsRejectsInvalidLinkedTransactionDay`, `TestCreateSharedExpenseHonorsPartnerLinkedTransactionDay`.

https://claude.ai/code/session_0119V9MCy7BZ5hXiZ1ku1xDK

---
_Generated by [Claude Code](https://claude.ai/code/session_0119V9MCy7BZ5hXiZ1ku1xDK)_