### PR TITLE
fix: débito na perna da contraparte em transfers cross-user (saldo da conexão zero-soma)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -327,7 +327,15 @@ When users create a transfer to another user through a connection account, 3 tra
 
 - 1 transfer operation type = 'debit' with the account being the author private account
 - 1 transfer operation type = 'credit' with the account being the author side's account of the user_connection (fromTx)
-- 1 transfer operation type = 'credit' with the account being the other user side's account of the user_connection (toTx)
+- 1 transfer operation type = 'debit' with the account being the other user side's account of the user_connection (toTx)
+
+The fromTx (author side, credit) and the toTx (counterpart side, debit) have **opposite**
+operation types so the connection stays zero-sum: a transfer only moves money, so crediting
+the author's shared account must debit the counterpart's. If both sides were credited, the
+combined connection balance would drift by `2 × amount` instead of staying balanced — and a
+direct transfer used to settle a debt would push the balance away from zero instead of
+toward it. This mirrors the charge-settlement flow, which already debits one connection
+account and credits the other.
 
 **Updates must preserve the same 3-transaction structure.** When `rebuildTransferLinkedTransactions` runs (for `RemainedTransfer` or `TypeChangedToTransfer` scenarios), it must recreate both the fromTx and the toTx. To determine if a transfer is cross-user, check for a `UserConnection` on the destination account via `getConnectionFromDestinationAccountID` — do NOT check account ownership (`account.UserID`), because connection accounts may belong to the connection creator.
 

--- a/backend/internal/service/transaction_balance_test.go
+++ b/backend/internal/service/transaction_balance_test.go
@@ -986,10 +986,11 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Transfer_DiffUser
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(0), result1.Balance)
 
-	// user2 balance: +3000 (credit on connection account)
+	// user2 balance: -3000 (debit toTx on connection account — the counterpart leg that
+	// mirrors user1's credit, keeping the connection zero-sum)
 	result2, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(3000), result2.Balance)
+	suite.Assert().Equal(int64(-3000), result2.Balance)
 
 	// user1 source account: -3000
 	resultSrc, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{
@@ -1005,12 +1006,18 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Transfer_DiffUser
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(3000), resultFromTx.Balance)
 
-	// user2 connection account: +3000
+	// user2 connection account: -3000 (debit toTx mirroring user1's credit fromTx, so the
+	// two sides of the connection net to zero — a transfer just moves money, it must not
+	// inflate the combined connection balance)
 	resultDst, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{
 		AccountIDs: []int{conn.ToAccountID},
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(3000), resultDst.Balance)
+	suite.Assert().Equal(int64(-3000), resultDst.Balance)
+
+	// The connection as a whole nets to zero: user1's +3000 fromTx offsets user2's -3000
+	// toTx, so the transfer settles cleanly instead of drifting the connection balance.
+	suite.Assert().Equal(int64(0), resultFromTx.Balance+resultDst.Balance)
 }
 
 func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Transfer_SameUser_AmountUpdated() {
@@ -1121,10 +1128,10 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Transfer_DiffUser
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(0), result1.Balance)
 
-	// user2: +4000
+	// user2: -4000 (debit toTx mirroring user1's credit fromTx)
 	result2, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(4000), result2.Balance)
+	suite.Assert().Equal(int64(-4000), result2.Balance)
 }
 
 func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Transfer_SameUser_DestinationChanged() {
@@ -1240,10 +1247,10 @@ func (suite *TransactionBalanceWithDBTestSuite) TestGetBalance_Transfer_SameUser
 	suite.Require().NoError(err)
 	suite.Assert().Equal(int64(0), result1.Balance)
 
-	// user2: +1500 (credit on connection account)
+	// user2: -1500 (debit toTx on connection account mirroring user1's credit fromTx)
 	result2, err := suite.Services.Transaction.GetBalance(ctx, user2.ID, period, domain.BalanceFilter{})
 	suite.Require().NoError(err)
-	suite.Assert().Equal(int64(1500), result2.Balance)
+	suite.Assert().Equal(int64(-1500), result2.Balance)
 
 	// user1 old destination account2: now 0
 	resultOldDst, err := suite.Services.Transaction.GetBalance(ctx, user1.ID, period, domain.BalanceFilter{

--- a/backend/internal/service/transaction_business_rules_test.go
+++ b/backend/internal/service/transaction_business_rules_test.go
@@ -227,11 +227,12 @@ func (suite *TransactionUpdateWithDBTestSuite) TestUpdate_Transfer_SameUserToDif
 	suite.Assert().Equal(userA.ID, fromTx.UserID)
 	suite.Assert().Equal(domain.OperationTypeCredit, fromTx.OperationType)
 
-	// toTx: credit on partner's shared account
+	// toTx: debit on partner's shared account (mirrors the author's credit fromTx, keeping
+	// the connection zero-sum)
 	toTx := updated.LinkedTransactions[1]
 	suite.Assert().Equal(conn.ToAccountID, toTx.AccountID)
 	suite.Assert().Equal(conn.ToUserID, toTx.UserID)
-	suite.Assert().Equal(domain.OperationTypeCredit, toTx.OperationType)
+	suite.Assert().Equal(domain.OperationTypeDebit, toTx.OperationType)
 
 	// Old same-user credit transaction should be deleted; author keeps main debit + fromTx credit
 	userATxs, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{UserID: &userA.ID})
@@ -375,11 +376,11 @@ func (suite *TransactionUpdateWithDBTestSuite) TestUpdate_Transfer_DifferentUser
 	suite.Assert().Equal(userA.ID, fromTx.UserID, "fromTx should belong to userA")
 	suite.Assert().Equal(domain.OperationTypeCredit, fromTx.OperationType)
 
-	// toTx: credit on userC's shared account
+	// toTx: debit on userC's shared account (mirrors the author's credit fromTx)
 	toTx := updated.LinkedTransactions[1]
 	suite.Assert().Equal(connAC.ToAccountID, toTx.AccountID, "toTx should now target userC's account")
 	suite.Assert().Equal(userC.ID, toTx.UserID, "toTx should now belong to userC")
-	suite.Assert().Equal(domain.OperationTypeCredit, toTx.OperationType)
+	suite.Assert().Equal(domain.OperationTypeDebit, toTx.OperationType)
 
 	// userB should have no transactions
 	userBTxs, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{UserID: &userB.ID})

--- a/backend/internal/service/transaction_coverage_gaps_test.go
+++ b/backend/internal/service/transaction_coverage_gaps_test.go
@@ -364,11 +364,12 @@ func (suite *TransactionUpdateWithDBTestSuite) TestUpdate_IncomeToDifferentUserT
 	suite.Assert().Equal(userA.ID, fromTx.UserID)
 	suite.Assert().Equal(domain.OperationTypeCredit, fromTx.OperationType)
 
-	// toTx: credit on partner's shared account
+	// toTx: debit on partner's shared account (mirrors the author's credit fromTx so the
+	// connection stays zero-sum)
 	toTx := updated.LinkedTransactions[1]
 	suite.Assert().Equal(conn.ToAccountID, toTx.AccountID)
 	suite.Assert().Equal(userB.ID, toTx.UserID)
-	suite.Assert().Equal(domain.OperationTypeCredit, toTx.OperationType)
+	suite.Assert().Equal(domain.OperationTypeDebit, toTx.OperationType)
 }
 
 // ─── shouldUpdateTransactionBasedOnPropagationSettings ───────────────────────

--- a/backend/internal/service/transaction_create.go
+++ b/backend/internal/service/transaction_create.go
@@ -602,6 +602,16 @@ func (s *transactionService) injectLinkedTransactions(
 			toDate = adjustLinkedTransactionDay(transaction.Date, connection.ToLinkedTransactionDayOfMonth)
 		}
 
+		// The counterpart's linked transaction always carries the author's own
+		// OperationType:
+		//   - Shared expense/income: mirrors the author's leg (debit/credit) so the
+		//     partner's shared account moves the same direction.
+		//   - Cross-user transfer: the author's fromTransaction is the credit mirror
+		//     of the private debit, so the counterpart leg must be the OPPOSITE
+		//     (a debit) to keep the connection zero-sum. Crediting the author's
+		//     shared account debits the counterpart's — otherwise both sides would be
+		//     credited and the connection balance would drift instead of settling.
+		//     For a transfer, transaction.OperationType is the debit we want here.
 		toTransaction := domain.Transaction{
 			ID:                0,
 			InstallmentNumber: transaction.InstallmentNumber,
@@ -610,7 +620,7 @@ func (s *transactionService) injectLinkedTransactions(
 			UserID:            connection.ToUserID,
 			OriginalUserID:    &userID,
 			Type:              transaction.Type,
-			OperationType:     lo.Ternary(req.TransactionType == domain.TransactionTypeTransfer, transaction.OperationType.Invert(), transaction.OperationType),
+			OperationType:     transaction.OperationType,
 			AccountID:         connection.ToAccountID,
 			CategoryID:        nil,
 			Amount:            amount,

--- a/backend/internal/service/transaction_create_test.go
+++ b/backend/internal/service/transaction_create_test.go
@@ -435,11 +435,12 @@ func (suite *TransactionCreateWithDBTestSuite) TestTransferBetweenDifferentUsers
 			suite.Assert().Equal(connection.FromAccountID, transactionsUser1[i].AccountID, fmt.Sprintf("transactionsUser1[%d].AccountID should be %d", i, connection.FromAccountID))
 			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser1[i].OperationType, fmt.Sprintf("transactionsUser1[%d].OperationType should be %s", i, domain.OperationTypeCredit))
 		case 2:
-			// toTx from transfer2: credit on user1's shared account (received from user2)
+			// toTx from transfer2: debit on user1's shared account (user2 transferred to user1,
+			// so user1 is the counterpart and gets the debit that mirrors user2's credit)
 			suite.Assert().Equal(user2.ID, lo.FromPtr(transactionsUser1[i].OriginalUserID), fmt.Sprintf("transactionsUser1[%d].OriginalUserID should be %d", i, user2.ID))
 			suite.Assert().Equal(int64(500), int64(transactionsUser1[i].Amount), fmt.Sprintf("transactionsUser1[%d].Amount should be %d", i, 500))
 			suite.Assert().Equal(connection.FromAccountID, transactionsUser1[i].AccountID, fmt.Sprintf("transactionsUser1[%d].AccountID should be %d", i, connection.FromAccountID))
-			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser1[i].OperationType, fmt.Sprintf("transactionsUser1[%d].OperationType should be %s", i, domain.OperationTypeCredit))
+			suite.Assert().Equal(domain.OperationTypeDebit, transactionsUser1[i].OperationType, fmt.Sprintf("transactionsUser1[%d].OperationType should be %s", i, domain.OperationTypeDebit))
 		}
 	}
 
@@ -482,11 +483,12 @@ func (suite *TransactionCreateWithDBTestSuite) TestTransferBetweenDifferentUsers
 			suite.Assert().Equal(connection.ToAccountID, transactionsUser2[i].AccountID, fmt.Sprintf("transactionsUser2[%d].AccountID should be %d", i, connection.ToAccountID))
 			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser2[i].OperationType, fmt.Sprintf("transactionsUser2[%d].OperationType should be %s", i, domain.OperationTypeCredit))
 		case 2:
-			// toTx from transfer1: credit on user2's shared account (received from user1)
+			// toTx from transfer1: debit on user2's shared account (user1 transferred to user2,
+			// so user2 is the counterpart and gets the debit that mirrors user1's credit)
 			suite.Assert().Equal(user1.ID, lo.FromPtr(transactionsUser2[i].OriginalUserID), fmt.Sprintf("transactionsUser2[%d].OriginalUserID should be %d", i, user1.ID))
 			suite.Assert().Equal(int64(100), int64(transactionsUser2[i].Amount), fmt.Sprintf("transactionsUser2[%d].Amount should be %d", i, 100))
 			suite.Assert().Equal(connection.ToAccountID, transactionsUser2[i].AccountID, fmt.Sprintf("transactionsUser2[%d].AccountID should be %d", i, connection.ToAccountID))
-			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser2[i].OperationType, fmt.Sprintf("transactionsUser2[%d].OperationType should be %s", i, domain.OperationTypeCredit))
+			suite.Assert().Equal(domain.OperationTypeDebit, transactionsUser2[i].OperationType, fmt.Sprintf("transactionsUser2[%d].OperationType should be %s", i, domain.OperationTypeDebit))
 		}
 	}
 
@@ -609,11 +611,11 @@ func (suite *TransactionCreateWithDBTestSuite) TestRecurringTransferBetweenDiffe
 				suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser1[i].OperationType, fmt.Sprintf("transactionsUser1[%d].OperationType should be %s", i, domain.OperationTypeCredit))
 			}
 		} else {
-			// Last 3: toTx from transfer2 (OriginalUserID=user2), credit on shared account
+			// Last 3: toTx from transfer2 (OriginalUserID=user2), debit on shared account
 			suite.Assert().Equal(user2.ID, lo.FromPtr(transactionsUser1[i].OriginalUserID), fmt.Sprintf("transactionsUser1[%d].OriginalUserID should be %d", i, user2.ID))
 			suite.Assert().Equal(int64(500), int64(transactionsUser1[i].Amount), fmt.Sprintf("transactionsUser1[%d].Amount should be %d", i, 500))
 			suite.Assert().Equal(connection.FromAccountID, transactionsUser1[i].AccountID, fmt.Sprintf("transactionsUser1[%d].AccountID should be %d", i, connection.FromAccountID))
-			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser1[i].OperationType, fmt.Sprintf("transactionsUser1[%d].OperationType should be %s", i, domain.OperationTypeCredit))
+			suite.Assert().Equal(domain.OperationTypeDebit, transactionsUser1[i].OperationType, fmt.Sprintf("transactionsUser1[%d].OperationType should be %s", i, domain.OperationTypeDebit))
 		}
 	}
 
@@ -654,11 +656,11 @@ func (suite *TransactionCreateWithDBTestSuite) TestRecurringTransferBetweenDiffe
 				suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser2[i].OperationType, fmt.Sprintf("transactionsUser2[%d].OperationType should be %s", i, domain.OperationTypeCredit))
 			}
 		} else {
-			// Last 3: toTx from transfer1 (OriginalUserID=user1), credit on shared account
+			// Last 3: toTx from transfer1 (OriginalUserID=user1), debit on shared account
 			suite.Assert().Equal(user1.ID, lo.FromPtr(transactionsUser2[i].OriginalUserID), fmt.Sprintf("transactionsUser2[%d].OriginalUserID should be %d", i, user1.ID))
 			suite.Assert().Equal(int64(100), int64(transactionsUser2[i].Amount), fmt.Sprintf("transactionsUser2[%d].Amount should be %d", i, 100))
 			suite.Assert().Equal(connection.ToAccountID, transactionsUser2[i].AccountID, fmt.Sprintf("transactionsUser2[%d].AccountID should be %d", i, connection.ToAccountID))
-			suite.Assert().Equal(domain.OperationTypeCredit, transactionsUser2[i].OperationType, fmt.Sprintf("transactionsUser2[%d].OperationType should be %s", i, domain.OperationTypeCredit))
+			suite.Assert().Equal(domain.OperationTypeDebit, transactionsUser2[i].OperationType, fmt.Sprintf("transactionsUser2[%d].OperationType should be %s", i, domain.OperationTypeDebit))
 		}
 	}
 }

--- a/backend/internal/service/transaction_update.go
+++ b/backend/internal/service/transaction_update.go
@@ -736,9 +736,11 @@ func (s *transactionService) rebuildTransferLinkedTransactions(
 
 	c.SwapIfNeeded(data.userID)
 
-	// Cross-user transfer: create both the fromTx (author's credit on shared account)
-	// and the toTx (receiver's credit on their shared account), matching the creation
-	// logic in injectLinkedTransactions.
+	// Cross-user transfer: create both the fromTx (author's credit on their shared
+	// account) and the toTx (a debit on the counterpart's shared account), matching the
+	// creation logic in injectLinkedTransactions. The two legs have opposite operation
+	// types so the connection stays zero-sum — crediting the author's side debits the
+	// counterpart's, otherwise both sides would be credited and the balance would drift.
 	fromTx := domain.Transaction{
 		ID:                      0,
 		InstallmentNumber:       tx.InstallmentNumber,
@@ -763,7 +765,7 @@ func (s *transactionService) rebuildTransferLinkedTransactions(
 		UserID:            c.ToUserID,
 		OriginalUserID:    tx.OriginalUserID,
 		Type:              domain.TransactionTypeTransfer,
-		OperationType:     domain.OperationTypeCredit,
+		OperationType:     domain.OperationTypeDebit,
 		AccountID:         c.ToAccountID,
 		CategoryID:        nil,
 		Amount:            baseAmount,

--- a/backend/internal/service/transaction_update_test.go
+++ b/backend/internal/service/transaction_update_test.go
@@ -1222,7 +1222,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestScenario6_OwnExpenseWithLinke
 			{
 				Amount:                  200,
 				Type:                    domain.TransactionTypeTransfer,
-				OperationType:           domain.OperationTypeCredit,
+				OperationType:           domain.OperationTypeDebit,
 				AccountID:               destination.ToAccountID,
 				CategoryID:              nil,
 				Date:                    expectedDate,
@@ -2668,10 +2668,10 @@ func (suite *TransactionUpdateWithDBTestSuite) TestInstallmentScenario5h_Increas
 	suite.Require().NoError(err)
 	suite.Assert().Len(afterFromTx, 6, "author should have 6 fromTx installments")
 
-	// toUser: 6 credit on shared account
+	// toUser: 6 debit on shared account (counterpart legs mirroring the author's credits)
 	toUserAfter, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{UserID: &toUser.ID})
 	suite.Require().NoError(err)
-	suite.Assert().Len(toUserAfter, 6, "toUser should have 6 credit installments")
+	suite.Assert().Len(toUserAfter, 6, "toUser should have 6 debit installments")
 
 	// Total: author 12 + toUser 6 = 18
 	suite.Assert().Equal(6, afterDebit[0].TransactionRecurrence.Installments)
@@ -5582,15 +5582,15 @@ func (suite *TransactionUpdateWithDBTestSuite) TestUpdateTransferBetweenDifferen
 	suite.Require().NoError(err)
 	suite.Assert().Len(authorTxs, 2, "author should see 2 transactions (debit + fromTx credit)")
 
-	// toUser sees 1 tx (credit on their shared account)
+	// toUser sees 1 tx (debit on their shared account — counterpart leg mirroring the author's credit)
 	toUserTxs, err := suite.Repos.Transaction.Search(ctx, domain.TransactionFilter{
 		UserID: &toUser.ID,
 	})
 	suite.Require().NoError(err)
-	suite.Assert().Len(toUserTxs, 1, "toUser should see 1 transaction (credit)")
+	suite.Assert().Len(toUserTxs, 1, "toUser should see 1 transaction (debit)")
 	suite.Assert().Equal(int64(10000), toUserTxs[0].Amount)
 	suite.Assert().Equal(domain.TransactionTypeTransfer, toUserTxs[0].Type)
-	suite.Assert().Equal(domain.OperationTypeCredit, toUserTxs[0].OperationType)
+	suite.Assert().Equal(domain.OperationTypeDebit, toUserTxs[0].OperationType)
 	suite.Assert().Equal(connection.ToAccountID, toUserTxs[0].AccountID)
 
 	// Update the transfer amount from the author
@@ -5620,7 +5620,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestUpdateTransferBetweenDifferen
 	suite.Assert().Len(toUserTxsAfterUpdate, 1, "toUser should still see 1 transaction after update")
 	suite.Assert().Equal(newAmount, toUserTxsAfterUpdate[0].Amount, "toUser tx amount should be updated")
 	suite.Assert().Equal(domain.TransactionTypeTransfer, toUserTxsAfterUpdate[0].Type)
-	suite.Assert().Equal(domain.OperationTypeCredit, toUserTxsAfterUpdate[0].OperationType)
+	suite.Assert().Equal(domain.OperationTypeDebit, toUserTxsAfterUpdate[0].OperationType)
 	suite.Assert().Equal(connection.ToAccountID, toUserTxsAfterUpdate[0].AccountID)
 	suite.Assert().Equal(author.ID, lo.FromPtr(toUserTxsAfterUpdate[0].OriginalUserID), "originalUserID should be the author")
 
@@ -5716,7 +5716,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestRecurringTransfer_CrossUser_U
 	for _, tx := range toUserTxsAfter {
 		suite.Assert().Equal(newAmount, tx.Amount)
 		suite.Assert().NotNil(tx.TransactionRecurrenceID, "toUser tx recurrence should be preserved")
-		suite.Assert().Equal(domain.OperationTypeCredit, tx.OperationType)
+		suite.Assert().Equal(domain.OperationTypeDebit, tx.OperationType)
 	}
 }
 
@@ -5927,7 +5927,7 @@ func (suite *TransactionUpdateWithDBTestSuite) TestRecurringTransfer_CrossUser_C
 	suite.Assert().Len(userCTxs, 3, "userC should have 3 installments")
 	for _, tx := range userCTxs {
 		suite.Assert().Equal(int64(4000), tx.Amount)
-		suite.Assert().Equal(domain.OperationTypeCredit, tx.OperationType)
+		suite.Assert().Equal(domain.OperationTypeDebit, tx.OperationType)
 		suite.Assert().Equal(connAC.ToAccountID, tx.AccountID)
 		suite.Assert().NotNil(tx.TransactionRecurrenceID, "userC tx recurrence should exist")
 	}


### PR DESCRIPTION
## Problema

Ao criar uma **transfer para uma conta compartilhada** (cross-user), eram criadas 3 transações:

- `debit` na conta privada do user_a
- `credit` na conta compartilhada do user_a (fromTx)
- `credit` na conta compartilhada do user_b (toTx) ← **bug**

Criar um **crédito dos dois lados** quebra a invariante de zero-soma da conexão: o saldo combinado da conexão derivava em `2 × amount`, e uma transfer usada para quitar uma dívida empurrava o saldo para **longe** do zero em vez de em direção a ele.

## Correção

A `toTx` agora carrega o `operation_type` do autor (um **débito** no caso de transfer), espelhando o crédito da `fromTx`:

- `debit` na conta privada do user_a
- `credit` na conta compartilhada do user_a (fromTx)
- **`debit`** na conta compartilhada do user_b (toTx)

Assim, ao creditar o lado do user_a, debita-se o lado do user_b — exatamente como o fluxo de **charge settlement** já faz (debita uma conta da conexão e credita a outra). A conexão volta a ser zero-soma e transfers diretas de quitação fecham o saldo corretamente.

## Mudanças

- `injectLinkedTransactions` (create path) — `toTransaction.OperationType` passa a usar `transaction.OperationType`
- `rebuildTransferLinkedTransactions` (update path) — `toTx` passa de `Credit` para `Debit`
- Testes de create/update/balance/business-rules/coverage atualizados (incl. o `TestGetBalance_Transfer_DiffUser`, que antes **codificava o comportamento bugado**)
- `backend/CLAUDE.md` — business rule de transfers cross-user atualizada

## Validação

- `go build ./...` ✅
- `go vet ./internal/service/...` ✅
- `go test -short ./internal/service/... ./internal/handler/...` ✅
- ⚠️ Os testes de integração (testcontainers/Postgres) **não rodaram** neste ambiente por falta de Docker — recomendo rodar `just test-integration` localmente, em especial os testes de transfer/balance cross-user.

https://claude.ai/code/session_01VgfXkWBSHbTCPqiGyxxQ7r

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgfXkWBSHbTCPqiGyxxQ7r)_