### PR TITLE
fix(ci): capture goose stderr in pending migration check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,7 +134,8 @@ jobs:
         env:
           DB_DSN: ${{ secrets.DB_DSN_PROD }}
         run: |
-          STATUS=$(goose -dir migrations postgres "$DB_DSN" status)
+          # goose logs to stderr, so capture both streams or $STATUS is empty
+          STATUS=$(goose -dir migrations postgres "$DB_DSN" status 2>&1)
           echo "$STATUS"
           PENDING=$(echo "$STATUS" | grep -c "Pending" || true)
           if [ "$PENDING" -gt 0 ]; then


### PR DESCRIPTION
## Problem

The `check-migrations` job in `deploy.yml` always reported "No pending migrations" even when pending migrations existed. A recent run showed `20260609000000_add_initiator_user_id_to_charges.sql` listed as `Pending`, yet the deploy proceeded.

## Root cause

goose writes its `status` output to **stderr** (via Go's `log` package — hence the `2026/06/10 00:20:50` timestamp prefixes). The command substitution

```bash
STATUS=$(goose -dir migrations postgres "$DB_DSN" status)
```

only captures stdout, so `$STATUS` was always empty. The migration list visible in the CI log was stderr leaking straight through to the job output, not the captured variable. `grep -c "Pending"` then ran against an empty string and always counted 0.

## Fix

Redirect stderr into the substitution:

```bash
STATUS=$(goose -dir migrations postgres "$DB_DSN" status 2>&1)
```

Now `$STATUS` contains the actual status table and the `Pending` count works as intended.

https://claude.ai/code/session_0125e6rEjahSMZydmBvJp5X7

---
_Generated by [Claude Code](https://claude.ai/code/session_0125e6rEjahSMZydmBvJp5X7)_