### PR TITLE
fix(transactions): let partner bulk-edit category/date on their linked tx

### DIFF
--- a/frontend/e2e/tests/bulk-linked-transaction-edit.spec.ts
+++ b/frontend/e2e/tests/bulk-linked-transaction-edit.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Bulk edits on a partner's (to_user) linked transaction — issue #205 parity.
+ *
+ * The single-row edit drawer already lets the partner (the "ponta" of a share)
+ * change the date / description / category / amount / tags of their OWN linked
+ * transaction. Before this change the bulk actions silently skipped those rows:
+ * getEligibleIds filtered out any transaction whose original_user_id != the
+ * current user, which is exactly the partner's linked side (original_user_id
+ * points at the author).
+ *
+ * These tests assert the parity: the partner can now bulk-change the two fields
+ * that have a bulk action AND are allowed on a linked tx — category and date.
+ *
+ * Setup: the primary user creates a shared expense (split) so the partner
+ * receives a real debit transaction on their connection account. We then drive
+ * the bulk action while authenticated as the PARTNER.
+ */
+
+import { test, expect } from "@playwright/test";
+import { TransactionsPage } from "../pages/TransactionsPage";
+import { TransactionsTestIds } from "@/testIds";
+import { createUserAndPartner, type UserAndPartnerResult } from "../helpers/createUserAndPartner";
+import { apiFetchAs, openAuthedPage } from "../helpers/api";
+import type { Transactions } from "@/types/transactions";
+
+const now = new Date();
+const MONTH = now.getMonth() + 1;
+const YEAR = now.getFullYear();
+const TODAY = `${YEAR}-${String(MONTH).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+
+async function apiCreateSharedExpense(
+  setup: UserAndPartnerResult,
+  categoryId: number,
+  description: string,
+  amount: number,
+  date: string,
+): Promise<void> {
+  const res = await apiFetchAs(setup.userToken, "/api/transactions", {
+    method: "POST",
+    body: JSON.stringify({
+      transaction_type: "expense",
+      account_id: setup.userAccountId,
+      category_id: categoryId,
+      amount,
+      date,
+      description,
+      split_settings: [{ connection_id: setup.connectionId, percentage: 50 }],
+    }),
+  });
+  if (!res.ok) throw new Error(`Failed to create shared expense: ${res.status}`);
+}
+
+/** Resolve the partner's linked (debit) transaction on their connection account. */
+async function apiGetPartnerLinkedTx(
+  setup: UserAndPartnerResult,
+  description: string,
+): Promise<Transactions.Transaction> {
+  const res = await apiFetchAs(
+    setup.partnerToken,
+    `/api/transactions?month=${MONTH}&year=${YEAR}&account_id[]=${setup.partnerConnAccountId}`,
+  );
+  const txs = (await res.json()) as Transactions.Transaction[];
+  const tx = txs.find((t) => t.description === description);
+  if (!tx) throw new Error(`Partner linked tx not found: ${description}`);
+  return tx;
+}
+
+test.describe("Bulk edits on partner's linked transaction", () => {
+  let setup: UserAndPartnerResult;
+  let primaryCategoryId: number;
+  let partnerCategoryId: number;
+
+  test.beforeAll(async () => {
+    setup = await createUserAndPartner("e2e-bulk-linked");
+
+    const primaryCatRes = await apiFetchAs(setup.userToken, "/api/categories", {
+      method: "POST",
+      body: JSON.stringify({ name: `Bulk Linked Primary Cat ${Date.now()}` }),
+    });
+    primaryCategoryId = ((await primaryCatRes.json()) as { id: number }).id;
+
+    const partnerCatRes = await apiFetchAs(setup.partnerToken, "/api/categories", {
+      method: "POST",
+      body: JSON.stringify({ name: `Bulk Linked Partner Cat ${Date.now()}` }),
+    });
+    partnerCategoryId = ((await partnerCatRes.json()) as { id: number }).id;
+  });
+
+  // ── Category ──────────────────────────────────────────────────────────────
+  test("partner can bulk-change the category of their own linked transaction", async ({
+    browser,
+  }) => {
+    const description = `bulk-linked-cat-${Date.now()}`;
+    await apiCreateSharedExpense(setup, primaryCategoryId, description, 10000, TODAY);
+
+    const partnerTx = await apiGetPartnerLinkedTx(setup, description);
+
+    const page = await openAuthedPage(browser, setup.partnerToken);
+    const txPage = new TransactionsPage(page);
+    await page.goto(
+      `/transactions?month=${MONTH}&year=${YEAR}&account_id[]=${setup.partnerConnAccountId}`,
+    );
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId(TransactionsTestIds.Checkbox(partnerTx.id)).first().click();
+    expect(await txPage.getSelectedCount()).toBe(1);
+
+    await txPage.openBulkActionsMenu();
+    await page.getByTestId(TransactionsTestIds.BtnBulkCategory).click();
+    await page.getByTestId(TransactionsTestIds.CategoryOption(partnerCategoryId)).click();
+
+    // Pre-fix this never appeared: the row was silently skipped, leaving 0
+    // eligible items so the progress drawer never opened.
+    await expect(page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible({
+      timeout: 15000,
+    });
+
+    const updated = await apiGetPartnerLinkedTx(setup, description);
+    expect(updated.category_id).toBe(partnerCategoryId);
+
+    await page.close();
+  });
+
+  // ── Date ──────────────────────────────────────────────────────────────────
+  test("partner can bulk-change the date of their own linked transaction", async ({
+    browser,
+  }) => {
+    const description = `bulk-linked-date-${Date.now()}`;
+    // Create on a day inside the current month that is NOT today, so applying
+    // the bulk-date default (today) is observable.
+    const todayDay = now.getDate();
+    const sourceDay = todayDay === 15 ? 16 : 15;
+    const sourceDate = `${YEAR}-${String(MONTH).padStart(2, "0")}-${String(sourceDay).padStart(2, "0")}`;
+    await apiCreateSharedExpense(setup, primaryCategoryId, description, 10000, sourceDate);
+
+    const partnerTx = await apiGetPartnerLinkedTx(setup, description);
+
+    const page = await openAuthedPage(browser, setup.partnerToken);
+    const txPage = new TransactionsPage(page);
+    await page.goto(
+      `/transactions?month=${MONTH}&year=${YEAR}&account_id[]=${setup.partnerConnAccountId}`,
+    );
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId(TransactionsTestIds.Checkbox(partnerTx.id)).first().click();
+    expect(await txPage.getSelectedCount()).toBe(1);
+
+    await txPage.openBulkActionsMenu();
+    await page.getByTestId(TransactionsTestIds.BtnBulkDate).click();
+
+    const dateDrawer = page.getByTestId(TransactionsTestIds.DrawerSelectDate);
+    await expect(dateDrawer).toBeVisible();
+    // The DateInput defaults to today; click Aplicar straight away.
+    await page.getByTestId(TransactionsTestIds.BtnApplyDate).click();
+
+    await expect(page.getByTestId(TransactionsTestIds.BulkSuccess)).toBeVisible({
+      timeout: 15000,
+    });
+
+    const updated = await apiGetPartnerLinkedTx(setup, description);
+    expect(updated.date?.slice(0, 10)).toBe(TODAY);
+
+    await page.close();
+  });
+});

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -171,11 +171,33 @@ export function TransactionsPage() {
     return tx?.transaction_recurrence_id != null;
   });
 
-  // Filter out linked transactions where user is not the original creator (SEL-02 silent skip)
+  // Filter out linked transactions where user is not the original creator (SEL-02 silent skip).
+  // Used for actions that the partner (to_user) is NOT allowed to perform on their own
+  // linked side: bulk delete (the backend cascades a partner delete onto the author's
+  // source) and bulk division (split_settings is a disallowed field for linked txs).
   function getEligibleIds(): number[] {
     return [...selectedIds].filter((id) => {
       const tx = allTransactions.find((t) => t.id === id);
       return tx?.original_user_id == null || tx?.original_user_id === currentUserId;
+    });
+  }
+
+  // Eligibility for bulk edits of fields the partner (to_user) is allowed to change on
+  // their own linked side — date and category (issue #205 parity with single-row edit).
+  // Unlike getEligibleIds, this includes the partner's linked transactions: their
+  // original_user_id points at the author, but the partner OWNS the row
+  // (user_id === currentUserId) and the backend permits amount/date/description/tags/
+  // category edits on it. buildUpdatePayload sends only { tags, ...overrides } for linked
+  // txs, so no disallowed structural field leaks onto the wire.
+  function getFieldEditEligibleIds(): number[] {
+    return [...selectedIds].filter((id) => {
+      const tx = allTransactions.find((t) => t.id === id);
+      if (!tx) return false;
+      return (
+        tx.user_id === currentUserId ||
+        tx.original_user_id == null ||
+        tx.original_user_id === currentUserId
+      );
     });
   }
 
@@ -303,7 +325,7 @@ export function TransactionsPage() {
         propagation = await renderDrawer<PropagationSetting>(() => <PropagationSettingsDrawer actionLabel="alterar" />);
       }
 
-      const eligibleIds = getEligibleIds();
+      const eligibleIds = getFieldEditEligibleIds();
       const items: BulkProgressItem[] = eligibleIds.map((id) => {
         const tx = allTransactions.find((t) => t.id === id);
         return { id, label: tx?.description ?? String(id) };
@@ -353,7 +375,7 @@ export function TransactionsPage() {
       // Settlement IDs are tagged with a stable prefix in the BulkProgressItem
       // label-key so the action callback can dispatch each kind to the right
       // endpoint while reusing the existing progress drawer.
-      const eligibleTxIds = getEligibleIds();
+      const eligibleTxIds = getFieldEditEligibleIds();
       const txItems: BulkProgressItem[] = eligibleTxIds.map((id) => {
         const tx = allTransactions.find((t) => t.id === id);
         return { id, label: tx?.description ?? String(id) };


### PR DESCRIPTION
## Contexto

Recentemente (#205) passamos a permitir que o **user da ponta** (`to_user`) de um compartilhamento altere campos da sua própria transação vinculada. A investigação pedida foi verificar se **todos os campos com alteração permitida à ponta também funcionam nas ações em massa**.

## Achado

**Não funcionavam.** O backend e a edição individual permitem que a ponta altere, na sua transação vinculada: **amount, date, description, tags e category_id** (`validateUpdateTransactionRequest`). As ações em massa, porém, **pulavam silenciosamente** essas transações.

O culpado é o filtro de elegibilidade `getEligibleIds` em `TransactionsPage.tsx`:

```ts
return tx?.original_user_id == null || tx?.original_user_id === currentUserId;
```

Na transação da ponta, `original_user_id` aponta para o **autor** do compartilhamento (não para a ponta), então `original_user_id !== currentUserId` → a linha era excluída de **todas** as ações em massa (categoria, data, divisão e exclusão).

Esse filtro foi introduzido em #149/#145 — **antes** de #205, quando a ponta não podia editar nada. Depois de #205 ele ficou restritivo demais.

## Correção

Separei a elegibilidade em duas:

- **`getEligibleIds`** (inalterado) continua barrando a ponta em **bulk delete** e **bulk divisão**, que ela realmente não deve fazer no seu lado vinculado:
  - delete da ponta faz *cascade* na transação source do autor (ver `transaction_delete.go`);
  - `split_settings` é campo proibido para linked tx.
- **`getFieldEditEligibleIds`** (novo) habilita **Alterar categoria** e **Alterar data** — os campos que (a) têm ação em massa e (b) são permitidos numa linked tx. Inclui as transações da ponta (ela é dona da linha via `user_id`) e se apoia no `buildUpdatePayload`, que já envia apenas `{ tags, ...overrides }` para linked txs (nenhum campo estrutural vaza para o wire).

> Conforme alinhado, **não** foi adicionada ação em massa de descrição.

## Veredito por campo/ação (após o fix)

| Campo permitido p/ ponta | Edição individual | Ação em massa |
|---|---|---|
| Categoria | ✅ | ✅ agora processa a tx da ponta |
| Data | ✅ | ✅ agora processa a tx da ponta |
| Descrição | ✅ | — sem ação em massa (por decisão) |
| Valor / Tags | ✅ | — sem ação em massa |
| Divisão (split) | 🚫 proibido p/ ponta | ✅ corretamente continua pulando a ponta |
| Excluir | (cascade) | mantido estrito (continua pulando a ponta) |

## Testes

- Lint e `tsc` passam (`src` e `e2e`).
- Novo e2e `frontend/e2e/tests/bulk-linked-transaction-edit.spec.ts`: a ponta seleciona sua transação compartilhada e usa **Alterar categoria** e **Alterar data** em massa, verificando que a alteração é persistida (antes do fix, a tela pulava a linha e o drawer de progresso nem abria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fni9QiSMDHBTwGzgtDywK2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fni9QiSMDHBTwGzgtDywK2)_