### PR TITLE
fix(import): corrige data do CSV exibida um dia a menos

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -666,7 +666,8 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int64"
                             }
                         }
                     },
@@ -3259,7 +3260,12 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "date": {
-                    "type": "string"
+                    "description": "Date is a calendar date (no time-of-day). It serializes as YYYY-MM-DD so\nthe frontend's date components parse it as a local date instead of a UTC\ninstant — emitting a full RFC3339 timestamp here shifts the displayed day\nby one in negative-offset timezones (e.g. UTC-3).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.Date"
+                        }
+                    ]
                 },
                 "description": {
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -660,7 +660,8 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int64"
                             }
                         }
                     },
@@ -3253,7 +3254,12 @@
                     "type": "boolean"
                 },
                 "date": {
-                    "type": "string"
+                    "description": "Date is a calendar date (no time-of-day). It serializes as YYYY-MM-DD so\nthe frontend's date components parse it as a local date instead of a UTC\ninstant — emitting a full RFC3339 timestamp here shifts the displayed day\nby one in negative-offset timezones (e.g. UTC-3).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.Date"
+                        }
+                    ]
                 },
                 "description": {
                     "type": "string"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -303,7 +303,13 @@ definitions:
       category_inferred:
         type: boolean
       date:
-        type: string
+        allOf:
+        - $ref: '#/definitions/domain.Date'
+        description: |-
+          Date is a calendar date (no time-of-day). It serializes as YYYY-MM-DD so
+          the frontend's date components parse it as a local date instead of a UTC
+          instant — emitting a full RFC3339 timestamp here shifts the displayed day
+          by one in negative-offset timezones (e.g. UTC-3).
       description:
         type: string
       destination_account_id:
@@ -1245,6 +1251,7 @@ paths:
           description: OK
           schema:
             additionalProperties:
+              format: int64
               type: integer
             type: object
         "401":

--- a/backend/internal/domain/transaction_import.go
+++ b/backend/internal/domain/transaction_import.go
@@ -21,21 +21,25 @@ const (
 // It includes inferred values (e.g. category from transaction history) and
 // any transactions or settlements detected as possible duplicates of this row.
 type ParsedImportRow struct {
-	RowIndex                     int                `json:"row_index"`
-	Status                       ImportRowStatus    `json:"status"`
-	Date                         *time.Time         `json:"date,omitempty"`
-	Description                  string             `json:"description"`
-	Type                         TransactionType    `json:"type"`
-	Amount                       int64              `json:"amount"` // cents
-	CategoryID                   *int               `json:"category_id,omitempty"`
-	CategoryInferred             bool               `json:"category_inferred"`
-	DestinationAccountID         *int               `json:"destination_account_id,omitempty"`
-	RecurrenceType               *RecurrenceType    `json:"recurrence_type,omitempty"`
-	RecurrenceCount              *int               `json:"recurrence_count,omitempty"`
-	RecurrenceCurrentInstallment *int               `json:"recurrence_current_installment,omitempty"`
-	ParseErrors                  []string           `json:"parse_errors,omitempty"`
-	DuplicateMatches             []Transaction      `json:"duplicate_matches,omitempty"`
-	SettlementMatches            []SettlementMatch  `json:"settlement_matches,omitempty"`
+	RowIndex int             `json:"row_index"`
+	Status   ImportRowStatus `json:"status"`
+	// Date is a calendar date (no time-of-day). It serializes as YYYY-MM-DD so
+	// the frontend's date components parse it as a local date instead of a UTC
+	// instant — emitting a full RFC3339 timestamp here shifts the displayed day
+	// by one in negative-offset timezones (e.g. UTC-3).
+	Date                         *Date             `json:"date,omitempty"`
+	Description                  string            `json:"description"`
+	Type                         TransactionType   `json:"type"`
+	Amount                       int64             `json:"amount"` // cents
+	CategoryID                   *int              `json:"category_id,omitempty"`
+	CategoryInferred             bool              `json:"category_inferred"`
+	DestinationAccountID         *int              `json:"destination_account_id,omitempty"`
+	RecurrenceType               *RecurrenceType   `json:"recurrence_type,omitempty"`
+	RecurrenceCount              *int              `json:"recurrence_count,omitempty"`
+	RecurrenceCurrentInstallment *int              `json:"recurrence_current_installment,omitempty"`
+	ParseErrors                  []string          `json:"parse_errors,omitempty"`
+	DuplicateMatches             []Transaction     `json:"duplicate_matches,omitempty"`
+	SettlementMatches            []SettlementMatch `json:"settlement_matches,omitempty"`
 }
 
 // SettlementMatch is a settlement flagged as a possible duplicate of an
@@ -92,9 +96,9 @@ type CheckDuplicatesBulkRequest struct {
 // settlements (income rows match credit settlements, expense rows match
 // debit settlements). Both share the same amount/description thresholds.
 type CheckDuplicateRowResult struct {
-	RowIndex          int                `json:"row_index"`
-	Matches           []Transaction      `json:"matches"`
-	SettlementMatches []SettlementMatch  `json:"settlement_matches,omitempty"`
+	RowIndex          int               `json:"row_index"`
+	Matches           []Transaction     `json:"matches"`
+	SettlementMatches []SettlementMatch `json:"settlement_matches,omitempty"`
 }
 
 // CheckDuplicatesBulkResponse is the response of the bulk duplicate check.

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -212,7 +212,7 @@ func parseCSVRow(
 		for _, format := range formats {
 			t, err := time.Parse(format, dateStr)
 			if err == nil {
-				row.Date = &t
+				row.Date = &domain.Date{Time: t}
 				break
 			}
 		}
@@ -485,7 +485,7 @@ func detectDuplicateRows(ctx context.Context, s *transactionService, userID, acc
 		if row.Date != nil && row.Amount > 0 {
 			inputs = append(inputs, domain.CheckDuplicateRowInput{
 				RowIndex:    i,
-				Date:        domain.Date{Time: *row.Date},
+				Date:        *row.Date,
 				Amount:      row.Amount,
 				Description: row.Description,
 				Type:        row.Type,

--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -224,8 +224,10 @@ export class ImportPage {
 
   /** Get the displayed date value of a row (formatted DD/MM/YYYY). */
   async getRowDateValue(rowIndex: number): Promise<string> {
-    const dateInput = this.reviewStep.getByTestId(ImportTestIds.RowInputDate(rowIndex));
-    return dateInput.locator("input").inputValue();
+    // DatePickerInput renders the formatted value as the text content of a
+    // button-like control (the testid'd element) — it has no fillable <input>.
+    const control = this.reviewStep.getByTestId(ImportTestIds.RowInputDate(rowIndex));
+    return (await control.innerText()).trim();
   }
 
   /** Get the current value of the main account select in the upload step. */

--- a/frontend/e2e/pages/ImportPage.ts
+++ b/frontend/e2e/pages/ImportPage.ts
@@ -222,6 +222,12 @@ export class ImportPage {
     return select.inputValue();
   }
 
+  /** Get the displayed date value of a row (formatted DD/MM/YYYY). */
+  async getRowDateValue(rowIndex: number): Promise<string> {
+    const dateInput = this.reviewStep.getByTestId(ImportTestIds.RowInputDate(rowIndex));
+    return dateInput.locator("input").inputValue();
+  }
+
   /** Get the current value of the main account select in the upload step. */
   async getHeaderAccountValue(): Promise<string> {
     const select = this.uploadStep.getByTestId(ImportTestIds.SelectAccount);

--- a/frontend/e2e/tests/import-enhancements.spec.ts
+++ b/frontend/e2e/tests/import-enhancements.spec.ts
@@ -316,7 +316,9 @@ test.describe("Import: date parsing", () => {
     await importPage.uploadCSV(csv, user.accountId);
 
     await expect(importPage.reviewStep.getByTestId(ImportTestIds.Row(0))).toBeVisible();
-    expect(await importPage.getRowDateValue(0)).toBe("04/05/2026");
+    await expect
+      .poll(() => importPage.getRowDateValue(0), { timeout: 10000 })
+      .toBe("04/05/2026");
 
     await page.close();
   });

--- a/frontend/e2e/tests/import-enhancements.spec.ts
+++ b/frontend/e2e/tests/import-enhancements.spec.ts
@@ -293,3 +293,31 @@ test.describe("Import: duplicate detection criteria", () => {
     await page.close();
   });
 });
+
+// ─── Date parsing (timezone regression) ────────────────────────────────────
+// Regression for the bug where a CSV date in DD/MM/YYYY was displayed one day
+// earlier in the review table. The backend serialized the date as a UTC
+// timestamp (e.g. 2026-05-04T00:00:00Z), which the DatePickerInput then
+// re-interpreted in the browser's local timezone (UTC-3 → 2026-05-03). The fix
+// makes the API emit a date-only string (YYYY-MM-DD) so no shift occurs.
+
+test.describe("Import: date parsing", () => {
+  test("CSV date DD/MM/YYYY is displayed exactly, with no off-by-one shift", async ({ browser }) => {
+    const user = await createTestUser("date-shift");
+    const page = await openAuthedPage(browser, user.token);
+    const importPage = new ImportPage(page);
+    await importPage.goto();
+
+    // The exact date from the original bug report: 04/05/2026.
+    const csv = buildCsvContent([
+      ["04/05/2026", `Date Shift ${Date.now()}`, "-100,00"],
+    ]);
+
+    await importPage.uploadCSV(csv, user.accountId);
+
+    await expect(importPage.reviewStep.getByTestId(ImportTestIds.Row(0))).toBeVisible();
+    expect(await importPage.getRowDateValue(0)).toBe("04/05/2026");
+
+    await page.close();
+  });
+});

--- a/frontend/src/types/transactions.ts
+++ b/frontend/src/types/transactions.ts
@@ -220,7 +220,7 @@ export namespace Transactions {
   export interface ParsedImportRow {
     row_index: number;
     status: ImportRowStatus;
-    date?: string; // ISO string (backend sends time.Time serialised)
+    date?: string; // YYYY-MM-DD (date-only; no timezone shift on display)
     description: string;
     type: TransactionType;
     amount: number; // cents


### PR DESCRIPTION
## Problema

Ao importar transações de um CSV com a data no formato `DD/MM/YYYY`, a data exibida no frontend ficava **um dia a menos**.

Exemplo do reporte: CSV = `04/05/2026` → frontend exibia `03/05/2026`.

## Causa raiz

O campo `Date` de `ParsedImportRow` era um `*time.Time`, serializado na API como timestamp UTC:

```
2026-05-04T00:00:00Z
```

O `DatePickerInput` (Mantine) interpretava essa string com `Z` como um **instante UTC** e convertia para o fuso local do navegador. Em fusos negativos (ex.: `UTC-3`, Brasil), `2026-05-04T00:00:00Z` vira `2026-05-03 21:00`, e o componente passava a exibir `03/05/2026`.

O restante do app já trafega datas de transação como `YYYY-MM-DD` (string de data pura, sem fuso) — apenas o fluxo de importação destoava.

## Correção

Troca o tipo do campo para o `domain.Date` já existente, que serializa como data pura (`YYYY-MM-DD`):

- `ParsedImportRow.Date`: `*time.Time` → `*domain.Date`
- Ajustes nos pontos de atribuição/leitura em `service/transaction_import.go`
- Tipo do frontend e Swagger atualizados (`just generate-docs`)

Isso elimina o deslocamento de fuso na exibição e alinha o fluxo de importação com a convenção de datas do resto da aplicação. O endpoint de checagem de duplicidade e o de criação de transação já aceitam `YYYY-MM-DD`, então não há quebra no round-trip.

## Teste

Adicionado teste e2e de regressão (`import-enhancements.spec.ts`) que importa um CSV com `04/05/2026` e verifica que a linha de revisão exibe exatamente `04/05/2026`, mais o helper `getRowDateValue` no `ImportPage`.

- ✅ `go build ./...` e `go test -short ./...`
- ✅ `tsc` (app + e2e) e `eslint` nos arquivos alterados

https://claude.ai/code/session_01D92jnTRMdovrN2x6DKjvRB

---
_Generated by [Claude Code](https://claude.ai/code/session_01D92jnTRMdovrN2x6DKjvRB)_