### PR TITLE
feat(charges): allow deleting non-paid charges

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -267,6 +267,7 @@ func registerAPIRoutes(api *echo.Group, services *service.Services, h apiHandler
 	charges.POST("/:id/cancel", h.charge.Cancel)
 	charges.POST("/:id/reject", h.charge.Reject)
 	charges.POST("/:id/accept", h.charge.Accept)
+	charges.DELETE("/:id", h.charge.Delete)
 
 	// Push subscriptions
 	pushSubs := api.Group("/push-subscriptions")

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -680,6 +680,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/charges/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently deletes a charge. Allowed only while the charge is pending, rejected, or cancelled; paid charges cannot be deleted.",
+                "tags": [
+                    "charges"
+                ],
+                "summary": "Delete a charge (either party)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Charge ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/charges/{id}/accept": {
             "post": {
                 "security": [

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -674,6 +674,61 @@
                 }
             }
         },
+        "/api/charges/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently deletes a charge. Allowed only while the charge is pending, rejected, or cancelled; paid charges cannot be deleted.",
+                "tags": [
+                    "charges"
+                ],
+                "summary": "Delete a charge (either party)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Charge ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/middleware.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/charges/{id}/accept": {
             "post": {
                 "security": [

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1133,6 +1133,41 @@ paths:
       summary: Create a charge
       tags:
       - charges
+  /api/charges/{id}:
+    delete:
+      description: Permanently deletes a charge. Allowed only while the charge is
+        pending, rejected, or cancelled; paid charges cannot be deleted.
+      parameters:
+      - description: Charge ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/middleware.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/middleware.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/middleware.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/middleware.ErrorResponse'
+      security:
+      - CookieAuth: []
+      - BearerAuth: []
+      summary: Delete a charge (either party)
+      tags:
+      - charges
   /api/charges/{id}/accept:
     post:
       consumes:

--- a/backend/internal/domain/charge.go
+++ b/backend/internal/domain/charge.go
@@ -73,6 +73,15 @@ func (c *Charge) IsParty(userID int) bool {
 	return c.ChargerUserID == userID || c.PayerUserID == userID
 }
 
+// IsDeletable reports whether the charge can be permanently deleted. Paid
+// charges are never deletable because accepting one created settlement
+// transfer transactions that must be preserved.
+func (c *Charge) IsDeletable() bool {
+	return c.Status == ChargeStatusPending ||
+		c.Status == ChargeStatusRejected ||
+		c.Status == ChargeStatusCancelled
+}
+
 func (c *Charge) ValidateTransition(newStatus ChargeStatus) error {
 	switch c.Status {
 	case ChargeStatusPending:

--- a/backend/internal/handler/charge_handler.go
+++ b/backend/internal/handler/charge_handler.go
@@ -156,6 +156,34 @@ func (h *ChargeHandler) Reject(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// Delete godoc
+// @Summary      Delete a charge (either party)
+// @Description  Permanently deletes a charge. Allowed only while the charge is pending, rejected, or cancelled; paid charges cannot be deleted.
+// @Tags         charges
+// @Security     CookieAuth
+// @Security     BearerAuth
+// @Param        id  path  int  true  "Charge ID"
+// @Success      204
+// @Failure      400  {object}  middleware.ErrorResponse
+// @Failure      401  {object}  middleware.ErrorResponse
+// @Failure      403  {object}  middleware.ErrorResponse
+// @Failure      404  {object}  middleware.ErrorResponse
+// @Router       /api/charges/{id} [delete]
+func (h *ChargeHandler) Delete(c echo.Context) error {
+	userID := appcontext.GetUserIDFromContext(c.Request().Context())
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid charge ID")
+	}
+
+	if err := h.chargeService.Delete(c.Request().Context(), userID, id); err != nil {
+		return HandleServiceError(err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
 // Accept godoc
 // @Summary      Accept a charge (non-initiating party only)
 // @Description  Atomically settles a pending charge by creating two linked transfer transactions. Caller must be the non-initiating party (the one whose account field is nil on the charge).

--- a/backend/internal/repository/charge_repository.go
+++ b/backend/internal/repository/charge_repository.go
@@ -43,6 +43,10 @@ func (r *chargeRepository) Update(ctx context.Context, charge *domain.Charge) er
 	return GetTxFromContext(ctx, r.db).Save(ent).Error
 }
 
+func (r *chargeRepository) Delete(ctx context.Context, id int) error {
+	return GetTxFromContext(ctx, r.db).Delete(&entity.Charge{}, id).Error
+}
+
 func (r *chargeRepository) Search(ctx context.Context, options domain.ChargeSearchOptions) ([]*domain.Charge, error) {
 	var ents []entity.Charge
 	query := GetTxFromContext(ctx, r.db)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -99,6 +99,7 @@ type ChargeRepository interface {
 	GetByID(ctx context.Context, id int) (*domain.Charge, error)
 	Search(ctx context.Context, options domain.ChargeSearchOptions) ([]*domain.Charge, error)
 	Update(ctx context.Context, charge *domain.Charge) error
+	Delete(ctx context.Context, id int) error
 	Count(ctx context.Context, options domain.ChargeSearchOptions) (int64, error)
 	ConditionalAccept(ctx context.Context, id int) error
 }

--- a/backend/internal/service/charge_service.go
+++ b/backend/internal/service/charge_service.go
@@ -234,6 +234,29 @@ func (s *chargeService) Reject(ctx context.Context, callerUserID, chargeID int) 
 	return nil
 }
 
+// Delete permanently removes a charge. Either party may delete it, but only
+// while it is pending, rejected, or cancelled — paid charges are kept because
+// they own settlement transfer transactions.
+func (s *chargeService) Delete(ctx context.Context, callerUserID, chargeID int) error {
+	charge, err := s.chargeRepo.GetByID(ctx, chargeID)
+	if err != nil {
+		return pkgErrors.NotFound("charge")
+	}
+
+	if !charge.IsParty(callerUserID) {
+		return pkgErrors.Forbidden("charge")
+	}
+
+	if !charge.IsDeletable() {
+		return pkgErrors.ErrChargeCannotDeletePaid
+	}
+
+	if err := s.chargeRepo.Delete(ctx, chargeID); err != nil {
+		return pkgErrors.Internal("failed to delete charge", err)
+	}
+	return nil
+}
+
 func (s *chargeService) List(ctx context.Context, options domain.ChargeSearchOptions) ([]*domain.Charge, error) {
 	results, err := s.chargeRepo.Search(ctx, options)
 	if err != nil {

--- a/backend/internal/service/charge_service_test.go
+++ b/backend/internal/service/charge_service_test.go
@@ -1016,3 +1016,115 @@ func (s *ChargeServiceTestSuite) TestUpdate_ChargeTransferRejectsTypeAndRecurren
 			"expected ErrorTagChargeTransactionRecurrenceNotAllowed")
 	})
 }
+
+// chargeExists reports whether a charge with the given ID is still visible to the user.
+func (s *ChargeServiceTestSuite) chargeExists(ctx context.Context, userID, chargeID int) bool {
+	charges, err := s.Repos.Charge.Search(ctx, domain.ChargeSearchOptions{
+		UserID: userID,
+		IDs:    []int{chargeID},
+	})
+	s.Require().NoError(err)
+	return len(charges) > 0
+}
+
+func (s *ChargeServiceTestSuite) TestDelete_PendingByEitherParty() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+	chargerAcc, err := s.createTestAccount(ctx, charger)
+	s.Require().NoError(err)
+
+	chargeDate := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	charge := s.createPendingCharge(ctx, charger.ID, payer.ID, chargerAcc.ID, conn.ID, 3, 2026, chargeDate)
+
+	// The payer (counterparty) may delete a pending charge.
+	err = s.Services.Charge.Delete(ctx, payer.ID, charge.ID)
+	s.Require().NoError(err)
+	s.False(s.chargeExists(ctx, charger.ID, charge.ID), "charge should be gone")
+}
+
+func (s *ChargeServiceTestSuite) TestDelete_RejectedAndCancelled() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+	chargerAcc, err := s.createTestAccount(ctx, charger)
+	s.Require().NoError(err)
+	chargeDate := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, status := range []domain.ChargeStatus{domain.ChargeStatusRejected, domain.ChargeStatusCancelled} {
+		charge := s.createPendingCharge(ctx, charger.ID, payer.ID, chargerAcc.ID, conn.ID, 3, 2026, chargeDate)
+		charge.Status = status
+		s.Require().NoError(s.Repos.Charge.Update(ctx, charge))
+
+		err = s.Services.Charge.Delete(ctx, charger.ID, charge.ID)
+		s.Require().NoError(err, "should delete %s charge", status)
+		s.False(s.chargeExists(ctx, charger.ID, charge.ID))
+	}
+}
+
+func (s *ChargeServiceTestSuite) TestDelete_PaidIsBlocked() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+	chargerPrivAcc, err := s.createTestAccount(ctx, charger)
+	s.Require().NoError(err)
+	payerPrivAcc, err := s.createTestAccount(ctx, payer)
+	s.Require().NoError(err)
+
+	periodMonth, periodYear := 3, 2026
+	conn.SwapIfNeeded(charger.ID)
+	s.seedTransaction(ctx, charger.ID, conn.FromAccountID, 10000, domain.OperationTypeCredit, periodMonth, periodYear)
+
+	chargeDate := time.Date(periodYear, time.Month(periodMonth), 1, 0, 0, 0, 0, time.UTC)
+	charge := s.createPendingCharge(ctx, charger.ID, payer.ID, chargerPrivAcc.ID, conn.ID, periodMonth, periodYear, chargeDate)
+
+	acceptDate := time.Date(periodYear, time.Month(periodMonth), 2, 0, 0, 0, 0, time.UTC)
+	err = s.Services.Charge.Accept(ctx, payer.ID, charge.ID, &domain.AcceptChargeRequest{
+		AccountID: payerPrivAcc.ID,
+		Date:      acceptDate,
+	})
+	s.Require().NoError(err)
+
+	err = s.Services.Charge.Delete(ctx, charger.ID, charge.ID)
+	s.Require().Error(err)
+	s.True(errors.Is(err, pkgErrors.ErrChargeCannotDeletePaid) || hasTag(err, pkgErrors.ErrorTagChargeCannotDeletePaid),
+		"expected paid charge delete to be blocked")
+	s.True(s.chargeExists(ctx, charger.ID, charge.ID), "paid charge must remain")
+}
+
+func (s *ChargeServiceTestSuite) TestDelete_NonPartyForbidden() {
+	ctx := context.Background()
+
+	charger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	payer, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	stranger, err := s.createTestUser(ctx)
+	s.Require().NoError(err)
+	conn, err := s.createAcceptedTestUserConnection(ctx, charger.ID, payer.ID, 50)
+	s.Require().NoError(err)
+	chargerAcc, err := s.createTestAccount(ctx, charger)
+	s.Require().NoError(err)
+
+	chargeDate := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	charge := s.createPendingCharge(ctx, charger.ID, payer.ID, chargerAcc.ID, conn.ID, 3, 2026, chargeDate)
+
+	err = s.Services.Charge.Delete(ctx, stranger.ID, charge.ID)
+	s.Require().Error(err)
+	s.True(s.chargeExists(ctx, charger.ID, charge.ID), "charge must remain after forbidden delete")
+}

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -78,6 +78,7 @@ type ChargeService interface {
 	Create(ctx context.Context, callerUserID int, req *domain.CreateChargeRequest) (*domain.Charge, error)
 	Cancel(ctx context.Context, callerUserID, chargeID int) error
 	Reject(ctx context.Context, callerUserID, chargeID int) error
+	Delete(ctx context.Context, callerUserID, chargeID int) error
 	List(ctx context.Context, options domain.ChargeSearchOptions) ([]*domain.Charge, error)
 	PendingCount(ctx context.Context, callerUserID int) (int64, error)
 	Accept(ctx context.Context, callerUserID int, chargeID int, req *domain.AcceptChargeRequest) error

--- a/backend/mocks/mock_ChargeRepository.go
+++ b/backend/mocks/mock_ChargeRepository.go
@@ -185,6 +185,53 @@ func (_c *MockChargeRepository_Create_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
+// Delete provides a mock function with given fields: ctx, id
+func (_m *MockChargeRepository) Delete(ctx context.Context, id int) error {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockChargeRepository_Delete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Delete'
+type MockChargeRepository_Delete_Call struct {
+	*mock.Call
+}
+
+// Delete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id int
+func (_e *MockChargeRepository_Expecter) Delete(ctx interface{}, id interface{}) *MockChargeRepository_Delete_Call {
+	return &MockChargeRepository_Delete_Call{Call: _e.mock.On("Delete", ctx, id)}
+}
+
+func (_c *MockChargeRepository_Delete_Call) Run(run func(ctx context.Context, id int)) *MockChargeRepository_Delete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int))
+	})
+	return _c
+}
+
+func (_c *MockChargeRepository_Delete_Call) Return(_a0 error) *MockChargeRepository_Delete_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockChargeRepository_Delete_Call) RunAndReturn(run func(context.Context, int) error) *MockChargeRepository_Delete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetByID provides a mock function with given fields: ctx, id
 func (_m *MockChargeRepository) GetByID(ctx context.Context, id int) (*domain.Charge, error) {
 	ret := _m.Called(ctx, id)

--- a/backend/mocks/mock_ChargeService.go
+++ b/backend/mocks/mock_ChargeService.go
@@ -179,6 +179,54 @@ func (_c *MockChargeService_Create_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// Delete provides a mock function with given fields: ctx, callerUserID, chargeID
+func (_m *MockChargeService) Delete(ctx context.Context, callerUserID int, chargeID int) error {
+	ret := _m.Called(ctx, callerUserID, chargeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, int) error); ok {
+		r0 = rf(ctx, callerUserID, chargeID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockChargeService_Delete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Delete'
+type MockChargeService_Delete_Call struct {
+	*mock.Call
+}
+
+// Delete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - callerUserID int
+//   - chargeID int
+func (_e *MockChargeService_Expecter) Delete(ctx interface{}, callerUserID interface{}, chargeID interface{}) *MockChargeService_Delete_Call {
+	return &MockChargeService_Delete_Call{Call: _e.mock.On("Delete", ctx, callerUserID, chargeID)}
+}
+
+func (_c *MockChargeService_Delete_Call) Run(run func(ctx context.Context, callerUserID int, chargeID int)) *MockChargeService_Delete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int), args[2].(int))
+	})
+	return _c
+}
+
+func (_c *MockChargeService_Delete_Call) Return(_a0 error) *MockChargeService_Delete_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockChargeService_Delete_Call) RunAndReturn(run func(context.Context, int, int) error) *MockChargeService_Delete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // List provides a mock function with given fields: ctx, options
 func (_m *MockChargeService) List(ctx context.Context, options domain.ChargeSearchOptions) ([]*domain.Charge, error) {
 	ret := _m.Called(ctx, options)

--- a/backend/pkg/errors/errors.go
+++ b/backend/pkg/errors/errors.go
@@ -64,6 +64,8 @@ const (
 	ErrorTagChargeTransactionTypeCannotChange                        ErrorTag = "TRANSACTION.CHARGE_TYPE_CANNOT_CHANGE"
 	ErrorTagChargeTransactionRecurrenceNotAllowed                    ErrorTag = "TRANSACTION.CHARGE_RECURRENCE_NOT_ALLOWED"
 
+	ErrorTagChargeCannotDeletePaid ErrorTag = "CHARGE.CANNOT_DELETE_PAID"
+
 	ErrorTagTagNameCannotBeEmpty ErrorTag = "TAG.NAME_CANNOT_BE_EMPTY"
 	ErrorTagFailedToCreateTag    ErrorTag = "TAG.FAILED_TO_CREATE"
 
@@ -141,6 +143,7 @@ var (
 	ErrLinkedTransactionDisallowedFieldChanged     = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagLinkedTransactionDisallowedFieldChanged)}, "linked transactions can only edit date, description, category, and tags")
 	ErrChargeTransactionTypeCannotChange           = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagChargeTransactionTypeCannotChange)}, "the type of a transaction linked to a charge cannot be changed")
 	ErrChargeTransactionRecurrenceNotAllowed       = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagChargeTransactionRecurrenceNotAllowed)}, "recurrence cannot be added to a transaction linked to a charge")
+	ErrChargeCannotDeletePaid                      = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagChargeCannotDeletePaid)}, "paid charges cannot be deleted")
 	ErrSettlementForbidden                         = NewWithTag(ErrCodeForbidden, []string{string(ErrorTagSettlementForbidden)}, "settlement belongs to another user")
 	ErrSettlementDateIsRequired                    = NewWithTag(ErrCodeBadRequest, []string{string(ErrorTagSettlementDateIsRequired)}, "date is required")
 

--- a/frontend/e2e/pages/ChargesPage.ts
+++ b/frontend/e2e/pages/ChargesPage.ts
@@ -13,6 +13,7 @@ export class ChargesPage {
   readonly acceptDrawer: Locator;
   readonly rejectModal: Locator;
   readonly cancelModal: Locator;
+  readonly deleteModal: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -20,6 +21,7 @@ export class ChargesPage {
     this.acceptDrawer = page.getByTestId(ChargesTestIds.DrawerAccept);
     this.rejectModal = page.getByTestId(ChargesTestIds.ModalConfirm('reject'));
     this.cancelModal = page.getByTestId(ChargesTestIds.ModalConfirm('cancel'));
+    this.deleteModal = page.getByTestId(ChargesTestIds.ModalConfirm('delete'));
   }
 
   async goto() {
@@ -151,6 +153,16 @@ export class ChargesPage {
   async confirmCancel() {
     await this.cancelModal.getByTestId(ChargesTestIds.BtnConfirm('cancel')).click();
     await expect(this.cancelModal).not.toBeVisible({ timeout: 10000 });
+  }
+
+  async clickDelete() {
+    await this.page.getByTestId(ChargesTestIds.BtnDelete).first().click();
+    await expect(this.deleteModal).toBeVisible({ timeout: 5000 });
+  }
+
+  async confirmDelete() {
+    await this.deleteModal.getByTestId(ChargesTestIds.BtnConfirm('delete')).click();
+    await expect(this.deleteModal).not.toBeVisible({ timeout: 10000 });
   }
 
   // --- Sidebar Badge ---

--- a/frontend/e2e/pages/ChargesPage.ts
+++ b/frontend/e2e/pages/ChargesPage.ts
@@ -155,8 +155,14 @@ export class ChargesPage {
     await expect(this.cancelModal).not.toBeVisible({ timeout: 10000 });
   }
 
-  async clickDelete() {
-    await this.page.getByTestId(ChargesTestIds.BtnDelete).first().click();
+  async clickDelete(chargeId: number) {
+    // Scope to the specific card: Mantine keeps inactive Tabs.Panels mounted
+    // (keepMounted defaults to true), so a page-wide `.first()` can resolve to a
+    // delete button inside the hidden Received/Sent panel and never become visible.
+    await this.page
+      .getByTestId(ChargesTestIds.Card(chargeId))
+      .getByTestId(ChargesTestIds.BtnDelete)
+      .click();
     await expect(this.deleteModal).toBeVisible({ timeout: 5000 });
   }
 

--- a/frontend/e2e/tests/charges.spec.ts
+++ b/frontend/e2e/tests/charges.spec.ts
@@ -252,6 +252,32 @@ test.describe("Charges", () => {
     await chargesPage.expectNotification(/Cobrança cancelada/);
   });
 
+  test("delete a sent charge", async ({ page }) => {
+    const description = `Delete Test ${Date.now()}`;
+
+    const charge = await apiCreateCharge({
+      connection_id: connectionId,
+      my_account_id: primaryAccountId,
+      period_month: PERIOD_MONTH,
+      period_year: PERIOD_YEAR,
+      description,
+      role: "charger" as const,
+      date: new Date().toISOString(),
+    });
+    createdChargeIds.push(charge.id);
+
+    await chargesPage.gotoMonth(PERIOD_MONTH, PERIOD_YEAR);
+    await chargesPage.selectSentTab();
+
+    await expect(page.getByTestId(ChargesTestIds.Card(charge.id))).toBeVisible();
+
+    await chargesPage.clickDelete();
+    await chargesPage.confirmDelete();
+
+    await chargesPage.expectNotification(/Cobrança excluída/);
+    await expect(page.getByTestId(ChargesTestIds.Card(charge.id))).not.toBeVisible({ timeout: 10000 });
+  });
+
   test("create charge via UI with arbitrary amount + charger role on zero balance", async ({ browser }) => {
     // Isolated user pair — the fresh primary will have exactly one connection and one account,
     // so the drawer selectors are unambiguous.

--- a/frontend/e2e/tests/charges.spec.ts
+++ b/frontend/e2e/tests/charges.spec.ts
@@ -271,7 +271,7 @@ test.describe("Charges", () => {
 
     await expect(page.getByTestId(ChargesTestIds.Card(charge.id))).toBeVisible();
 
-    await chargesPage.clickDelete();
+    await chargesPage.clickDelete(charge.id);
     await chargesPage.confirmDelete();
 
     await chargesPage.expectNotification(/Cobrança excluída/);

--- a/frontend/src/api/charges.ts
+++ b/frontend/src/api/charges.ts
@@ -63,3 +63,11 @@ export async function cancelCharge(id: number): Promise<void> {
   })
   if (!res.ok) throw res
 }
+
+export async function deleteCharge(id: number): Promise<void> {
+  const res = await fetch(`${apiUrl}/api/charges/${id}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  })
+  if (!res.ok) throw res
+}

--- a/frontend/src/components/charges/ChargeCard.tsx
+++ b/frontend/src/components/charges/ChargeCard.tsx
@@ -1,4 +1,5 @@
-import { Button, Card, Group, Stack, Text } from '@mantine/core'
+import { ActionIcon, Button, Card, Group, Stack, Text } from '@mantine/core'
+import { IconTrash } from '@tabler/icons-react'
 import { Charges } from '@/types/charges'
 import { formatBalance } from '@/utils/formatCents'
 import { ChargeStatusBadge } from './ChargeStatusBadge'
@@ -13,14 +14,17 @@ interface Props {
   onAccept?: () => void
   onReject?: () => void
   onCancel?: () => void
+  onDelete?: () => void
 }
 
-export function ChargeCard({ charge, currentUserId, partnerName, balanceAmount, onAccept, onReject, onCancel }: Props) {
+export function ChargeCard({ charge, currentUserId, partnerName, balanceAmount, onAccept, onReject, onCancel, onDelete }: Props) {
   // "Received" means the charge is awaiting MY action: I'm a party but I did
   // not initiate it. The initiator (whatever their charger/payer role) is the
   // one who can cancel; the counterparty is the one who accepts/rejects.
   const isReceived = charge.initiator_user_id !== currentUserId
   const isPending = charge.status === 'pending'
+  // Paid charges own settlement transfers and cannot be deleted.
+  const isDeletable = charge.status !== 'paid'
 
   const period =
     String(charge.period_month).padStart(2, '0') + '/' + charge.period_year
@@ -69,6 +73,18 @@ export function ChargeCard({ charge, currentUserId, partnerName, balanceAmount, 
             <Button size="xs" color="red" variant="light" onClick={onCancel} data-testid={ChargesTestIds.BtnCancel}>
               Cancelar
             </Button>
+          )}
+          {isDeletable && onDelete && (
+            <ActionIcon
+              size="lg"
+              color="red"
+              variant="subtle"
+              onClick={onDelete}
+              aria-label="Excluir cobrança"
+              data-testid={ChargesTestIds.BtnDelete}
+            >
+              <IconTrash size={16} />
+            </ActionIcon>
           )}
         </Group>
       </Group>

--- a/frontend/src/components/charges/ConfirmChargeActionDrawer.tsx
+++ b/frontend/src/components/charges/ConfirmChargeActionDrawer.tsx
@@ -2,10 +2,28 @@ import { Button, Group, Modal, Stack, Text } from '@mantine/core'
 import { useDrawerContext } from '@/utils/renderDrawer'
 import { ChargesTestIds } from '@/testIds'
 
-export type ConfirmChargeAction = 'reject' | 'cancel'
+export type ConfirmChargeAction = 'reject' | 'cancel' | 'delete'
 
 type Props = {
   action: ConfirmChargeAction
+}
+
+const COPY: Record<ConfirmChargeAction, { title: string; message: string; confirmLabel: string }> = {
+  reject: {
+    title: 'Recusar cobrança',
+    message: 'Tem certeza que deseja recusar esta cobrança? Esta acao nao pode ser desfeita.',
+    confirmLabel: 'Recusar',
+  },
+  cancel: {
+    title: 'Cancelar cobrança',
+    message: 'Tem certeza que deseja cancelar esta cobrança? Esta acao nao pode ser desfeita.',
+    confirmLabel: 'Cancelar cobrança',
+  },
+  delete: {
+    title: 'Excluir cobrança',
+    message: 'Tem certeza que deseja excluir esta cobrança? Esta acao nao pode ser desfeita.',
+    confirmLabel: 'Excluir',
+  },
 }
 
 /**
@@ -15,12 +33,7 @@ type Props = {
 export function ConfirmChargeActionDrawer({ action }: Props) {
   const { opened, close, reject } = useDrawerContext<void>()
 
-  const title = action === 'reject' ? 'Recusar cobrança' : 'Cancelar cobrança'
-  const message =
-    action === 'reject'
-      ? 'Tem certeza que deseja recusar esta cobrança? Esta acao nao pode ser desfeita.'
-      : 'Tem certeza que deseja cancelar esta cobrança? Esta acao nao pode ser desfeita.'
-  const confirmLabel = action === 'reject' ? 'Recusar' : 'Cancelar cobrança'
+  const { title, message, confirmLabel } = COPY[action]
 
   return (
     <Modal

--- a/frontend/src/hooks/useDeleteCharge.ts
+++ b/frontend/src/hooks/useDeleteCharge.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query'
+import { deleteCharge } from '@/api/charges'
+
+export function useDeleteCharge() {
+  const mutation = useMutation({
+    mutationFn: (id: number) => deleteCharge(id),
+  })
+  return { mutation }
+}

--- a/frontend/src/pages/ChargesPage.tsx
+++ b/frontend/src/pages/ChargesPage.tsx
@@ -11,6 +11,7 @@ import { useCharges } from "@/hooks/useCharges";
 import { useChargesPendingCount } from "@/hooks/useChargesPendingCount";
 import { useRejectCharge } from "@/hooks/useRejectCharge";
 import { useCancelCharge } from "@/hooks/useCancelCharge";
+import { useDeleteCharge } from "@/hooks/useDeleteCharge";
 import { renderDrawer } from "@/utils/renderDrawer";
 import { Fab } from "@/components/Fab";
 import { PullToRefresh } from "@/components/PullToRefresh";
@@ -56,6 +57,7 @@ export function ChargesPage() {
 
   const { mutation: rejectMutation } = useRejectCharge();
   const { mutation: cancelMutation } = useCancelCharge();
+  const { mutation: deleteMutation } = useDeleteCharge();
 
   function getPartnerName(charge: Charges.Charge): string {
     return partnerNameMapQuery.data?.get(charge.connection_id) ?? "Parceiro(a)";
@@ -72,7 +74,13 @@ export function ChargesPage() {
       return; // user dismissed the modal
     }
 
-    const mutation = action === "reject" ? rejectMutation : cancelMutation;
+    const mutation =
+      action === "reject" ? rejectMutation : action === "cancel" ? cancelMutation : deleteMutation;
+    const copy: Record<ConfirmChargeAction, { title: string; message: string }> = {
+      reject: { title: "Cobrança recusada", message: "Cobrança recusada com sucesso." },
+      cancel: { title: "Cobrança cancelada", message: "Cobrança cancelada com sucesso." },
+      delete: { title: "Cobrança excluída", message: "Cobrança excluída com sucesso." },
+    };
     mutation.mutate(charge.id, {
       onSuccess: () => {
         invalidateCharges();
@@ -80,11 +88,8 @@ export function ChargesPage() {
         invalidateTransactions();
         notifications.show({
           color: "teal",
-          title: action === "reject" ? "Cobrança recusada" : "Cobrança cancelada",
-          message:
-            action === "reject"
-              ? "Cobrança recusada com sucesso."
-              : "Cobrança cancelada com sucesso.",
+          title: copy[action].title,
+          message: copy[action].message,
           autoClose: 3000,
         });
       },
@@ -171,6 +176,7 @@ export function ChargesPage() {
                   balanceAmount={charge.amount}
                   onAccept={() => handleAccept(charge)}
                   onReject={() => void handleChargeAction("reject", charge)}
+                  onDelete={() => void handleChargeAction("delete", charge)}
                 />
               ))}
             </Stack>
@@ -203,6 +209,7 @@ export function ChargesPage() {
                   partnerName={getPartnerName(charge)}
                   balanceAmount={charge.amount}
                   onCancel={() => void handleChargeAction("cancel", charge)}
+                  onDelete={() => void handleChargeAction("delete", charge)}
                 />
               ))}
             </Stack>

--- a/frontend/src/testIds/charges.ts
+++ b/frontend/src/testIds/charges.ts
@@ -1,4 +1,4 @@
-export type ChargeAction = 'reject' | 'cancel'
+export type ChargeAction = 'reject' | 'cancel' | 'delete'
 export type ChargeRole = 'charger' | 'payer'
 export type ChargesTab = 'received' | 'sent'
 
@@ -13,6 +13,7 @@ export const ChargesTestIds = {
   BtnAccept: 'btn_accept_charge',
   BtnReject: 'btn_reject_charge',
   BtnCancel: 'btn_cancel_charge',
+  BtnDelete: 'btn_delete_charge',
   SelectConnection: 'select_connection',
   SelectMyAccount: 'select_my_account',
   RadioRole: (role: ChargeRole) => `radio_role_${role}` as const,


### PR DESCRIPTION
## Summary

PR 2 of 2 for issue #199. Adds the ability to delete charges that were never accepted. Independent of PR #203 (accounts) — branches off `main`.

### Behavior
- New `DELETE /api/charges/:id`. Either party (charger or payer) may permanently delete a charge **while it is pending, rejected, or cancelled**.
- **Paid charges cannot be deleted** (`CHARGE.CANNOT_DELETE_PAID`) — accepting a charge creates settlement transfer transactions that must be preserved.
- IDOR-gated to the charge's parties.

### UI
- Charge cards show a trash action for any non-paid charge. Confirming routes through the existing `ConfirmChargeActionDrawer` (extended with a `delete` action) → `DELETE /api/charges/:id`, then invalidates the charge list and pending count and shows a success notification.

## Testing
- Backend: `go build ./...` ✅, `go test -short ./...` (unit) ✅. New integration tests in `charge_service_test.go` cover delete by either party (pending), rejected/cancelled, paid-is-blocked, and non-party-forbidden. Integration tests run in CI (Docker/testcontainers not available in the authoring sandbox).
- Frontend: `npm run build` ✅, `npm run lint` ✅ (2 pre-existing warnings unrelated), e2e tsc ✅. Added a `deleteCharge` page-object helper + a "delete a sent charge" spec.
- Mocks and Swagger regenerated.

https://claude.ai/code/session_01VK4TVzpyYffvCwWVB6yBe8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VK4TVzpyYffvCwWVB6yBe8)_