### PR TITLE
feat(frontend): PWA app shortcuts para nova despesa/receita/transferência

### DIFF
--- a/frontend/e2e/pages/TransactionsPage.ts
+++ b/frontend/e2e/pages/TransactionsPage.ts
@@ -35,6 +35,23 @@ export class TransactionsPage {
     await this.page.waitForLoadState("networkidle");
   }
 
+  /**
+   * Navigate via a PWA app-shortcut deep link (`?new=<type>`), which should open
+   * the create-transaction drawer pre-set to that type. Waits for the drawer.
+   */
+  async gotoCreateShortcut(type: TransactionType) {
+    await this.page.goto(`/transactions?new=${type}`);
+    await expect(this.formDrawer).toBeVisible({ timeout: 8000 });
+  }
+
+  /** Assert the create drawer's type SegmentedControl has `type` selected. */
+  async assertCreateTypeSelected(type: TransactionType) {
+    const segmented = this.formDrawer.getByTestId(
+      TransactionsTestIds.SegmentedTransactionType,
+    );
+    await expect(segmented.locator("input:checked")).toHaveValue(type);
+  }
+
   async openAdvancedFilters() {
     await this.page.getByTestId(TransactionsTestIds.BtnOpenAdvancedFilters).click();
   }

--- a/frontend/e2e/tests/transaction-shortcuts.spec.ts
+++ b/frontend/e2e/tests/transaction-shortcuts.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+import { TransactionsPage } from '../pages/TransactionsPage'
+import { TransactionsTestIds } from '@/testIds'
+
+/**
+ * PWA app shortcuts (long-press the installed icon) deep-link into
+ * `/transactions?new=<type>`. Landing on that URL should open the
+ * create-transaction drawer pre-set to the matching type, then strip the param
+ * so a refresh/back-nav doesn't reopen it.
+ */
+test.describe('Transaction app shortcuts', () => {
+  let transactionsPage: TransactionsPage
+
+  test.beforeEach(({ page }) => {
+    transactionsPage = new TransactionsPage(page)
+  })
+
+  for (const type of ['expense', 'income', 'transfer'] as const) {
+    test(`?new=${type} opens the create drawer pre-set to ${type}`, async () => {
+      await transactionsPage.gotoCreateShortcut(type)
+      await transactionsPage.assertCreateTypeSelected(type)
+    })
+  }
+
+  test('the new param is stripped from the URL after opening', async ({ page }) => {
+    await transactionsPage.gotoCreateShortcut('income')
+
+    // The drawer is open but the deep-link param is gone, so reloading or
+    // navigating back won't reopen it.
+    await expect(page).toHaveURL(/\/transactions(\?(?!.*\bnew=).*)?$/)
+
+    await page.reload()
+    await expect(page.getByTestId(TransactionsTestIds.DrawerCreate)).not.toBeVisible()
+  })
+})

--- a/frontend/src/components/transactions/CreateTransactionDrawer.tsx
+++ b/frontend/src/components/transactions/CreateTransactionDrawer.tsx
@@ -27,7 +27,16 @@ const TYPE_LABELS: Record<Transactions.TransactionType, string> = {
   transfer: "Nova Transferência",
 };
 
-export function CreateTransactionDrawer() {
+interface CreateTransactionDrawerProps {
+  /**
+   * Transaction type the form opens with. Defaults to "expense". Set by the
+   * PWA app shortcuts (long-press the installed icon) so "Nova Despesa",
+   * "Nova Receita" and "Nova Transferência" each land on the right type.
+   */
+  initialType?: Transactions.TransactionType;
+}
+
+export function CreateTransactionDrawer({ initialType = "expense" }: CreateTransactionDrawerProps = {}) {
   const { opened, close } = useDrawerContext<void>();
   const [submitError, setSubmitError] = useState<string | undefined>();
   const isMobile = useIsMobile();
@@ -51,7 +60,7 @@ export function CreateTransactionDrawer() {
   const methods = useForm<TransactionFormValues>({
     resolver: zodResolver(transactionFormSchema),
     defaultValues: {
-      transaction_type: "expense",
+      transaction_type: initialType,
       date: prefill.date ? localDateStr(parseDate(prefill.date)) : localDateStr(new Date()),
       description: "",
       amount: 0,

--- a/frontend/src/hooks/useCreateTransactionShortcut.tsx
+++ b/frontend/src/hooks/useCreateTransactionShortcut.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react'
+import { useNavigate, useSearch } from '@tanstack/react-router'
+import { renderDrawer } from '@/utils/renderDrawer'
+import { CreateTransactionDrawer } from '@/components/transactions/CreateTransactionDrawer'
+
+/**
+ * Opens the create-transaction drawer in response to the `?new=<type>` search
+ * param used by the PWA app shortcuts (long-press the installed icon →
+ * "Nova Despesa" / "Nova Receita" / "Nova Transferência").
+ *
+ * The param is stripped (replace, so it doesn't add a history entry) before the
+ * drawer opens, so a page refresh or back-navigation doesn't reopen it. A ref
+ * guards against the param's brief presence reopening the drawer between the
+ * navigate call and the resulting re-render.
+ */
+export function useCreateTransactionShortcut() {
+  const newType = useSearch({
+    from: '/_authenticated/transactions',
+    select: (s) => s.new,
+  })
+  const navigate = useNavigate({ from: '/transactions' })
+  const handledRef = useRef(false)
+
+  useEffect(() => {
+    if (!newType || handledRef.current) return
+    handledRef.current = true
+    void navigate({ search: (prev) => ({ ...prev, new: undefined }), replace: true })
+    void renderDrawer(() => <CreateTransactionDrawer initialType={newType} />)
+  }, [newType, navigate])
+}

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useMe } from "@/hooks/useMe";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useHotkey } from "@/hooks/useHotkey";
+import { useCreateTransactionShortcut } from "@/hooks/useCreateTransactionShortcut";
 import { useActiveFilters } from "@/hooks/useActiveFilters";
 import { useTransactions } from "@/hooks/useTransactions";
 import { useAccounts } from "@/hooks/useAccounts";
@@ -503,6 +504,9 @@ export function TransactionsPage() {
     void renderDrawer(() => <CreateTransactionDrawer />);
   }, []);
   useHotkey("n", openCreateTransaction, { enabled: !isSelecting });
+
+  // Open the create drawer from a PWA app-shortcut deep link (?new=<type>).
+  useCreateTransactionShortcut();
 
   async function handleSwipeDelete(tx: Transactions.Transaction) {
     try {

--- a/frontend/src/routes/_authenticated.transactions.tsx
+++ b/frontend/src/routes/_authenticated.transactions.tsx
@@ -16,6 +16,10 @@ export const transactionSearchSchema = z.object({
   groupBy: z.enum(['date', 'category', 'account']).default('date'),
   accumulated: z.coerce.boolean().default(false),
   hideSettlements: z.coerce.boolean().default(false),
+  // Deep-link target for the PWA app shortcuts (long-press the installed icon).
+  // When present, the page opens the create-transaction drawer pre-set to this
+  // type, then strips the param so a refresh/back-nav doesn't reopen it.
+  new: z.enum(['expense', 'income', 'transfer']).optional(),
 })
 
 export type TransactionsSearch = z.infer<typeof transactionSearchSchema>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -61,6 +61,32 @@ export default defineConfig({
             purpose: "any maskable",
           },
         ],
+        // App shortcuts surface in the long-press menu of the installed icon.
+        // Each deep-links into the transactions page with the create drawer
+        // pre-set to a type (see useCreateTransactionShortcut).
+        shortcuts: [
+          {
+            name: "Nova despesa",
+            short_name: "Despesa",
+            description: "Registrar uma nova despesa",
+            url: "/transactions?new=expense",
+            icons: [{ src: "/icon-192.png", sizes: "192x192", type: "image/png" }],
+          },
+          {
+            name: "Nova receita",
+            short_name: "Receita",
+            description: "Registrar uma nova receita",
+            url: "/transactions?new=income",
+            icons: [{ src: "/icon-192.png", sizes: "192x192", type: "image/png" }],
+          },
+          {
+            name: "Nova transferência",
+            short_name: "Transferência",
+            description: "Registrar uma nova transferência",
+            url: "/transactions?new=transfer",
+            icons: [{ src: "/icon-192.png", sizes: "192x192", type: "image/png" }],
+          },
+        ],
       },
     }),
   ],


### PR DESCRIPTION
## O que

Adiciona **app shortcuts** ao manifest da PWA. Ao segurar o ícone do app instalado, o menu de atalhos passa a oferecer:

- **Nova despesa**
- **Nova receita**
- **Nova transferência**

Cada atalho abre o app já com o drawer de criação de transação aberto e com o tipo (`expense` / `income` / `transfer`) pré-selecionado.

## Como funciona

- Cada shortcut é um deep-link para `/transactions?new=<type>`.
- Um novo hook `useCreateTransactionShortcut` lê o search param `new`, abre o `CreateTransactionDrawer` com o `initialType` correspondente e **remove o param** da URL (via `replace`), pra que um refresh ou navegação "voltar" não reabra o drawer.
- `CreateTransactionDrawer` ganhou uma prop opcional `initialType` (default `expense`), então todo o resto do fluxo de criação permanece inalterado.

## Observações

- **Plataforma:** shortcuts de PWA são suportados em Android/Chrome e Edge/Windows. iOS/Safari não suporta — degrada de forma transparente (o app abre normalmente). Só aparecem após a PWA ser instalada.
- **Auth:** o `_authenticated` preserva `location.href` no redirect de login, então o deep-link sobrevive ao fluxo de autenticação.
- Como os atalhos são estáticos no manifest, o usuário pode precisar reinstalar a PWA para o SO atualizar o cache de shortcuts.

## Arquivos

- `frontend/vite.config.ts` — campo `shortcuts` no manifest.
- `frontend/src/hooks/useCreateTransactionShortcut.tsx` — novo hook (efeito encapsulado, seguindo a convenção de "zero `useEffect` em componentes").
- `frontend/src/components/transactions/CreateTransactionDrawer.tsx` — prop `initialType`.
- `frontend/src/routes/_authenticated.transactions.tsx` — param `new` no schema de busca.
- `frontend/src/pages/TransactionsPage.tsx` — liga o hook.
- `frontend/e2e/` — Page Object (`gotoCreateShortcut`, `assertCreateTypeSelected`) + spec `transaction-shortcuts.spec.ts`.

## Validação

- `npx tsc --noEmit` ✅
- `npm run build` ✅ (manifest gerado com os 3 shortcuts)
- `npm run lint` ✅ (sem erros; 2 warnings pré-existentes não relacionados)
- E2E adicionado (não executado neste ambiente — requer stack completa).

https://claude.ai/code/session_01FZMCoPF9sbhLSZBfKoJ7fB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZMCoPF9sbhLSZBfKoJ7fB)_