### PR TITLE
feat(import): sinaliza duplicados por data+valor exatos ignorando descrição

### DIFF
--- a/backend/internal/service/transaction_check_duplicate.go
+++ b/backend/internal/service/transaction_check_duplicate.go
@@ -56,7 +56,7 @@ func checkDuplicatesByWindow(ctx context.Context, s *transactionService, userID 
 			}
 			txWindows[key] = txs
 		}
-		txResult[row.RowIndex] = filterDuplicateMatches(txs, row.Amount, row.Description)
+		txResult[row.RowIndex] = filterDuplicateMatches(txs, row.Date.Time, row.Amount, row.Description)
 
 		// Settlement lookup only when the row type can plausibly match one.
 		if _, ok := allowedSettlementTypeFor(row.Type); !ok {
@@ -70,7 +70,7 @@ func checkDuplicatesByWindow(ctx context.Context, s *transactionService, userID 
 			settlementWindows[key] = settlements
 			settlementWindowLoaded[key] = true
 		}
-		if matches := filterSettlementDuplicateMatches(settlementWindows[key], row.Amount, row.Description, row.Type); len(matches) > 0 {
+		if matches := filterSettlementDuplicateMatches(settlementWindows[key], row.Date.Time, row.Amount, row.Description, row.Type); len(matches) > 0 {
 			settlementResult[row.RowIndex] = matches
 		}
 	}

--- a/backend/internal/service/transaction_import.go
+++ b/backend/internal/service/transaction_import.go
@@ -359,6 +359,25 @@ func parseAmountSigned(s string) (int64, error) {
 // transaction amounts to be considered a possible duplicate.
 const duplicateAmountThreshold = int64(2)
 
+// sameCalendarDay reports whether a and b fall on the same year-month-day.
+// All times are UTC across the wire (time.Local is set to UTC at startup), so a
+// plain calendar-component comparison is unambiguous here.
+func sameCalendarDay(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}
+
+// isExactDateAmountMatch reports whether a candidate with candidateDate and
+// candidateAmount is an exact duplicate of a row on (date, amount): same
+// calendar day and identical amount. This is a description-independent signal —
+// re-imported statements frequently carry garbled or missing descriptions but
+// keep the date and amount intact, so an exact match on both flags a duplicate
+// on its own.
+func isExactDateAmountMatch(candidateDate, date time.Time, candidateAmount, amount int64) bool {
+	return candidateAmount == amount && sameCalendarDay(candidateDate, date)
+}
+
 // searchMonthWindow fetches every transaction for the user in the calendar
 // month of date, optionally scoped to a single account.
 func searchMonthWindow(ctx context.Context, s *transactionService, userID int, date time.Time, accountID *int) ([]*domain.Transaction, error) {
@@ -415,10 +434,12 @@ func allowedSettlementTypeFor(t domain.TransactionType) (domain.SettlementType, 
 // filterSettlementDuplicateMatches mirrors filterDuplicateMatches but for
 // settlements: amount within ±duplicateAmountThreshold, a similar description
 // (against the preloaded source transaction description), and the settlement
-// type aligned with the row type.
+// type aligned with the row type. As with transactions, an exact match on both
+// calendar day and amount flags a duplicate regardless of description.
 // Settlements without a preloaded SourceTransaction contribute an empty
-// description — they only match when the row description is also empty.
-func filterSettlementDuplicateMatches(candidates []*domain.Settlement, amount int64, description string, rowType domain.TransactionType) []domain.SettlementMatch {
+// description — they only match when the row description is also empty (or the
+// exact date+amount signal fires).
+func filterSettlementDuplicateMatches(candidates []*domain.Settlement, date time.Time, amount int64, description string, rowType domain.TransactionType) []domain.SettlementMatch {
 	allowedType, ok := allowedSettlementTypeFor(rowType)
 	if !ok {
 		return nil
@@ -438,7 +459,8 @@ func filterSettlementDuplicateMatches(candidates []*domain.Settlement, amount in
 		if st.SourceTransaction != nil {
 			sourceDesc = st.SourceTransaction.Description
 		}
-		if description != "" && !descriptionsAreSimilar(sourceDesc, description) {
+		if !isExactDateAmountMatch(st.Date, date, st.Amount, amount) &&
+			description != "" && !descriptionsAreSimilar(sourceDesc, description) {
 			continue
 		}
 		matches = append(matches, domain.SettlementMatch{
@@ -455,10 +477,11 @@ func filterSettlementDuplicateMatches(candidates []*domain.Settlement, amount in
 }
 
 // filterDuplicateMatches keeps only the candidates that are possible
-// duplicates of (amount, description): amount within ±2 cents and, when a
+// duplicates of (date, amount, description): amount within ±2 cents and either
+// an exact match on calendar day and amount (description ignored) or, when a
 // description is supplied, a similar description (accent-folded trigram
 // similarity or a shared significant word).
-func filterDuplicateMatches(candidates []*domain.Transaction, amount int64, description string) []domain.Transaction {
+func filterDuplicateMatches(candidates []*domain.Transaction, date time.Time, amount int64, description string) []domain.Transaction {
 	matches := make([]domain.Transaction, 0)
 	for _, tx := range candidates {
 		if tx == nil {
@@ -467,7 +490,8 @@ func filterDuplicateMatches(candidates []*domain.Transaction, amount int64, desc
 		if diff := tx.Amount - amount; diff < -duplicateAmountThreshold || diff > duplicateAmountThreshold {
 			continue
 		}
-		if description != "" && !descriptionsAreSimilar(tx.Description, description) {
+		if !isExactDateAmountMatch(tx.Date, date, tx.Amount, amount) &&
+			description != "" && !descriptionsAreSimilar(tx.Description, description) {
 			continue
 		}
 		matches = append(matches, *tx)

--- a/backend/internal/service/transaction_import_test.go
+++ b/backend/internal/service/transaction_import_test.go
@@ -182,9 +182,14 @@ func TestFilterSettlementDuplicateMatches(t *testing.T) {
 		return settlement(id, amount, domain.SettlementTypeDebit, desc)
 	}
 
+	// otherDay never coincides with the helper's time.Now() settlement date, so
+	// the exact date+amount bypass stays dormant and these cases exercise the
+	// description-based path. The dedicated bypass case below opts in explicitly.
+	otherDay := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
 	t.Run("income matches credit settlement only", func(t *testing.T) {
 		candidates := []*domain.Settlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
-		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
+		got := filterSettlementDuplicateMatches(candidates, otherDay, 5000, "Petz", domain.TransactionTypeIncome)
 		require.Len(t, got, 1)
 		assert.Equal(t, 1, got[0].ID)
 		assert.Equal(t, domain.SettlementTypeCredit, got[0].Type)
@@ -193,7 +198,7 @@ func TestFilterSettlementDuplicateMatches(t *testing.T) {
 
 	t.Run("expense matches debit settlement only", func(t *testing.T) {
 		candidates := []*domain.Settlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
-		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeExpense)
+		got := filterSettlementDuplicateMatches(candidates, otherDay, 5000, "Petz", domain.TransactionTypeExpense)
 		require.Len(t, got, 1)
 		assert.Equal(t, 2, got[0].ID)
 		assert.Equal(t, domain.SettlementTypeDebit, got[0].Type)
@@ -201,26 +206,26 @@ func TestFilterSettlementDuplicateMatches(t *testing.T) {
 
 	t.Run("transfer skips settlement matching entirely", func(t *testing.T) {
 		candidates := []*domain.Settlement{credit(1, 5000, "Petz"), debit(2, 5000, "Petz")}
-		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeTransfer)
+		got := filterSettlementDuplicateMatches(candidates, otherDay, 5000, "Petz", domain.TransactionTypeTransfer)
 		assert.Nil(t, got)
 	})
 
 	t.Run("amount within tolerance matches, outside does not", func(t *testing.T) {
 		candidates := []*domain.Settlement{credit(1, 5002, "Petz"), credit(2, 5003, "Petz")}
-		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
+		got := filterSettlementDuplicateMatches(candidates, otherDay, 5000, "Petz", domain.TransactionTypeIncome)
 		require.Len(t, got, 1)
 		assert.Equal(t, 1, got[0].ID)
 	})
 
 	t.Run("description mismatch is filtered out", func(t *testing.T) {
 		candidates := []*domain.Settlement{credit(1, 5000, "Imec")}
-		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
+		got := filterSettlementDuplicateMatches(candidates, otherDay, 5000, "Petz", domain.TransactionTypeIncome)
 		assert.Empty(t, got)
 	})
 
 	t.Run("empty description skips similarity check", func(t *testing.T) {
 		candidates := []*domain.Settlement{credit(1, 5000, "Whatever")}
-		got := filterSettlementDuplicateMatches(candidates, 5000, "", domain.TransactionTypeIncome)
+		got := filterSettlementDuplicateMatches(candidates, otherDay, 5000, "", domain.TransactionTypeIncome)
 		require.Len(t, got, 1)
 	})
 
@@ -232,17 +237,39 @@ func TestFilterSettlementDuplicateMatches(t *testing.T) {
 		candidates := []*domain.Settlement{bare}
 		// With a non-empty description, the bare settlement fails the
 		// similarity check (empty source description) and is filtered out.
-		assert.Empty(t, filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome))
+		assert.Empty(t, filterSettlementDuplicateMatches(candidates, otherDay, 5000, "Petz", domain.TransactionTypeIncome))
 		// With an empty description, the similarity check is skipped and the
 		// settlement matches on amount + type alone.
-		require.Len(t, filterSettlementDuplicateMatches(candidates, 5000, "", domain.TransactionTypeIncome), 1)
+		require.Len(t, filterSettlementDuplicateMatches(candidates, otherDay, 5000, "", domain.TransactionTypeIncome), 1)
 	})
 
 	t.Run("nil settlement is skipped without panic", func(t *testing.T) {
 		candidates := []*domain.Settlement{nil, credit(1, 5000, "Petz")}
-		got := filterSettlementDuplicateMatches(candidates, 5000, "Petz", domain.TransactionTypeIncome)
+		got := filterSettlementDuplicateMatches(candidates, otherDay, 5000, "Petz", domain.TransactionTypeIncome)
 		require.Len(t, got, 1)
 		assert.Equal(t, 1, got[0].ID)
+	})
+
+	t.Run("exact same day and amount matches even when description differs", func(t *testing.T) {
+		sameDay := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC)
+		st := credit(1, 5000, "Imec")
+		st.Date = sameDay
+		candidates := []*domain.Settlement{st}
+		// Description does not match, but the exact date+amount signal fires.
+		got := filterSettlementDuplicateMatches(candidates, sameDay, 5000, "Petz", domain.TransactionTypeIncome)
+		require.Len(t, got, 1)
+		assert.Equal(t, 1, got[0].ID)
+	})
+
+	t.Run("same day with description mismatch but amount off by a cent still needs description", func(t *testing.T) {
+		sameDay := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC)
+		st := credit(1, 5001, "Imec")
+		st.Date = sameDay
+		candidates := []*domain.Settlement{st}
+		// Amount is within tolerance but not exact, so the bypass does not fire
+		// and the mismatching description filters it out.
+		got := filterSettlementDuplicateMatches(candidates, sameDay, 5000, "Petz", domain.TransactionTypeIncome)
+		assert.Empty(t, got)
 	})
 }
 
@@ -536,6 +563,13 @@ func (suite *TransactionImportWithDBTestSuite) TestDuplicateMatchCriteria() {
 		mismatchDate := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
 		createTx(52132, mismatchDate, "Imec")
 		suite.Empty(checkOne(mismatchDate, 52134, "PETZ 22"))
+	})
+
+	suite.Run("exact same date and amount is a duplicate even with a different description", func() {
+		exactDate := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC)
+		createTx(33300, exactDate, "Original Store")
+		// Description is unrelated, but date and amount match exactly.
+		suite.NotEmpty(checkOne(exactDate, 33300, "Totally Different Text"))
 	})
 
 	suite.Run("no matching amount returns no matches", func() {

--- a/backend/internal/service/transaction_import_test.go
+++ b/backend/internal/service/transaction_import_test.go
@@ -683,8 +683,13 @@ func (suite *TransactionImportWithDBTestSuite) TestCheckDuplicatesBulkAgainstSet
 		{RowIndex: 3, Date: domain.Date{Time: time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)}, Amount: 5000, Description: "Jantar restaurante", Type: domain.TransactionTypeIncome},
 		// No match: amount too far.
 		{RowIndex: 4, Date: domain.Date{Time: sharedDate}, Amount: 9999, Description: "Jantar restaurante", Type: domain.TransactionTypeIncome},
-		// No match: description mismatch.
-		{RowIndex: 5, Date: domain.Date{Time: sharedDate}, Amount: 5000, Description: "Aluguel mensal apto", Type: domain.TransactionTypeIncome},
+		// No match: description mismatch. Uses a different day and a non-exact
+		// (within-tolerance) amount so the exact date+amount signal stays dormant
+		// and the description is the only criterion under test.
+		{RowIndex: 5, Date: domain.Date{Time: time.Date(2026, 11, 20, 0, 0, 0, 0, time.UTC)}, Amount: 5001, Description: "Aluguel mensal apto", Type: domain.TransactionTypeIncome},
+		// Match: exact same day and amount as the settlement flags a duplicate
+		// even though the description is unrelated.
+		{RowIndex: 6, Date: domain.Date{Time: sharedDate}, Amount: 5000, Description: "Aluguel mensal apto", Type: domain.TransactionTypeIncome},
 	}
 
 	results, err := suite.Services.Transaction.CheckDuplicatesBulk(ctx, user1.ID, &connAccountID, rows)
@@ -706,6 +711,8 @@ func (suite *TransactionImportWithDBTestSuite) TestCheckDuplicatesBulkAgainstSet
 	suite.Empty(byIndex[3].SettlementMatches, "different month should not match")
 	suite.Empty(byIndex[4].SettlementMatches, "amount outside tolerance should not match")
 	suite.Empty(byIndex[5].SettlementMatches, "description mismatch should not match")
+	suite.Require().Len(byIndex[6].SettlementMatches, 1, "exact date and amount should match despite description mismatch")
+	suite.Equal(settlements[0].ID, byIndex[6].SettlementMatches[0].ID)
 }
 
 func TestInferInstallment(t *testing.T) {

--- a/frontend/e2e/tests/import-enhancements.spec.ts
+++ b/frontend/e2e/tests/import-enhancements.spec.ts
@@ -233,7 +233,7 @@ test.describe("Import: installment inference from description", () => {
 // ─── Duplicate detection criteria ───────────────────────────────────────────
 
 test.describe("Import: duplicate detection criteria", () => {
-  test("same date+amount but unrelated description is NOT flagged", async ({ browser }) => {
+  test("same date+amount IS flagged even with an unrelated description", async ({ browser }) => {
     const user = await createTestUser("dup-desc");
     const txDate = new Date(2026, 8, 10);
 
@@ -255,10 +255,11 @@ test.describe("Import: duplicate detection criteria", () => {
 
     await importPage.uploadCSV(csv, user.accountId);
 
-    // Description similarity is now part of the match — an unrelated
-    // description means no duplicate warning even with same date + amount.
+    // Exact same date and amount flags a duplicate regardless of how different
+    // the descriptions are: re-imported statements often carry garbled or
+    // missing descriptions but keep the date and amount intact.
     await expect(importPage.reviewStep.getByTestId(ImportTestIds.Row(0))).toBeVisible();
-    await expect(importPage.duplicateWarning(0)).not.toBeVisible();
+    await expect(importPage.duplicateWarning(0)).toBeVisible();
 
     await page.close();
   });

--- a/frontend/src/components/transactions/import/DuplicateTransactionsDrawer.tsx
+++ b/frontend/src/components/transactions/import/DuplicateTransactionsDrawer.tsx
@@ -85,12 +85,16 @@ export function DuplicateTransactionsDrawer({ row, matches, settlementMatches, c
           title="Como detectamos duplicidades"
         >
           <Text fz="xs" mb={4}>
-            Uma linha é sinalizada quando existe uma transação ou liquidação que atende aos 3 critérios:
+            Uma linha é sinalizada quando existe uma transação ou liquidação em um destes casos:
           </Text>
           <List size="xs" spacing={2}>
-            <List.Item>{similarityLabel}</List.Item>
-            <List.Item>{amountLabel}</List.Item>
-            <List.Item>No mesmo mês da data da transação</List.Item>
+            <List.Item>
+              Mesma data e mesmo valor exatos — mesmo que a descrição seja diferente.
+            </List.Item>
+            <List.Item>
+              No mesmo mês da data da transação, com {amountLabel.toLowerCase()} e{' '}
+              {similarityLabel.toLowerCase()}.
+            </List.Item>
           </List>
           <Text fz="xs" mt={6}>
             Receitas também são comparadas com liquidações de crédito; despesas com liquidações de débito da mesma conta.


### PR DESCRIPTION
## O que muda

Expande os critérios de detecção de duplicados na importação para sinalizar uma linha sempre que existir uma transação **ou** liquidação com **exatamente a mesma data e o mesmo valor**, independentemente da similaridade de descrição.

### Por quê

Extratos bancários reimportados frequentemente trazem descrições truncadas, embaralhadas ou ausentes, mantendo apenas data e valor. O caminho atual (valor dentro da tolerância + descrição parecida, no mesmo mês) deixava esses casos passarem.

### Como ficou

Uma linha é sinalizada como possível duplicidade em **dois casos** (qualquer um basta):

1. **Mesma data e mesmo valor exatos** — descrição é ignorada (novo).
2. **Mesmo mês**, com valor dentro de ±2 centavos **e** descrição parecida (comportamento anterior, preservado).

O caso 1 exige correspondência exata: mesmo dia-calendário e valor idêntico (`diff == 0`). Um valor dentro da tolerância mas não idêntico continua precisando da descrição parecida.

## Mudanças

**Backend** (`internal/service/`)
- `transaction_import.go`: novos helpers `sameCalendarDay` e `isExactDateAmountMatch`; `filterDuplicateMatches` e `filterSettlementDuplicateMatches` agora recebem a data da linha e aplicam o bypass de descrição quando data+valor batem exatamente.
- `transaction_check_duplicate.go`: callers atualizados para passar `row.Date.Time`.
- `transaction_import_test.go`: novos casos cobrindo o bypass (transação via suíte de DB; liquidação via teste unitário) e um caso de contraste (valor dentro da tolerância mas não exato + descrição diferente continua sem match).

**Frontend**
- `DuplicateTransactionsDrawer.tsx`: texto explicativo dos critérios reescrito para refletir os dois casos.

## Testes

- `go build ./...`, `go vet ./internal/service/` e `go test ./internal/service/ -short` passam.
- Os testes de integração baseados em testcontainers (`TestDuplicateMatchCriteria`) não rodam neste ambiente por falta de Docker host — foram atualizados/estendidos mas devem ser validados no CI.

https://claude.ai/code/session_01QYxFEgjMUKE1LMk7Xkz8f6

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYxFEgjMUKE1LMk7Xkz8f6)_