### PR TITLE
Replace shell migration check with Go CLI tool

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,23 +126,11 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
 
-      - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@v3.26.0
-
       - name: Check pending migrations
         working-directory: backend
         env:
           DB_DSN: ${{ secrets.DB_DSN_PROD }}
-        run: |
-          # goose logs to stderr, so capture both streams or $STATUS is empty
-          STATUS=$(goose -dir migrations postgres "$DB_DSN" status 2>&1)
-          echo "$STATUS"
-          PENDING=$(echo "$STATUS" | grep -c "Pending" || true)
-          if [ "$PENDING" -gt 0 ]; then
-            echo "::error::Found $PENDING pending migration(s). Run the 'Run DB Migrations' workflow before deploying, or rerun this workflow with skip_migration_check=true."
-            exit 1
-          fi
-          echo "No pending migrations. Deploy can proceed."
+        run: go run ./cmd/migrate-check
 
   backend-deploy:
     name: Backend → Cloud Run

--- a/backend/cmd/migrate-check/main.go
+++ b/backend/cmd/migrate-check/main.go
@@ -1,0 +1,83 @@
+// Command migrate-check reports whether the database pointed at by DB_DSN has
+// any pending goose migrations. It replaces the previous shell pipeline
+// (`goose status | grep Pending`), which parsed goose's stderr text and — under
+// `set -e` — silently swallowed real errors (e.g. a failed DB connection) as a
+// bare "exit 1". Here we use goose's programmatic provider API (see
+// pressly/goose#225), so connection/parse failures surface explicitly and the
+// pending check is exact instead of text-matched.
+//
+// Exit codes:
+//
+//	0 — no pending migrations, deploy can proceed
+//	1 — one or more pending migrations
+//	2 — could not determine status (bad DSN, connection error, etc.)
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // registers the "pgx" database/sql driver
+	"github.com/pressly/goose/v3"
+)
+
+const migrationsDir = "migrations"
+
+func main() {
+	pending, err := check()
+	if err != nil {
+		// A GitHub Actions error annotation, plus the underlying cause.
+		fmt.Printf("::error::could not check pending migrations: %v\n", err)
+		os.Exit(2)
+	}
+
+	if len(pending) > 0 {
+		fmt.Printf("::error::Found %d pending migration(s). Run the 'Run DB Migrations' workflow before deploying, or rerun this workflow with skip_migration_check=true.\n", len(pending))
+		for _, name := range pending {
+			fmt.Printf("  - %s\n", name)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Println("No pending migrations. Deploy can proceed.")
+}
+
+func check() ([]string, error) {
+	dsn := os.Getenv("DB_DSN")
+	if dsn == "" {
+		return nil, errors.New("DB_DSN environment variable is required")
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if err := db.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("connect to database: %w", err)
+	}
+
+	provider, err := goose.NewProvider(goose.DialectPostgres, db, os.DirFS(migrationsDir))
+	if err != nil {
+		return nil, fmt.Errorf("initialize goose provider: %w", err)
+	}
+
+	statuses, err := provider.Status(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read migration status: %w", err)
+	}
+
+	var pending []string
+	for _, s := range statuses {
+		if s.State == goose.StatePending {
+			pending = append(pending, filepath.Base(s.Source.Path))
+		}
+	}
+	return pending, nil
+}


### PR DESCRIPTION
## Summary
Replaces the fragile shell pipeline for checking pending database migrations with a dedicated Go CLI tool (`migrate-check`). This improves error handling, eliminates text parsing, and makes the check deterministic.

## Changes
- **New tool**: `backend/cmd/migrate-check/main.go`
  - Uses goose's programmatic provider API instead of shelling out to the CLI
  - Explicitly distinguishes between "pending migrations found" (exit 1) and "could not determine status" (exit 2)
  - Reads migration status directly from the database, eliminating fragile stderr parsing
  - Outputs GitHub Actions error annotations for visibility in workflow logs

- **Workflow update**: `.github/workflows/deploy.yml`
  - Removes `goose` CLI installation step
  - Replaces multi-line shell pipeline with simple `go run ./cmd/migrate-check`
  - Maintains same environment variable (`DB_DSN`) and error reporting behavior

## Implementation Details
- Connects to PostgreSQL via pgx driver and validates the connection with `PingContext`
- Iterates through migration statuses and collects those with `goose.StatePending` state
- Returns migration names (extracted from file paths) for user-friendly output
- All errors are wrapped with context for debugging (DSN validation, connection failures, goose initialization, status read)

https://claude.ai/code/session_01BjxqbuyersjBb16Syzr8cL