### PR TITLE
refactor(transactions): decouple read-only previousTransaction from mutable currentTransaction

### DIFF
--- a/backend/internal/service/structs.go
+++ b/backend/internal/service/structs.go
@@ -7,9 +7,17 @@ import (
 )
 
 type transactionUpdateData struct {
-	userID                 int
-	req                    *domain.TransactionUpdateRequest
-	previousTransaction    *domain.Transaction
+	userID int
+	req    *domain.TransactionUpdateRequest
+	// previousTransaction is a strictly READ-ONLY pristine snapshot of the edited
+	// transaction as it was before the update. It must never be mutated after
+	// construction so that any "before" comparison (e.g. propagation/date checks)
+	// reads the original values.
+	previousTransaction *domain.Transaction
+	// currentTransaction is the MUTABLE clone of previousTransaction that the
+	// update loop mutates and persists. It is the entry seeded into transactions
+	// for the edited row; previousTransaction is never placed in transactions.
+	currentTransaction     *domain.Transaction
 	transactions           []*domain.Transaction
 	transactionIDsToRemove map[int]bool
 	scenario               updateChanges

--- a/backend/internal/service/structs.go
+++ b/backend/internal/service/structs.go
@@ -10,10 +10,10 @@ type transactionUpdateData struct {
 	userID int
 	req    *domain.TransactionUpdateRequest
 	// previousTransaction is a strictly READ-ONLY pristine snapshot of the edited
-	// transaction as it was before the update. It must never be mutated after
-	// construction so that any "before" comparison (e.g. propagation/date checks)
-	// reads the original values.
-	previousTransaction *domain.Transaction
+	// transaction as it was before the update. It is held by value (not a pointer)
+	// so it cannot be aliased into the mutable transactions slice — any "before"
+	// comparison (e.g. propagation/date checks) always reads the original values.
+	previousTransaction domain.Transaction
 	// currentTransaction is the MUTABLE clone of previousTransaction that the
 	// update loop mutates and persists. It is the entry seeded into transactions
 	// for the edited row; previousTransaction is never placed in transactions.

--- a/backend/internal/service/transaction_coverage_gaps_test.go
+++ b/backend/internal/service/transaction_coverage_gaps_test.go
@@ -390,6 +390,9 @@ func (suite *TransactionUpdateWithDBTestSuite) TestShouldUpdateTransaction_PastI
 			PropagationSettings: domain.TransactionPropagationSettingsCurrentAndFuture,
 		},
 		previousTransaction: prevTx,
+		// shouldUpdateTransactionBasedOnPropagationSettings compares against the
+		// mutable edited row, so currentTransaction must be set as well.
+		currentTransaction: prevTx,
 	}
 
 	// A transaction dated BEFORE the previous transaction must not be updated.

--- a/backend/internal/service/transaction_coverage_gaps_test.go
+++ b/backend/internal/service/transaction_coverage_gaps_test.go
@@ -389,7 +389,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestShouldUpdateTransaction_PastI
 		req: &domain.TransactionUpdateRequest{
 			PropagationSettings: domain.TransactionPropagationSettingsCurrentAndFuture,
 		},
-		previousTransaction: prevTx,
+		previousTransaction: *prevTx,
 		// shouldUpdateTransactionBasedOnPropagationSettings compares against the
 		// mutable edited row, so currentTransaction must be set as well.
 		currentTransaction: prevTx,

--- a/backend/internal/service/transaction_update.go
+++ b/backend/internal/service/transaction_update.go
@@ -1043,8 +1043,8 @@ func (s *transactionService) handlerRecurrenceUpdate(
 		// propagation=current: only detach the current transaction from the recurrence.
 		// The recurrence record itself must be preserved because other installments still reference it.
 		if data.req.PropagationSettings == domain.TransactionPropagationSettingsCurrent {
-			data.transactions[0].TransactionRecurrenceID = nil
-			data.transactions[0].TransactionRecurrence = nil
+			data.currentTransaction.TransactionRecurrenceID = nil
+			data.currentTransaction.TransactionRecurrence = nil
 			return nil
 		}
 

--- a/backend/internal/service/transaction_update.go
+++ b/backend/internal/service/transaction_update.go
@@ -13,6 +13,37 @@ import (
 	"github.com/samber/lo"
 )
 
+// cloneTransactionForUpdate returns a copy of t that is deep enough for the
+// update loop to mutate freely without touching the original. The loop mutates
+// row-level fields plus the Tags and LinkedTransactions slices — including
+// LinkedTransactions[i].Date/.Description in the non-linked propagation path —
+// so those backing arrays must not be shared with the pristine snapshot.
+// Pointer fields (TransactionRecurrence, InstallmentNumber, CategoryID, ...) are
+// only ever reassigned, never mutated in place on the clone, so sharing them is
+// safe; the shared TransactionRecurrence is intentionally mutated in place when
+// shrinking the original recurrence.
+func cloneTransactionForUpdate(t *domain.Transaction) *domain.Transaction {
+	if t == nil {
+		return nil
+	}
+
+	clone := *t
+	clone.Tags = slices.Clone(t.Tags)
+	clone.SettlementsFromSource = slices.Clone(t.SettlementsFromSource)
+
+	if t.LinkedTransactions != nil {
+		clone.LinkedTransactions = make([]domain.Transaction, len(t.LinkedTransactions))
+		for i := range t.LinkedTransactions {
+			lt := t.LinkedTransactions[i]
+			lt.Tags = slices.Clone(t.LinkedTransactions[i].Tags)
+			lt.LinkedTransactions = slices.Clone(t.LinkedTransactions[i].LinkedTransactions)
+			clone.LinkedTransactions[i] = lt
+		}
+	}
+
+	return &clone
+}
+
 func (s *transactionService) Update(ctx context.Context, id, userID int, req *domain.TransactionUpdateRequest) error {
 	ctx, err := s.dbTransaction.Begin(ctx)
 	if err != nil {
@@ -44,6 +75,7 @@ func (s *transactionService) Update(ctx context.Context, id, userID int, req *do
 		userID:                 userID,
 		req:                    req,
 		previousTransaction:    previousTransaction,
+		currentTransaction:     cloneTransactionForUpdate(previousTransaction),
 		transactions:           []*domain.Transaction{},
 		transactionIDsToRemove: make(map[int]bool),
 		isLinkedTxEdit:         isLinkedTxEdit,
@@ -410,7 +442,7 @@ func (s *transactionService) normalizeInstallments(ctx context.Context, data *tr
 
 	r := data.transactions[0].TransactionRecurrence
 
-	if r == nil && data.previousTransaction.TransactionRecurrenceID == nil {
+	if r == nil && data.currentTransaction.TransactionRecurrenceID == nil {
 		return nil
 	}
 
@@ -451,7 +483,7 @@ func (s *transactionService) normalizeInstallments(ctx context.Context, data *tr
 
 	existingCount := len(data.transactions)
 	if expectedCount > existingCount {
-		base := data.previousTransaction
+		base := data.currentTransaction
 		lastInstallment := minInstallment + existingCount - 1
 		// Use the last existing transaction's date as the anchor for new installments,
 		// so dates continue sequentially from where the series left off.
@@ -886,9 +918,10 @@ func (s *transactionService) syncSettlementsForTransaction(ctx context.Context, 
 
 	// Map of ToAccountID → custom settlement date diff taken from the update request's
 	// split_settings. The user's date input is the intended settlement date for the
-	// EDITED installment (data.previousTransaction). For every other affected
-	// installment in the recurrence we shift its own date by the same diff so the
-	// offset between the installment date and the settlement date stays consistent.
+	// EDITED installment (data.currentTransaction, whose Date already reflects any
+	// requested date change). For every other affected installment in the recurrence
+	// we shift its own date by the same diff so the offset between the installment
+	// date and the settlement date stays consistent.
 	requestedDateDiffByToAccount := make(map[int]time.Duration, len(data.req.SplitSettings))
 	for _, ss := range data.req.SplitSettings {
 		if ss.UserConnection == nil || ss.Date == nil {
@@ -896,7 +929,7 @@ func (s *transactionService) syncSettlementsForTransaction(ctx context.Context, 
 		}
 		conn := *ss.UserConnection
 		conn.SwapIfNeeded(userID)
-		requestedDateDiffByToAccount[conn.ToAccountID] = ss.Date.Time.Sub(data.previousTransaction.Date)
+		requestedDateDiffByToAccount[conn.ToAccountID] = ss.Date.Time.Sub(data.currentTransaction.Date)
 	}
 
 	keptParentIDs := make(map[int]bool, len(own.LinkedTransactions))
@@ -981,11 +1014,11 @@ func (s *transactionService) shouldUpdateTransactionBasedOnPropagationSettings(t
 		return true
 	}
 
-	if data.req.PropagationSettings == domain.TransactionPropagationSettingsCurrent && t.ID != data.previousTransaction.ID {
+	if data.req.PropagationSettings == domain.TransactionPropagationSettingsCurrent && t.ID != data.currentTransaction.ID {
 		return false
 	} else if data.req.PropagationSettings == domain.TransactionPropagationSettingsCurrentAndFuture &&
-		t.ID != data.previousTransaction.ID &&
-		!t.Date.After(data.previousTransaction.Date) {
+		t.ID != data.currentTransaction.ID &&
+		!t.Date.After(data.currentTransaction.Date) {
 		return false
 	}
 
@@ -1010,8 +1043,6 @@ func (s *transactionService) handlerRecurrenceUpdate(
 		// propagation=current: only detach the current transaction from the recurrence.
 		// The recurrence record itself must be preserved because other installments still reference it.
 		if data.req.PropagationSettings == domain.TransactionPropagationSettingsCurrent {
-			data.previousTransaction.TransactionRecurrenceID = nil
-			data.previousTransaction.TransactionRecurrence = nil
 			data.transactions[0].TransactionRecurrenceID = nil
 			data.transactions[0].TransactionRecurrence = nil
 			return nil
@@ -1143,7 +1174,7 @@ func (s *transactionService) handlerRecurrenceUpdate(
 		return *r, nil
 	}
 
-	r, err := upsertRecurrence(data.userID, *data.previousTransaction)
+	r, err := upsertRecurrence(data.userID, *data.currentTransaction)
 	if err != nil {
 		return err
 	}
@@ -1185,7 +1216,12 @@ func (s *transactionService) fetchRelatedTransactions(
 	ctx context.Context,
 	data *transactionUpdateData) error {
 
-	transactions := []*domain.Transaction{data.previousTransaction}
+	// Seed the list with the MUTABLE clone (currentTransaction); the pristine
+	// previousTransaction is never placed in data.transactions so the update loop
+	// cannot mutate the before-snapshot. The remaining read-only filters below use
+	// previousTransaction since both hold identical values at this point (before any
+	// mutation) and it documents that we are keying off the original installment.
+	transactions := []*domain.Transaction{data.currentTransaction}
 	hasInstallments := data.previousTransaction.TransactionRecurrenceID != nil && data.previousTransaction.InstallmentNumber != nil
 
 	// propagation current atualiza somente a transação atual e linked transactions

--- a/backend/internal/service/transaction_update.go
+++ b/backend/internal/service/transaction_update.go
@@ -74,7 +74,7 @@ func (s *transactionService) Update(ctx context.Context, id, userID int, req *do
 	data := &transactionUpdateData{
 		userID:                 userID,
 		req:                    req,
-		previousTransaction:    previousTransaction,
+		previousTransaction:    *previousTransaction,
 		currentTransaction:     cloneTransactionForUpdate(previousTransaction),
 		transactions:           []*domain.Transaction{},
 		transactionIDsToRemove: make(map[int]bool),


### PR DESCRIPTION
## Context

In `TransactionService.Update`, the `previousTransaction` returned by `getByID` was **also** seeded into `data.transactions` as the edited row — the *same* pointer. The update loop then mutated that row in place (`Amount`, `Date`, `Description`, `AccountID`, `CategoryID`, `Tags`, `LinkedTransactions`) and persisted it. As a result `previousTransaction` was not actually the "before" state; it ended up mutated, making it unreliable for any before/after comparison.

This refactors that aliasing away. It is a **structural decoupling with no behavior change** on the non-linked update/propagation paths.

> **Branch note:** This was scoped against `main`, **not** on top of PR #206. Because #206 is still an open draft, `main` does not contain its `previousAmount` workaround, `collectSplitUpdatedEvents`, the amount-comparison guard, or `fetchRelatedLinkedTransactions`. Per discussion, scope here is **decoupling only** — the notification logic is intentionally left untouched (no #205 amount-guard change). Expect overlap with #206; sequence the merges accordingly.

## Changes

- **`structs.go`** — add `currentTransaction *domain.Transaction` to `transactionUpdateData`; document `previousTransaction` as a strictly read-only snapshot.
- **`Update`** — build `currentTransaction` via a new `cloneTransactionForUpdate` helper. The clone duplicates the `Tags`, `SettlementsFromSource`, and `LinkedTransactions` backing arrays (and each linked row's nested slices) so row-level and linked-row mutations in the loop can never touch the snapshot. Pointer fields are only ever reassigned (never mutated in place) on the clone, so sharing them is safe; the shared `TransactionRecurrence` is intentionally mutated in place when shrinking the original recurrence.
- **`fetchRelatedTransactions`** — seed the list with `currentTransaction`; `previousTransaction` is never placed in `data.transactions`.
- **Edited-row reads that depend on in-flow mutations** routed to `currentTransaction` to preserve behavior exactly:
  - `normalizeInstallments`: the "any recurrence at all?" check and the new-installment `base` template (both need the recurrence set by `handlerRecurrenceUpdate`).
  - `syncSettlementsForTransaction`: the custom-split-date offset reference (the edited installment's *new* date).
  - `shouldUpdateTransactionBasedOnPropagationSettings`: the propagation date/ID comparison (matches the pre-refactor mutated-date behavior exactly — no propagation change).
  - `handlerRecurrenceUpdate`: the `upsertRecurrence` reference.
- **`handlerRecurrenceUpdate`** — removed the two writes to `previousTransaction` (recurrence detach); only the mutable row is detached now.
- **`transaction_coverage_gaps_test.go`** — `TestShouldUpdateTransaction_PastInstallment` now sets `currentTransaction` (the helper compares against the mutable row).

## Acceptance

- `previousTransaction` is never written after construction (verified by grep — only `==` comparisons remain).
- Notification logic is unchanged; the only path that actually dispatches (partner linked-amount edit) reads a freshly-fetched source tx + `req.Amount`, not `previousTransaction`, so it is unaffected.

## Validation

- `go build ./...` — clean.
- `go vet ./internal/service/` — clean.
- `go test -short ./internal/service/` (unit) — **pass**.
- `gofmt -l` — clean on all changed files.
- ⚠️ The testcontainers **integration suite could not run here (no Docker)**. CI must exercise it — pay attention to all `InstallmentScenario*`, the `#117` linked-tx tests, the `#205` tests, and `TestSplitUpdatedNotification` / `TestSplitUpdatedCosmeticNoNotification` / `TestSplitUpdatedSelfEditNoNotification`.
- golangci-lint could not run locally (config references a linter name unknown to the locally-installed version); CI runs the pinned version. `Update`'s cyclomatic complexity is essentially unchanged (clone is a separate function).

https://claude.ai/code/session_01PF7fXs8f1FgLnDw6Qzn1Lk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PF7fXs8f1FgLnDw6Qzn1Lk)_