### PR TITLE
fix: count selected settlements in selection total

### DIFF
--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -476,7 +476,25 @@ export function TransactionsPage() {
   const settlementById = useMemo(() => {
     const m = new Map<number, Transactions.Settlement>();
     for (const tx of allTransactions) {
+      // Inline settlements riding along with their source transaction.
       for (const s of tx.settlements_from_source ?? []) m.set(s.id, s);
+      // Orphan/synthetic settlement rows arrive as standalone transactions
+      // carrying origin_settlement_id; their amount/type live on the tx
+      // itself, so map them too — otherwise selecting one wouldn't count
+      // toward selectedTotalCents.
+      if (tx.origin_settlement_id !== undefined) {
+        m.set(tx.origin_settlement_id, {
+          id: tx.origin_settlement_id,
+          user_id: tx.user_id,
+          amount: tx.amount,
+          type: tx.operation_type === "credit" ? "credit" : "debit",
+          account_id: tx.account_id,
+          source_transaction_id: tx.source_transaction_id ?? 0,
+          parent_transaction_id: 0,
+          date: tx.date,
+          created_at: tx.created_at,
+        });
+      }
     }
     return m;
   }, [allTransactions]);


### PR DESCRIPTION
## Problem

O valor total selecionado (na `SelectionActionBar`) não estava considerando no cálculo do saldo os **settlements selecionados** em certos casos.

## Root cause

Settlements aparecem em duas formas na listagem:

1. **Inline** — vindos de `tx.settlements_from_source`.
2. **Sintéticos/órfãos** — chegam como transações standalone em `allTransactions`, carregando `origin_settlement_id` e renderizadas como `SettlementRow` (`TransactionGroup.tsx:194-228`).

O mapa `settlementById` em `TransactionsPage.tsx` era construído **apenas** a partir de `settlements_from_source`. Ao selecionar um settlement sintético, seu `origin_settlement_id` entrava em `selectedSettlementIds`, mas `settlementById.get(id)` retornava `undefined` e o `selectedTotalCents` simplesmente pulava aquele valor — então o saldo selecionado não mudava.

## Fix

Ao montar `settlementById`, também indexar os settlements sintéticos (transações com `origin_settlement_id` definido), usando `amount`/`operation_type` da própria transação. Assim todo settlement selecionado contribui para o `selectedTotalCents`.

## Testing

- `tsc --noEmit` passa.
- (ESLint não roda neste ambiente por falta de devDeps — não relacionado à mudança.)

https://claude.ai/code/session_01FJJLDifoguHSCCK4uh2ki7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJJLDifoguHSCCK4uh2ki7)_