### PR TITLE
feat(frontend): Página Inicial com indicadores por período (#198)

### DIFF
--- a/frontend/e2e/pages/HomePage.ts
+++ b/frontend/e2e/pages/HomePage.ts
@@ -1,0 +1,23 @@
+import { type Page, type Locator, expect } from '@playwright/test'
+import { HomeTestIds } from '@/testIds'
+
+export class HomePage {
+  readonly page: Page
+
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  async goto(month: number, year: number) {
+    await this.page.goto(`/home?month=${month}&year=${year}`)
+    await expect(this.page.getByTestId(HomeTestIds.Page)).toBeVisible()
+  }
+
+  accountRow(accountId: number): Locator {
+    return this.page.getByTestId(HomeTestIds.AccountRow(accountId))
+  }
+
+  section(testId: string): Locator {
+    return this.page.getByTestId(testId)
+  }
+}

--- a/frontend/e2e/tests/home.spec.ts
+++ b/frontend/e2e/tests/home.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test'
+import {
+  apiFetchAs,
+  apiCreateTransaction,
+  getAuthTokenForUser,
+  openAuthedPage,
+} from '../helpers/api'
+import { HomePage } from '../pages/HomePage'
+import { HomeTestIds } from '@/testIds'
+
+const MONTH = 4
+const YEAR = 2026
+const DATE = `${YEAR}-0${MONTH}-15` // 2026-04-15
+
+async function createAccount(token: string, name: string): Promise<number> {
+  const res = await apiFetchAs(token, '/api/accounts', {
+    method: 'POST',
+    body: JSON.stringify({ name, initial_balance: 100000 }),
+  })
+  return ((await res.json()) as { id: number }).id
+}
+
+async function createCategory(token: string, name: string): Promise<number> {
+  const res = await apiFetchAs(token, '/api/categories', {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  })
+  return ((await res.json()) as { id: number }).id
+}
+
+test('home dashboard renders period summaries and account rows deep-link to the filtered transactions', async ({
+  browser,
+}) => {
+  const stamp = Date.now()
+  const token = await getAuthTokenForUser(`e2e-home-${stamp}@financeapp.local`)
+
+  const accountId = await createAccount(token, `Conta Home ${stamp}`)
+  const foodCat = await createCategory(token, `Alimentação ${stamp}`)
+  const salaryCat = await createCategory(token, `Salário ${stamp}`)
+
+  // An expense (feeds the category pie + income/expense flow).
+  await apiCreateTransaction(
+    {
+      transaction_type: 'expense',
+      account_id: accountId,
+      category_id: foodCat,
+      amount: 25000,
+      date: DATE,
+      description: `Supermercado ${stamp}`,
+    },
+    { token },
+  )
+  // An income (feeds the Sankey income flow).
+  await apiCreateTransaction(
+    {
+      transaction_type: 'income',
+      account_id: accountId,
+      category_id: salaryCat,
+      amount: 500000,
+      date: DATE,
+      description: `Salário ${stamp}`,
+    },
+    { token },
+  )
+  // A recurring expense whose first installment lands in the period.
+  await apiCreateTransaction(
+    {
+      transaction_type: 'expense',
+      account_id: accountId,
+      category_id: foodCat,
+      amount: 12000,
+      date: DATE,
+      description: `Assinatura ${stamp}`,
+      recurrence_settings: { type: 'monthly', current_installment: 1, total_installments: 3 },
+    },
+    { token },
+  )
+
+  const page = await openAuthedPage(browser, token)
+  const home = new HomePage(page)
+  await home.goto(MONTH, YEAR)
+
+  // All dashboard sections are present.
+  await expect(home.section(HomeTestIds.AccountBalancesSection)).toBeVisible()
+  await expect(home.section(HomeTestIds.ExpenseChartSection)).toBeVisible()
+  await expect(home.section(HomeTestIds.IncomeFlowSection)).toBeVisible()
+  await expect(home.section(HomeTestIds.RecurringStartingSection)).toBeVisible()
+
+  // Expense category appears in the pie legend.
+  await expect(home.section(HomeTestIds.ExpenseChartSection)).toContainText(`Alimentação ${stamp}`)
+
+  // The recurring expense starting this period is listed.
+  await expect(home.section(HomeTestIds.RecurringStartingSection)).toContainText(`Assinatura ${stamp}`)
+
+  // Clicking an account row deep-links to its filtered transaction list.
+  await home.accountRow(accountId).click()
+  await expect(page).toHaveURL(/\/transactions\?.*accountIds/)
+  await expect(page).toHaveURL(new RegExp(String(accountId)))
+
+  await page.close()
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.55.0",
+        "recharts": "^3.8.1",
         "zod": "^4.3.6",
         "zustand": "^5.0.13"
       },
@@ -2903,6 +2904,42 @@
         "node": ">=18"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -3404,7 +3441,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -3991,6 +4027,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4075,6 +4174,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5114,6 +5219,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -5249,6 +5475,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -5563,6 +5795,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
+      "integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -5886,6 +6128,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -6483,6 +6731,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6523,6 +6781,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7942,6 +8209,29 @@
         "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -8087,6 +8377,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8198,6 +8533,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -9496,6 +9837,28 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.55.0",
+    "recharts": "^3.8.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.13"
   },

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -47,7 +47,7 @@ export function AppLayout() {
         }}
       >
         <Group h="100%" px="md" justify="space-between" wrap="nowrap">
-          <Link to="/transactions" style={{ textDecoration: "none" }}>
+          <Link to="/home" style={{ textDecoration: "none" }}>
             <Group gap="xs" wrap="nowrap">
               <img src="/icon.svg" width={24} height={24} alt="FinanceApp" />
               <Text fw={700} size="sm" c="blue.7">

--- a/frontend/src/components/DesktopSidebar.tsx
+++ b/frontend/src/components/DesktopSidebar.tsx
@@ -3,6 +3,7 @@ import { NotificationToggleRow } from "@/components/notifications/NotificationTo
 import {
   IconBell,
   IconCreditCard,
+  IconHome,
   IconReceipt2,
   IconTree,
   IconWallet,
@@ -33,6 +34,7 @@ type NavLinkDef = {
 };
 
 const navLinks: NavLinkDef[] = [
+  { to: "/home", label: "Início", icon: IconHome },
   { to: "/transactions", label: "Transações", icon: IconReceipt2 },
   { to: "/accounts", label: "Contas", icon: IconWallet },
   { to: "/categories", label: "Categorias", icon: IconTree },
@@ -93,7 +95,7 @@ export function DesktopSidebar() {
 
   return (
     <nav className={classes.sidebar} aria-label="Navegação lateral">
-      <Link to="/transactions" className={classes.brand} data-testid={CommonTestIds.SidebarBrand}>
+      <Link to="/home" className={classes.brand} data-testid={CommonTestIds.SidebarBrand}>
         <img src="/icon.svg" width={28} height={28} alt="FinanceApp" />
         <span className={classes.brandText}>FinanceApp</span>
       </Link>

--- a/frontend/src/components/MobileTabBar.tsx
+++ b/frontend/src/components/MobileTabBar.tsx
@@ -1,5 +1,6 @@
 import { Badge, Indicator, UnstyledButton } from '@mantine/core'
 import {
+  IconHome,
   IconReceipt2,
   IconWallet,
   IconTree,
@@ -24,6 +25,7 @@ type Tab = {
 }
 
 const tabs: Tab[] = [
+  { to: '/home', label: 'Início', icon: IconHome },
   { to: '/transactions', label: 'Transações', icon: IconReceipt2 },
   { to: '/accounts', label: 'Contas', icon: IconWallet },
   { to: '/categories', label: 'Categorias', icon: IconTree },

--- a/frontend/src/components/home/AccountBalanceRow.module.css
+++ b/frontend/src/components/home/AccountBalanceRow.module.css
@@ -1,0 +1,13 @@
+.row {
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.row:hover {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+}
+
+.amountCell {
+  text-align: right;
+  white-space: nowrap;
+}

--- a/frontend/src/components/home/AccountBalanceRow.tsx
+++ b/frontend/src/components/home/AccountBalanceRow.tsx
@@ -1,0 +1,53 @@
+import { Group, Skeleton, Table, Text } from '@mantine/core'
+import { useBalance } from '@/hooks/useBalance'
+import { AccountAvatar } from '@/components/AccountAvatar'
+import { formatBalance } from '@/utils/formatCents'
+import { Transactions } from '@/types/transactions'
+import { HomeTestIds } from '@/testIds'
+import classes from './AccountBalanceRow.module.css'
+
+interface Props {
+  account: Transactions.Account
+  month: number
+  year: number
+  accumulated: boolean
+  onSelect: (accountId: number) => void
+}
+
+export function AccountBalanceRow({ account, month, year, accumulated, onSelect }: Props) {
+  const { query } = useBalance(
+    { month, year, accumulated, accountIds: [account.id] },
+    (data) => data.balance,
+  )
+
+  const balance = query.data
+
+  return (
+    <Table.Tr
+      className={classes.row}
+      onClick={() => onSelect(account.id)}
+      data-testid={HomeTestIds.AccountRow(account.id)}
+    >
+      <Table.Td>
+        <Group gap="sm" wrap="nowrap">
+          <AccountAvatar account={account} size="md" />
+          <div style={{ minWidth: 0 }}>
+            <Text fw={600} truncate>{account.name}</Text>
+            {account.description && (
+              <Text size="xs" c="dimmed" truncate>{account.description}</Text>
+            )}
+          </div>
+        </Group>
+      </Table.Td>
+      <Table.Td className={classes.amountCell}>
+        {query.isLoading || balance === undefined ? (
+          <Skeleton height={18} width={90} ml="auto" />
+        ) : (
+          <Text fw={600} c={balance >= 0 ? 'teal' : 'red'}>
+            {formatBalance(balance)}
+          </Text>
+        )}
+      </Table.Td>
+    </Table.Tr>
+  )
+}

--- a/frontend/src/components/home/AccountBalancesCard.tsx
+++ b/frontend/src/components/home/AccountBalancesCard.tsx
@@ -1,4 +1,4 @@
-import { Switch, Table, Text } from '@mantine/core'
+import { Group, Switch, Table, Text } from '@mantine/core'
 import { useAccounts } from '@/hooks/useAccounts'
 import { useBalance } from '@/hooks/useBalance'
 import { formatBalance } from '@/utils/formatCents'
@@ -38,14 +38,16 @@ export function AccountBalancesCard({
       title="Saldo das contas"
       testId={HomeTestIds.AccountBalancesSection}
       action={
-        <Switch
-          size="sm"
-          checked={accumulated}
-          onChange={(e) => onAccumulatedChange(e.currentTarget.checked)}
-          label="Acumulado"
-          labelPosition="left"
-          data-testid={HomeTestIds.AccumulatedToggle}
-        />
+        <Group gap={8} wrap="nowrap" align="center">
+          <Text size="sm">Acumulado</Text>
+          <Switch
+            size="sm"
+            checked={accumulated}
+            onChange={(e) => onAccumulatedChange(e.currentTarget.checked)}
+            aria-label="Acumulado"
+            data-testid={HomeTestIds.AccumulatedToggle}
+          />
+        </Group>
       }
     >
       {accounts.length === 0 ? (

--- a/frontend/src/components/home/AccountBalancesCard.tsx
+++ b/frontend/src/components/home/AccountBalancesCard.tsx
@@ -1,0 +1,84 @@
+import { Switch, Table, Text } from '@mantine/core'
+import { useAccounts } from '@/hooks/useAccounts'
+import { useBalance } from '@/hooks/useBalance'
+import { formatBalance } from '@/utils/formatCents'
+import { DashboardCard } from './DashboardCard'
+import { AccountBalanceRow } from './AccountBalanceRow'
+import { HomeTestIds } from '@/testIds'
+
+interface Props {
+  month: number
+  year: number
+  accumulated: boolean
+  onAccumulatedChange: (value: boolean) => void
+  onSelectAccount: (accountId: number) => void
+}
+
+export function AccountBalancesCard({
+  month,
+  year,
+  accumulated,
+  onAccumulatedChange,
+  onSelectAccount,
+}: Props) {
+  const { query } = useAccounts((accounts) => accounts.filter((a) => a.is_active))
+  const accounts = query.data ?? []
+  const accountIds = accounts.map((a) => a.id)
+
+  // The balance endpoint sums across the given account_ids, so a single query
+  // over every active account gives the grand total without re-aggregating rows.
+  const { query: totalQuery } = useBalance(
+    { month, year, accumulated, accountIds },
+    (data) => data.balance,
+  )
+  const total = totalQuery.data
+
+  return (
+    <DashboardCard
+      title="Saldo das contas"
+      testId={HomeTestIds.AccountBalancesSection}
+      action={
+        <Switch
+          size="sm"
+          checked={accumulated}
+          onChange={(e) => onAccumulatedChange(e.currentTarget.checked)}
+          label="Acumulado"
+          data-testid={HomeTestIds.AccumulatedToggle}
+        />
+      }
+    >
+      {accounts.length === 0 ? (
+        <Text c="dimmed" ta="center" py="sm">Nenhuma conta ativa</Text>
+      ) : (
+        <Table verticalSpacing="sm" highlightOnHoverColor="transparent">
+          <Table.Tbody>
+            {accounts.map((account) => (
+              <AccountBalanceRow
+                key={account.id}
+                account={account}
+                month={month}
+                year={year}
+                accumulated={accumulated}
+                onSelect={onSelectAccount}
+              />
+            ))}
+          </Table.Tbody>
+          {accounts.length > 1 && (
+            <Table.Tfoot>
+              <Table.Tr>
+                <Table.Td>
+                  <Text fw={700}>Total</Text>
+                </Table.Td>
+                <Table.Td style={{ textAlign: 'right' }}>
+                  <Text fw={700} c={(total ?? 0) >= 0 ? 'teal' : 'red'} data-testid={HomeTestIds.AccountBalancesTotal}>
+                    {total === undefined ? '—' : formatBalance(total)}
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            </Table.Tfoot>
+          )}
+        </Table>
+      )}
+    </DashboardCard>
+  )
+}

--- a/frontend/src/components/home/AccountBalancesCard.tsx
+++ b/frontend/src/components/home/AccountBalancesCard.tsx
@@ -43,6 +43,7 @@ export function AccountBalancesCard({
           checked={accumulated}
           onChange={(e) => onAccumulatedChange(e.currentTarget.checked)}
           label="Acumulado"
+          labelPosition="left"
           data-testid={HomeTestIds.AccumulatedToggle}
         />
       }

--- a/frontend/src/components/home/DashboardCard.tsx
+++ b/frontend/src/components/home/DashboardCard.tsx
@@ -1,0 +1,25 @@
+import { Card, Group, Stack, Text } from '@mantine/core'
+import type { ReactNode } from 'react'
+
+interface Props {
+  title: string
+  /** Optional control rendered on the right of the header (e.g. a toggle). */
+  action?: ReactNode
+  children: ReactNode
+  testId?: string
+}
+
+/** Consistent section container for the home dashboard cards. */
+export function DashboardCard({ title, action, children, testId }: Props) {
+  return (
+    <Card withBorder radius="md" p="md" data-testid={testId}>
+      <Stack gap="sm">
+        <Group justify="space-between" align="center" wrap="nowrap" gap="sm">
+          <Text fw={700}>{title}</Text>
+          {action}
+        </Group>
+        {children}
+      </Stack>
+    </Card>
+  )
+}

--- a/frontend/src/components/home/ExpenseDonutCard.module.css
+++ b/frontend/src/components/home/ExpenseDonutCard.module.css
@@ -1,0 +1,15 @@
+.tooltip {
+  background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
+  border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  border-radius: var(--mantine-radius-sm);
+  padding: 6px 10px;
+  box-shadow: var(--mantine-shadow-sm);
+}
+
+.swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/home/ExpenseDonutCard.tsx
+++ b/frontend/src/components/home/ExpenseDonutCard.tsx
@@ -55,14 +55,16 @@ export function ExpenseDonutCard({ month, year, hideSettlements, onHideSettlemen
       title="Despesas por categoria"
       testId={HomeTestIds.ExpenseChartSection}
       action={
-        <Switch
-          size="sm"
-          checked={!hideSettlements}
-          onChange={(e) => onHideSettlementsChange(!e.currentTarget.checked)}
-          label="Considerar acertos"
-          labelPosition="left"
-          data-testid={HomeTestIds.SettlementsToggle}
-        />
+        <Group gap={8} wrap="nowrap" align="center">
+          <Text size="sm" ta="right">Considerar acertos</Text>
+          <Switch
+            size="sm"
+            checked={!hideSettlements}
+            onChange={(e) => onHideSettlementsChange(!e.currentTarget.checked)}
+            aria-label="Considerar acertos"
+            data-testid={HomeTestIds.SettlementsToggle}
+          />
+        </Group>
       }
     >
       {isLoading ? (

--- a/frontend/src/components/home/ExpenseDonutCard.tsx
+++ b/frontend/src/components/home/ExpenseDonutCard.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from 'react'
+import { Box, Center, Group, Loader, Stack, Switch, Text } from '@mantine/core'
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
+import { useCategorySpending } from '@/hooks/useCategorySpending'
+import { formatBalance } from '@/utils/formatCents'
+import { DashboardCard } from './DashboardCard'
+import { HomeTestIds } from '@/testIds'
+import classes from './ExpenseDonutCard.module.css'
+
+interface Props {
+  month: number
+  year: number
+  /** When true, settlements are ignored in the aggregation. */
+  hideSettlements: boolean
+  onHideSettlementsChange: (value: boolean) => void
+}
+
+interface Slice {
+  name: string
+  value: number
+  color: string
+}
+
+function DonutTooltip({ active, payload, total }: {
+  active?: boolean
+  payload?: Array<{ payload: Slice }>
+  total: number
+}) {
+  if (!active || !payload?.length) return null
+  const slice = payload[0].payload
+  const pct = total > 0 ? Math.round((slice.value / total) * 100) : 0
+  return (
+    <div className={classes.tooltip}>
+      <Text size="sm" fw={600}>{slice.name}</Text>
+      <Text size="sm">{formatBalance(slice.value)} · {pct}%</Text>
+    </div>
+  )
+}
+
+export function ExpenseDonutCard({ month, year, hideSettlements, onHideSettlementsChange }: Props) {
+  const { nodes, categoriesLoading, spendLoading } = useCategorySpending(month, year, { hideSettlements })
+  const isLoading = categoriesLoading || spendLoading
+
+  const { slices, total } = useMemo(() => {
+    const slices: Slice[] = nodes
+      .filter((n) => n.total < 0)
+      .map((n) => ({ name: n.category.name, value: -n.total, color: n.color }))
+      .sort((a, b) => b.value - a.value)
+    const total = slices.reduce((s, x) => s + x.value, 0)
+    return { slices, total }
+  }, [nodes])
+
+  return (
+    <DashboardCard
+      title="Despesas por categoria"
+      testId={HomeTestIds.ExpenseChartSection}
+      action={
+        <Switch
+          size="sm"
+          checked={!hideSettlements}
+          onChange={(e) => onHideSettlementsChange(!e.currentTarget.checked)}
+          label="Considerar acertos"
+          data-testid={HomeTestIds.SettlementsToggle}
+        />
+      }
+    >
+      {isLoading ? (
+        <Center h={260}><Loader size="sm" /></Center>
+      ) : slices.length === 0 ? (
+        <Text c="dimmed" ta="center" py="xl">Nenhuma despesa no período</Text>
+      ) : (
+        <Stack gap="sm">
+          <Box h={240} data-testid={HomeTestIds.ExpenseChart}>
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={slices}
+                  dataKey="value"
+                  nameKey="name"
+                  innerRadius="55%"
+                  outerRadius="85%"
+                  paddingAngle={1}
+                  stroke="none"
+                  isAnimationActive={false}
+                >
+                  {slices.map((s) => (
+                    <Cell key={s.name} fill={s.color} />
+                  ))}
+                </Pie>
+                <Tooltip content={<DonutTooltip total={total} />} />
+              </PieChart>
+            </ResponsiveContainer>
+          </Box>
+          <Stack gap={4}>
+            {slices.map((s) => {
+              const pct = total > 0 ? Math.round((s.value / total) * 100) : 0
+              return (
+                <Group key={s.name} justify="space-between" wrap="nowrap" gap="xs">
+                  <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+                    <span className={classes.swatch} style={{ backgroundColor: s.color }} />
+                    <Text size="sm" truncate>{s.name}</Text>
+                  </Group>
+                  <Text size="sm" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+                    {formatBalance(s.value)} · {pct}%
+                  </Text>
+                </Group>
+              )
+            })}
+          </Stack>
+        </Stack>
+      )}
+    </DashboardCard>
+  )
+}

--- a/frontend/src/components/home/ExpenseDonutCard.tsx
+++ b/frontend/src/components/home/ExpenseDonutCard.tsx
@@ -60,6 +60,7 @@ export function ExpenseDonutCard({ month, year, hideSettlements, onHideSettlemen
           checked={!hideSettlements}
           onChange={(e) => onHideSettlementsChange(!e.currentTarget.checked)}
           label="Considerar acertos"
+          labelPosition="left"
           data-testid={HomeTestIds.SettlementsToggle}
         />
       }

--- a/frontend/src/components/home/IncomeSankeyCard.tsx
+++ b/frontend/src/components/home/IncomeSankeyCard.tsx
@@ -49,7 +49,9 @@ function renderSankeyNode(rawProps: unknown): ReactNode {
     anchor = 'end'
   } else if (node.kind === 'hub') {
     labelX = x + width / 2
-    labelY = y - 8
+    // The hub is the tallest node and sits at the very top, so anchor the label
+    // just below the chart's top edge instead of above the node (which clips).
+    labelY = Math.max(y - 12, 14)
     anchor = 'middle'
   } else {
     labelX = x + width + 6
@@ -126,7 +128,7 @@ export function IncomeSankeyCard({ month, year }: Props) {
                 link={renderSankeyLink}
                 nodePadding={24}
                 nodeWidth={10}
-                margin={{ top: 8, right: 90, bottom: 8, left: 90 }}
+                margin={{ top: 30, right: 90, bottom: 8, left: 90 }}
               >
                 <Tooltip content={<SankeyTooltip />} />
               </Sankey>

--- a/frontend/src/components/home/IncomeSankeyCard.tsx
+++ b/frontend/src/components/home/IncomeSankeyCard.tsx
@@ -1,0 +1,146 @@
+import type { ReactNode, ReactElement } from 'react'
+import type { SVGProps } from 'react'
+import { Box, Center, Group, Loader, Stack, Text } from '@mantine/core'
+import { Sankey, Tooltip, ResponsiveContainer, Layer, Rectangle } from 'recharts'
+import { useIncomeExpenseFlow, type FlowNode } from '@/hooks/useIncomeExpenseFlow'
+import { formatBalance } from '@/utils/formatCents'
+import { DashboardCard } from './DashboardCard'
+import { HomeTestIds } from '@/testIds'
+import classes from './ExpenseDonutCard.module.css'
+
+interface Props {
+  month: number
+  year: number
+}
+
+// recharts doesn't export its Sankey node/link prop types from the package root,
+// and it injects our extra node fields (color, kind) at runtime since data.nodes
+// is untyped. Type the renderer params with the shape we read; `unknown` keeps
+// them assignable to recharts' expected (props) => ReactNode signature.
+interface SankeyNodeRenderProps {
+  x: number
+  y: number
+  width: number
+  height: number
+  index: number
+  payload: FlowNode
+}
+
+interface SankeyLinkRenderProps {
+  sourceX: number
+  targetX: number
+  sourceY: number
+  targetY: number
+  sourceControlX: number
+  targetControlX: number
+  linkWidth: number
+  index: number
+  payload: { color?: string }
+}
+
+function renderSankeyNode(rawProps: unknown): ReactNode {
+  const { x, y, width, height, payload, index } = rawProps as SankeyNodeRenderProps
+  const node = payload
+  let labelX: number
+  let labelY = y + height / 2
+  let anchor: 'start' | 'end' | 'middle'
+  if (node.kind === 'income') {
+    labelX = x - 6
+    anchor = 'end'
+  } else if (node.kind === 'hub') {
+    labelX = x + width / 2
+    labelY = y - 8
+    anchor = 'middle'
+  } else {
+    labelX = x + width + 6
+    anchor = 'start'
+  }
+  return (
+    <Layer key={`node-${index}`}>
+      <Rectangle x={x} y={y} width={width} height={height} fill={node.color} fillOpacity={0.9} radius={2} />
+      <text
+        x={labelX}
+        y={labelY}
+        textAnchor={anchor}
+        dominantBaseline="middle"
+        fontSize={11}
+        fill="var(--mantine-color-text)"
+      >
+        {node.name}
+      </text>
+    </Layer>
+  )
+}
+
+function renderSankeyLink(rawProps: unknown): ReactElement<SVGProps<SVGPathElement>> {
+  const { sourceX, targetX, sourceY, targetY, sourceControlX, targetControlX, linkWidth, payload, index } =
+    rawProps as SankeyLinkRenderProps
+  const color = payload.color ?? '#888'
+  return (
+    <path
+      key={`link-${index}`}
+      d={`M${sourceX},${sourceY}C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}`}
+      stroke={color}
+      strokeWidth={Math.max(1, linkWidth)}
+      strokeOpacity={0.35}
+      fill="none"
+    />
+  )
+}
+
+function SankeyTooltip({ active, payload }: {
+  active?: boolean
+  payload?: Array<{ payload: { value?: number; name?: string } }>
+}) {
+  if (!active || !payload?.length) return null
+  const data = payload[0].payload
+  if (data.value == null) return null
+  return (
+    <div className={classes.tooltip}>
+      {data.name && <Text size="sm" fw={600}>{data.name}</Text>}
+      <Text size="sm">{formatBalance(data.value)}</Text>
+    </div>
+  )
+}
+
+export function IncomeSankeyCard({ month, year }: Props) {
+  const { nodes, links, totalIncome, totalExpense, leftover, hasData, isLoading } =
+    useIncomeExpenseFlow(month, year)
+
+  // Grow the chart with the number of nodes so labels don't overlap.
+  const height = Math.max(260, nodes.length * 28)
+
+  return (
+    <DashboardCard title="Distribuição da receita" testId={HomeTestIds.IncomeFlowSection}>
+      {isLoading ? (
+        <Center h={260}><Loader size="sm" /></Center>
+      ) : !hasData ? (
+        <Text c="dimmed" ta="center" py="xl">Nenhuma receita no período</Text>
+      ) : (
+        <Stack gap="sm">
+          <Box h={height} data-testid={HomeTestIds.IncomeFlowChart}>
+            <ResponsiveContainer width="100%" height="100%">
+              <Sankey
+                data={{ nodes, links }}
+                node={renderSankeyNode}
+                link={renderSankeyLink}
+                nodePadding={24}
+                nodeWidth={10}
+                margin={{ top: 8, right: 90, bottom: 8, left: 90 }}
+              >
+                <Tooltip content={<SankeyTooltip />} />
+              </Sankey>
+            </ResponsiveContainer>
+          </Box>
+          <Group justify="space-between" wrap="wrap" gap="md">
+            <Text size="sm" c="teal">Receitas: {formatBalance(totalIncome)}</Text>
+            <Text size="sm" c="red">Despesas: {formatBalance(totalExpense)}</Text>
+            <Text size="sm" c={leftover >= 0 ? 'teal' : 'red'} fw={600}>
+              {leftover >= 0 ? 'Sobra' : 'Déficit'}: {formatBalance(leftover)}
+            </Text>
+          </Group>
+        </Stack>
+      )}
+    </DashboardCard>
+  )
+}

--- a/frontend/src/components/home/IncomeSankeyCard.tsx
+++ b/frontend/src/components/home/IncomeSankeyCard.tsx
@@ -3,6 +3,7 @@ import type { SVGProps } from 'react'
 import { Box, Center, Group, Loader, Stack, Text } from '@mantine/core'
 import { Sankey, Tooltip, ResponsiveContainer, Layer, Rectangle } from 'recharts'
 import { useIncomeExpenseFlow, type FlowNode } from '@/hooks/useIncomeExpenseFlow'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { formatBalance } from '@/utils/formatCents'
 import { DashboardCard } from './DashboardCard'
 import { HomeTestIds } from '@/testIds'
@@ -108,9 +109,13 @@ function SankeyTooltip({ active, payload }: {
 export function IncomeSankeyCard({ month, year }: Props) {
   const { nodes, links, totalIncome, totalExpense, leftover, hasData, isLoading } =
     useIncomeExpenseFlow(month, year)
+  const isMobile = useIsMobile()
 
   // Grow the chart with the number of nodes so labels don't overlap.
   const height = Math.max(260, nodes.length * 28)
+  // Side margins reserve room for the income/expense labels; trim them on
+  // mobile so the flow isn't squeezed into a thin strip.
+  const sideMargin = isMobile ? 60 : 90
 
   return (
     <DashboardCard title="Distribuição da receita" testId={HomeTestIds.IncomeFlowSection}>
@@ -128,7 +133,7 @@ export function IncomeSankeyCard({ month, year }: Props) {
                 link={renderSankeyLink}
                 nodePadding={24}
                 nodeWidth={10}
-                margin={{ top: 30, right: 90, bottom: 8, left: 90 }}
+                margin={{ top: 30, right: sideMargin, bottom: 8, left: sideMargin }}
               >
                 <Tooltip content={<SankeyTooltip />} />
               </Sankey>

--- a/frontend/src/components/home/RecurringTransactionsCard.tsx
+++ b/frontend/src/components/home/RecurringTransactionsCard.tsx
@@ -1,0 +1,66 @@
+import { Badge, Center, Divider, Group, Loader, Stack, Text } from '@mantine/core'
+import { formatBalance, formatCents } from '@/utils/formatCents'
+import { Transactions } from '@/types/transactions'
+import { DashboardCard } from './DashboardCard'
+import { HomeTestIds } from '@/testIds'
+
+interface Props {
+  title: string
+  transactions: Transactions.Transaction[]
+  total: number
+  isLoading: boolean
+  emptyLabel: string
+  testId: string
+  totalTestId: string
+}
+
+export function RecurringTransactionsCard({
+  title,
+  transactions,
+  total,
+  isLoading,
+  emptyLabel,
+  testId,
+  totalTestId,
+}: Props) {
+  return (
+    <DashboardCard
+      title={title}
+      testId={testId}
+      action={transactions.length > 0 ? <Badge variant="light" color="gray">{transactions.length}</Badge> : undefined}
+    >
+      {isLoading ? (
+        <Center py="md"><Loader size="sm" /></Center>
+      ) : transactions.length === 0 ? (
+        <Text c="dimmed" ta="center" py="sm">{emptyLabel}</Text>
+      ) : (
+        <Stack gap="xs">
+          {transactions.map((t) => (
+            <Group
+              key={t.id}
+              justify="space-between"
+              wrap="nowrap"
+              gap="sm"
+              data-testid={HomeTestIds.RecurringRow(t.id)}
+            >
+              <div style={{ minWidth: 0 }}>
+                <Text size="sm" fw={500} truncate>{t.description}</Text>
+                <Text size="xs" c="dimmed">
+                  Parcela {t.installment_number}/{t.transaction_recurrence?.installments}
+                </Text>
+              </div>
+              <Text size="sm" fw={600} c={t.operation_type === 'credit' ? 'teal' : 'red'} style={{ whiteSpace: 'nowrap' }}>
+                {formatCents(t.amount, t.operation_type)}
+              </Text>
+            </Group>
+          ))}
+          <Divider />
+          <Group justify="space-between">
+            <Text size="sm" fw={700}>Total</Text>
+            <Text size="sm" fw={700} data-testid={totalTestId}>{formatBalance(total)}</Text>
+          </Group>
+        </Stack>
+      )}
+    </DashboardCard>
+  )
+}

--- a/frontend/src/hooks/useCategorySpending.ts
+++ b/frontend/src/hooks/useCategorySpending.ts
@@ -45,7 +45,22 @@ export interface CategorySpending {
  * participation. Aggregation is frontend-only: it reuses the existing
  * "transactions for a period" endpoint (expense + income, never transfers).
  */
-export function useCategorySpending(month: number, year: number): CategorySpending {
+export interface CategorySpendingOptions {
+  /**
+   * When true, settlements are ignored so each category reflects the raw
+   * income/expense amounts (the "não considerar acertos" toggle on the home
+   * dashboard). Defaults to false, matching the backend balance endpoint which
+   * nets settlements into the source transaction's category.
+   */
+  hideSettlements?: boolean
+}
+
+export function useCategorySpending(
+  month: number,
+  year: number,
+  options: CategorySpendingOptions = {},
+): CategorySpending {
+  const { hideSettlements = false } = options
   const { query: categoriesQuery, invalidate } = useCategories()
   const { query: transactionsQuery } = useTransactions({ month, year, types: ['expense', 'income'] })
 
@@ -60,15 +75,17 @@ export function useCategorySpending(month: number, year: number): CategorySpendi
     // debit (expense / owed settlement) subtracts. Transfers are filtered out;
     // settlements have no category, so they net into the source transaction's
     // category — matching how the backend balance endpoint nets the settlement
-    // leg.
+    // leg (unless hideSettlements is set, which ignores them entirely).
     const own = new Map<number, { total: number; count: number }>()
     for (const t of txns) {
       if (t.type === 'transfer' || t.category_id == null) continue
       const acc = own.get(t.category_id) ?? { total: 0, count: 0 }
       acc.total += t.operation_type === 'credit' ? t.amount : -t.amount
       acc.count += 1
-      for (const s of t.settlements_from_source ?? []) {
-        acc.total += s.type === 'credit' ? s.amount : -s.amount
+      if (!hideSettlements) {
+        for (const s of t.settlements_from_source ?? []) {
+          acc.total += s.type === 'credit' ? s.amount : -s.amount
+        }
       }
       own.set(t.category_id, acc)
     }
@@ -86,7 +103,7 @@ export function useCategorySpending(month: number, year: number): CategorySpendi
     const gross = nodes.reduce((s, n) => s + Math.abs(n.total), 0)
     const maxAbs = nodes.reduce((m, n) => Math.max(m, Math.abs(n.total)), 0)
     return { nodes, net, gross, maxAbs }
-  }, [categories, transactions])
+  }, [categories, transactions, hideSettlements])
 
   return {
     nodes,

--- a/frontend/src/hooks/useIncomeExpenseFlow.ts
+++ b/frontend/src/hooks/useIncomeExpenseFlow.ts
@@ -1,0 +1,103 @@
+import { useMemo } from 'react'
+import { useCategorySpending } from './useCategorySpending'
+
+/** A node in the income → expenses Sankey diagram. */
+export interface FlowNode {
+  name: string
+  /** Display color for the node (income green, the central node neutral, expenses by category). */
+  color: string
+  /** Marks the leftover/savings node so the UI can label it distinctly. */
+  kind: 'income' | 'hub' | 'expense' | 'leftover'
+}
+
+export interface FlowLink {
+  source: number
+  target: number
+  /** Flow magnitude in cents (always > 0). */
+  value: number
+  color: string
+}
+
+export interface IncomeExpenseFlow {
+  nodes: FlowNode[]
+  links: FlowLink[]
+  totalIncome: number
+  totalExpense: number
+  /** income − expense, in cents (the leftover routed to savings when positive). */
+  leftover: number
+  /** True once there is at least one income source to draw. */
+  hasData: boolean
+  isLoading: boolean
+  isError: boolean
+  invalidate: () => void
+}
+
+const INCOME_COLOR = '#3a8a5f'
+const HUB_COLOR = '#457b9d'
+const LEFTOVER_COLOR = '#2a9d8f'
+
+/**
+ * Builds a Sankey graph showing the period's money flow: each income category
+ * flows into a central "Receita" hub, which then flows out to each expense
+ * category (and to a "Sobra" node when income exceeds expenses). Reuses the
+ * category aggregation from {@link useCategorySpending} so the numbers match the
+ * Categorias view and the backend balance endpoint.
+ */
+export function useIncomeExpenseFlow(month: number, year: number): IncomeExpenseFlow {
+  const { nodes: catNodes, categoriesLoading, spendLoading, isError, invalidate } =
+    useCategorySpending(month, year)
+
+  const flow = useMemo<Omit<IncomeExpenseFlow, 'isLoading' | 'isError' | 'invalidate'>>(() => {
+    const incomeCats = catNodes
+      .filter((n) => n.total > 0)
+      .sort((a, b) => b.total - a.total)
+    const expenseCats = catNodes
+      .filter((n) => n.total < 0)
+      .map((n) => ({ ...n, magnitude: -n.total }))
+      .sort((a, b) => b.magnitude - a.magnitude)
+
+    const totalIncome = incomeCats.reduce((s, n) => s + n.total, 0)
+    const totalExpense = expenseCats.reduce((s, n) => s + n.magnitude, 0)
+    const leftover = totalIncome - totalExpense
+
+    const nodes: FlowNode[] = []
+    const links: FlowLink[] = []
+
+    // Index 0..N-1: income categories. Then the hub. Then expenses, then leftover.
+    incomeCats.forEach((n) => nodes.push({ name: n.category.name, color: n.color, kind: 'income' }))
+    const hubIndex = nodes.length
+    nodes.push({ name: 'Receita', color: HUB_COLOR, kind: 'hub' })
+
+    incomeCats.forEach((n, i) => {
+      links.push({ source: i, target: hubIndex, value: n.total, color: INCOME_COLOR })
+    })
+
+    expenseCats.forEach((n) => {
+      const idx = nodes.length
+      nodes.push({ name: n.category.name, color: n.color, kind: 'expense' })
+      links.push({ source: hubIndex, target: idx, value: n.magnitude, color: n.color })
+    })
+
+    if (leftover > 0) {
+      const idx = nodes.length
+      nodes.push({ name: 'Sobra', color: LEFTOVER_COLOR, kind: 'leftover' })
+      links.push({ source: hubIndex, target: idx, value: leftover, color: LEFTOVER_COLOR })
+    }
+
+    return {
+      nodes,
+      links,
+      totalIncome,
+      totalExpense,
+      leftover,
+      hasData: incomeCats.length > 0 && links.length > 0,
+    }
+  }, [catNodes])
+
+  return {
+    ...flow,
+    isLoading: categoriesLoading || spendLoading,
+    isError,
+    invalidate,
+  }
+}

--- a/frontend/src/hooks/useRecurringForPeriod.ts
+++ b/frontend/src/hooks/useRecurringForPeriod.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react'
+import { useTransactions } from './useTransactions'
+import { Transactions } from '@/types/transactions'
+
+export interface RecurringSummary {
+  /** Recurring installments whose first installment lands in the period. */
+  starting: Transactions.Transaction[]
+  /** Recurring installments whose last installment lands in the period. */
+  ending: Transactions.Transaction[]
+  /** Σ amount (cents) of the starting installments. */
+  startingTotal: number
+  /** Σ amount (cents) of the ending installments. */
+  endingTotal: number
+  isLoading: boolean
+  isError: boolean
+  invalidate: () => void
+}
+
+/** Returns 1-based installment count of a recurring transaction, or undefined. */
+function totalInstallments(t: Transactions.Transaction): number | undefined {
+  return t.transaction_recurrence?.installments
+}
+
+/**
+ * Splits the period's recurring transactions into those starting
+ * (installment_number === 1) and those ending (installment_number === total
+ * installments) within the selected month, with the summed amount of each
+ * group. Derives everything client-side from the existing transactions list,
+ * which already preloads each transaction's recurrence.
+ */
+export function useRecurringForPeriod(month: number, year: number): RecurringSummary {
+  const { query, invalidate } = useTransactions({ month, year })
+  const transactions = query.data
+
+  const { starting, ending, startingTotal, endingTotal } = useMemo(() => {
+    const starting: Transactions.Transaction[] = []
+    const ending: Transactions.Transaction[] = []
+
+    for (const t of transactions ?? []) {
+      if (t.transaction_recurrence_id == null || t.installment_number == null) continue
+      const total = totalInstallments(t)
+      if (t.installment_number === 1) starting.push(t)
+      if (total != null && t.installment_number === total) ending.push(t)
+    }
+
+    const sum = (list: Transactions.Transaction[]) => list.reduce((s, t) => s + t.amount, 0)
+    return {
+      starting,
+      ending,
+      startingTotal: sum(starting),
+      endingTotal: sum(ending),
+    }
+  }, [transactions])
+
+  return {
+    starting,
+    ending,
+    startingTotal,
+    endingTotal,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    invalidate,
+  }
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,108 @@
+import { Suspense, lazy } from 'react'
+import { Center, Group, Loader, SimpleGrid, Stack, Text } from '@mantine/core'
+import { useNavigate, useSearch } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
+import { PeriodNavigator } from '@/components/transactions/PeriodNavigator'
+import { AccountBalancesCard } from '@/components/home/AccountBalancesCard'
+import { RecurringTransactionsCard } from '@/components/home/RecurringTransactionsCard'
+
+// The chart cards pull in recharts; lazy-load them so it splits into its own
+// chunk instead of bloating the main bundle served on every route.
+const ExpenseDonutCard = lazy(() =>
+  import('@/components/home/ExpenseDonutCard').then((m) => ({ default: m.ExpenseDonutCard })),
+)
+const IncomeSankeyCard = lazy(() =>
+  import('@/components/home/IncomeSankeyCard').then((m) => ({ default: m.IncomeSankeyCard })),
+)
+
+function ChartFallback() {
+  return <Center h={280}><Loader size="sm" /></Center>
+}
+import { useRecurringForPeriod } from '@/hooks/useRecurringForPeriod'
+import { PullToRefresh } from '@/components/PullToRefresh'
+import { QueryKeys } from '@/utils/queryKeys'
+import { HomeTestIds } from '@/testIds'
+
+export function HomePage() {
+  const { month, year, accumulated, hideSettlements } = useSearch({ from: '/_authenticated/home' })
+  const navigate = useNavigate({ from: '/home' })
+  const queryClient = useQueryClient()
+
+  const recurring = useRecurringForPeriod(month, year)
+
+  const setPeriod = (m: number, y: number) =>
+    navigate({ search: (prev) => ({ ...prev, month: m, year: y }) })
+
+  const setAccumulated = (value: boolean) =>
+    navigate({ search: (prev) => ({ ...prev, accumulated: value }) })
+
+  const setHideSettlements = (value: boolean) =>
+    navigate({ search: (prev) => ({ ...prev, hideSettlements: value }) })
+
+  const goToAccount = (accountId: number) =>
+    navigate({ to: '/transactions', search: { accountIds: [accountId], month, year } })
+
+  const refresh = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.Balance] }),
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.Transactions] }),
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.Accounts] }),
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.Categories] }),
+    ])
+
+  return (
+    <PullToRefresh onRefresh={refresh}>
+      <Stack gap="md" data-testid={HomeTestIds.Page}>
+        <Group justify="space-between" align="center" wrap="nowrap">
+          <Text fw={700} size="xl">Início</Text>
+          <div data-testid={HomeTestIds.PeriodNavigator}>
+            <PeriodNavigator month={month} year={year} onPeriodChange={setPeriod} />
+          </div>
+        </Group>
+
+        <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md">
+          <AccountBalancesCard
+            month={month}
+            year={year}
+            accumulated={accumulated}
+            onAccumulatedChange={setAccumulated}
+            onSelectAccount={goToAccount}
+          />
+          <Suspense fallback={<ChartFallback />}>
+            <ExpenseDonutCard
+              month={month}
+              year={year}
+              hideSettlements={hideSettlements}
+              onHideSettlementsChange={setHideSettlements}
+            />
+          </Suspense>
+        </SimpleGrid>
+
+        <Suspense fallback={<ChartFallback />}>
+          <IncomeSankeyCard month={month} year={year} />
+        </Suspense>
+
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+          <RecurringTransactionsCard
+            title="Recorrentes iniciando"
+            transactions={recurring.starting}
+            total={recurring.startingTotal}
+            isLoading={recurring.isLoading}
+            emptyLabel="Nenhuma recorrência inicia neste período"
+            testId={HomeTestIds.RecurringStartingSection}
+            totalTestId={HomeTestIds.RecurringStartingTotal}
+          />
+          <RecurringTransactionsCard
+            title="Recorrentes finalizando"
+            transactions={recurring.ending}
+            total={recurring.endingTotal}
+            isLoading={recurring.isLoading}
+            emptyLabel="Nenhuma recorrência finaliza neste período"
+            testId={HomeTestIds.RecurringEndingSection}
+            totalTestId={HomeTestIds.RecurringEndingTotal}
+          />
+        </SimpleGrid>
+      </Stack>
+    </PullToRefresh>
+  )
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -84,7 +84,7 @@ export function HomePage() {
 
         <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
           <RecurringTransactionsCard
-            title="Recorrentes iniciando"
+            title="Recorrências iniciando"
             transactions={recurring.starting}
             total={recurring.startingTotal}
             isLoading={recurring.isLoading}
@@ -93,7 +93,7 @@ export function HomePage() {
             totalTestId={HomeTestIds.RecurringStartingTotal}
           />
           <RecurringTransactionsCard
-            title="Recorrentes finalizando"
+            title="Recorrências finalizando"
             transactions={recurring.ending}
             total={recurring.endingTotal}
             isLoading={recurring.isLoading}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as AuthCallbackRouteImport } from './routes/auth.callback'
 import { Route as AuthenticatedTransactionsRouteImport } from './routes/_authenticated.transactions'
 import { Route as AuthenticatedOnboardingRouteImport } from './routes/_authenticated.onboarding'
 import { Route as AuthenticatedNotificationsRouteImport } from './routes/_authenticated.notifications'
+import { Route as AuthenticatedHomeRouteImport } from './routes/_authenticated.home'
 import { Route as AuthenticatedChargesRouteImport } from './routes/_authenticated.charges'
 import { Route as AuthenticatedCategoriesRouteImport } from './routes/_authenticated.categories'
 import { Route as AuthenticatedAccountsRouteImport } from './routes/_authenticated.accounts'
@@ -58,6 +59,11 @@ const AuthenticatedNotificationsRoute =
     path: '/notifications',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedHomeRoute = AuthenticatedHomeRouteImport.update({
+  id: '/home',
+  path: '/home',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 const AuthenticatedChargesRoute = AuthenticatedChargesRouteImport.update({
   id: '/charges',
   path: '/charges',
@@ -92,6 +98,7 @@ export interface FileRoutesByFullPath {
   '/accounts': typeof AuthenticatedAccountsRoute
   '/categories': typeof AuthenticatedCategoriesRoute
   '/charges': typeof AuthenticatedChargesRoute
+  '/home': typeof AuthenticatedHomeRoute
   '/notifications': typeof AuthenticatedNotificationsRoute
   '/onboarding': typeof AuthenticatedOnboardingRoute
   '/transactions': typeof AuthenticatedTransactionsRoute
@@ -105,6 +112,7 @@ export interface FileRoutesByTo {
   '/accounts': typeof AuthenticatedAccountsRoute
   '/categories': typeof AuthenticatedCategoriesRoute
   '/charges': typeof AuthenticatedChargesRoute
+  '/home': typeof AuthenticatedHomeRoute
   '/notifications': typeof AuthenticatedNotificationsRoute
   '/onboarding': typeof AuthenticatedOnboardingRoute
   '/transactions': typeof AuthenticatedTransactionsRoute
@@ -120,6 +128,7 @@ export interface FileRoutesById {
   '/_authenticated/accounts': typeof AuthenticatedAccountsRoute
   '/_authenticated/categories': typeof AuthenticatedCategoriesRoute
   '/_authenticated/charges': typeof AuthenticatedChargesRoute
+  '/_authenticated/home': typeof AuthenticatedHomeRoute
   '/_authenticated/notifications': typeof AuthenticatedNotificationsRoute
   '/_authenticated/onboarding': typeof AuthenticatedOnboardingRoute
   '/_authenticated/transactions': typeof AuthenticatedTransactionsRoute
@@ -135,6 +144,7 @@ export interface FileRouteTypes {
     | '/accounts'
     | '/categories'
     | '/charges'
+    | '/home'
     | '/notifications'
     | '/onboarding'
     | '/transactions'
@@ -148,6 +158,7 @@ export interface FileRouteTypes {
     | '/accounts'
     | '/categories'
     | '/charges'
+    | '/home'
     | '/notifications'
     | '/onboarding'
     | '/transactions'
@@ -162,6 +173,7 @@ export interface FileRouteTypes {
     | '/_authenticated/accounts'
     | '/_authenticated/categories'
     | '/_authenticated/charges'
+    | '/_authenticated/home'
     | '/_authenticated/notifications'
     | '/_authenticated/onboarding'
     | '/_authenticated/transactions'
@@ -228,6 +240,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedNotificationsRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/home': {
+      id: '/_authenticated/home'
+      path: '/home'
+      fullPath: '/home'
+      preLoaderRoute: typeof AuthenticatedHomeRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/charges': {
       id: '/_authenticated/charges'
       path: '/charges'
@@ -270,6 +289,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAccountsRoute: typeof AuthenticatedAccountsRoute
   AuthenticatedCategoriesRoute: typeof AuthenticatedCategoriesRoute
   AuthenticatedChargesRoute: typeof AuthenticatedChargesRoute
+  AuthenticatedHomeRoute: typeof AuthenticatedHomeRoute
   AuthenticatedNotificationsRoute: typeof AuthenticatedNotificationsRoute
   AuthenticatedOnboardingRoute: typeof AuthenticatedOnboardingRoute
   AuthenticatedTransactionsRoute: typeof AuthenticatedTransactionsRoute
@@ -281,6 +301,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAccountsRoute: AuthenticatedAccountsRoute,
   AuthenticatedCategoriesRoute: AuthenticatedCategoriesRoute,
   AuthenticatedChargesRoute: AuthenticatedChargesRoute,
+  AuthenticatedHomeRoute: AuthenticatedHomeRoute,
   AuthenticatedNotificationsRoute: AuthenticatedNotificationsRoute,
   AuthenticatedOnboardingRoute: AuthenticatedOnboardingRoute,
   AuthenticatedTransactionsRoute: AuthenticatedTransactionsRoute,

--- a/frontend/src/routes/_authenticated.home.tsx
+++ b/frontend/src/routes/_authenticated.home.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { zodValidator } from '@tanstack/zod-adapter'
+import { z } from 'zod'
+import { HomePage } from '@/pages/HomePage'
+
+const now = new Date()
+
+export const homeSearchSchema = z.object({
+  month: z.coerce.number().int().min(1).max(12).default(now.getMonth() + 1),
+  year: z.coerce.number().int().default(now.getFullYear()),
+  // Accumulate the account balances across all prior periods (same flag as the
+  // transactions list).
+  accumulated: z.coerce.boolean().default(false),
+  // Drop settlements from the expense-by-category chart ("considerar acertos").
+  hideSettlements: z.coerce.boolean().default(false),
+})
+
+export type HomeSearch = z.infer<typeof homeSearchSchema>
+
+export const Route = createFileRoute('/_authenticated/home')({
+  validateSearch: zodValidator(homeSearchSchema),
+  component: HomePage,
+})

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Navigate } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
-  component: () => <Navigate to="/transactions" />,
+  component: () => <Navigate to="/home" />,
 })

--- a/frontend/src/testIds/home.ts
+++ b/frontend/src/testIds/home.ts
@@ -1,0 +1,28 @@
+export const HomeTestIds = {
+  Page: 'home_page',
+  PeriodNavigator: 'home_period_navigator',
+
+  // Account balances
+  AccountBalancesSection: 'section_account_balances',
+  AccumulatedToggle: 'toggle_balances_accumulated',
+  /** Clickable balance row, parametric by account id. */
+  AccountRow: (accountId: number) => `row_account_balance_${accountId}` as const,
+  AccountBalancesTotal: 'account_balances_total',
+
+  // Expense distribution (pie)
+  ExpenseChartSection: 'section_expense_chart',
+  SettlementsToggle: 'toggle_consider_settlements',
+  ExpenseChart: 'expense_pie_chart',
+
+  // Income flow (sankey)
+  IncomeFlowSection: 'section_income_flow',
+  IncomeFlowChart: 'income_sankey_chart',
+
+  // Recurring transactions
+  RecurringStartingSection: 'section_recurring_starting',
+  RecurringEndingSection: 'section_recurring_ending',
+  RecurringStartingTotal: 'recurring_starting_total',
+  RecurringEndingTotal: 'recurring_ending_total',
+  /** Recurring transaction row, parametric by transaction id. */
+  RecurringRow: (transactionId: number) => `row_recurring_${transactionId}` as const,
+} as const

--- a/frontend/src/testIds/index.ts
+++ b/frontend/src/testIds/index.ts
@@ -37,3 +37,4 @@ export { OnboardingTestIds } from "./onboarding";
 export { MobileNavTestIds } from "./mobileNav";
 export { LoginTestIds } from "./login";
 export { NotificationsTestIds } from "./notifications";
+export { HomeTestIds } from "./home";


### PR DESCRIPTION
Closes #198

## O que faz

Nova **Página Inicial** (`/home`) com dados sumarizados por período (MM-YYYY):

- **Saldo das contas** — tabela com avatar + descrição + saldo de cada conta ativa. Linha clicável → abre a lista de transações filtrada por aquela conta. Toggle **Acumulado** (mesma flag da lista de transações) para alternar entre saldo do mês e acumulado.
- **Despesas por categoria** — gráfico de pizza (donut) com legenda de valores/percentuais e toggle **Considerar acertos** (liga/desliga settlements).
- **Distribuição da receita** — gráfico **Sankey**: receitas por categoria → nó central "Receita" → despesas por categoria, mais o nó "Sobra" quando a receita supera as despesas.
- **Recorrentes iniciando** (parcela 1) e **Recorrentes finalizando** (última parcela) no período, cada tabela com a contagem e o valor total somado.

Também adiciona "Início" à navegação (sidebar desktop + tab bar mobile + logo do header) e redireciona a raiz `/` para `/home`.

## Como foi feito

**Sem mudanças no backend.** Tudo reaproveita endpoints existentes:

| Indicador | Fonte |
|---|---|
| Saldo das contas | `GET /api/transactions/balance` (`account_id[]`, `accumulated`) |
| Pizza de despesas | `useCategorySpending` (categorias + transações do período), estendido com `hideSettlements` |
| Sankey | mesma agregação por categoria (`useIncomeExpenseFlow`) |
| Recorrentes | `GET /api/transactions` — a lista já faz preload de `transaction_recurrence`, então `installment_number` e `installments` chegam no front |

As agregações batem com a view de Categorias e com a leg de settlements do endpoint de balance.

### Dependências / bundle
- Adiciona `recharts` (pizza + Sankey). Os dois cards de gráfico são carregados via `React.lazy`, então o `recharts` vai para um chunk próprio (carregado só em `/home`) — o bundle principal **caiu de ~459KB para ~357KB gzip**.

### Testes
- `npm run build` (tsc + vite) ✅ · `npm run lint` ✅ (só warnings pré-existentes em `TransactionsPage`).
- E2E: adicionado `e2e/tests/home.spec.ts` (smoke) seguindo o padrão de 1 usuário por teste + `data-testid`. Type-check do e2e passa; **não foi possível executá-lo aqui** (requer stack completa) — primeira execução será no CI.

## Decisões confirmadas com o autor
- Saldo das contas: toggle do mês/acumulado (mesma flag da lista de transações).
- Sankey: fluxo Receita → Despesas por categoria.

## Notas / pontos de atenção
- O saldo por conta é uma query por linha (poucas contas em um app de casal); o total usa uma única query somando todos os `account_id`. Um endpoint de "saldos agrupados por conta" otimizaria isso no futuro.
- O Sankey usa renderizadores customizados de nó/link do recharts (cores + rótulos por `kind`).

https://claude.ai/code/session_01BjxqbuyersjBb16Syzr8cL

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjxqbuyersjBb16Syzr8cL)_